### PR TITLE
Implement weekly duty scheduling and patient appointment management

### DIFF
--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -2,8 +2,16 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { Role, Prisma } from "@prisma/client";
-import { buildManilaDate, startOfManilaDay } from "@/lib/time";
+import { AppointmentStatus, DoctorSpecialization, Role, Prisma } from "@prisma/client";
+import {
+    addManilaDays,
+    buildManilaDate,
+    formatManilaDate,
+    manilaNow,
+    rangesOverlap,
+    startOfManilaDay,
+    startOfManilaWeek,
+} from "@/lib/time";
 
 /**
  * ✅ GET — Fetch all consultation slots for logged-in doctor
@@ -59,21 +67,11 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { clinic_id, available_date, available_timestart, available_timeend } =
+        const { clinic_id, available_timestart, available_timeend, week_start } =
             await req.json();
 
-        if (!clinic_id || !available_date || !available_timestart || !available_timeend) {
+        if (!clinic_id || !available_timestart || !available_timeend) {
             return NextResponse.json({ error: "All fields are required" }, { status: 400 });
-        }
-
-        const start = buildManilaDate(available_date, available_timestart);
-        const end = buildManilaDate(available_date, available_timeend);
-
-        if (end <= start) {
-            return NextResponse.json(
-                { error: "End time must be after start time" },
-                { status: 400 }
-            );
         }
 
         const clinic = await prisma.clinic.findUnique({ where: { clinic_id } });
@@ -81,20 +79,111 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Clinic not found" }, { status: 404 });
         }
 
-        const newSlot = await prisma.doctorAvailability.create({
-            data: {
-                doctor_user_id: doctor.user_id,
-                clinic_id,
-                available_date: startOfManilaDay(available_date),
-                available_timestart: start,
-                available_timeend: end,
-            },
-            include: {
-                clinic: { select: { clinic_id: true, clinic_name: true } },
-            },
+        const baseDate = week_start ? startOfManilaDay(week_start) : manilaNow();
+        const weekStart = startOfManilaWeek(baseDate);
+
+        const dailyCount =
+            doctor.specialization === DoctorSpecialization.Dentist ? 6 : 5; // Mon-Fri or Mon-Sat
+
+        const scheduleDays = Array.from({ length: dailyCount }, (_, idx) => {
+            const current = addManilaDays(weekStart, idx);
+            const dateStr = formatManilaDate(current);
+            const start = buildManilaDate(dateStr, available_timestart);
+            const end = buildManilaDate(dateStr, available_timeend);
+            return { current, dateStr, start, end };
         });
 
-        return NextResponse.json(newSlot);
+        if (scheduleDays.some((day) => day.end <= day.start)) {
+            return NextResponse.json(
+                { error: "End time must be after start time" },
+                { status: 400 }
+            );
+        }
+
+        const rangeStartStr = formatManilaDate(scheduleDays[0].current);
+        const rangeEndStr = formatManilaDate(scheduleDays[scheduleDays.length - 1].current);
+
+        const [existingAvailability, existingAppointments] = await Promise.all([
+            prisma.doctorAvailability.findMany({
+                where: {
+                    doctor_user_id: doctor.user_id,
+                    available_date: {
+                        gte: startOfManilaDay(rangeStartStr),
+                        lte: startOfManilaDay(rangeEndStr),
+                    },
+                },
+            }),
+            prisma.appointment.findMany({
+                where: {
+                    doctor_user_id: doctor.user_id,
+                    appointment_timestart: {
+                        gte: buildManilaDate(rangeStartStr, "00:00"),
+                        lte: buildManilaDate(rangeEndStr, "23:59"),
+                    },
+                    status: {
+                        in: [
+                            AppointmentStatus.Pending,
+                            AppointmentStatus.Approved,
+                            AppointmentStatus.Moved,
+                        ],
+                    },
+                },
+            }),
+        ]);
+
+        const conflicts = scheduleDays.filter((day) =>
+            existingAvailability.some((existing) =>
+                rangesOverlap(
+                    day.start,
+                    day.end,
+                    existing.available_timestart,
+                    existing.available_timeend,
+                )
+            ) ||
+            existingAppointments.some((appt) =>
+                rangesOverlap(day.start, day.end, appt.appointment_timestart, appt.appointment_timeend)
+            )
+        );
+
+        if (conflicts.length > 0) {
+            const conflictDates = Array.from(new Set(conflicts.map((day) => day.dateStr))).join(", ");
+            return NextResponse.json(
+                {
+                    error: `Duty hours conflict with existing schedules on: ${conflictDates}`,
+                },
+                { status: 409 }
+            );
+        }
+
+        const created = await prisma.$transaction(async (tx) => {
+            const rows = [] as {
+                availability_id: string;
+                available_date: Date;
+                available_timestart: Date;
+                available_timeend: Date;
+                clinic: { clinic_id: string; clinic_name: string };
+            }[];
+
+            for (const day of scheduleDays) {
+                const row = await tx.doctorAvailability.create({
+                    data: {
+                        doctor_user_id: doctor.user_id,
+                        clinic_id,
+                        available_date: startOfManilaDay(day.dateStr),
+                        available_timestart: day.start,
+                        available_timeend: day.end,
+                    },
+                    include: {
+                        clinic: { select: { clinic_id: true, clinic_name: true } },
+                    },
+                });
+                rows.push(row);
+            }
+
+            return rows;
+        });
+
+        return NextResponse.json(created);
     } catch (err) {
         console.error("[POST /api/doctor/consultation]", err);
         return NextResponse.json(
@@ -134,7 +223,55 @@ export async function PUT(req: Request) {
             return NextResponse.json({ error: "Missing availability ID" }, { status: 400 });
         }
 
-        const updateData: Prisma.DoctorAvailabilityUpdateInput = {};
+        const existing = await prisma.doctorAvailability.findUnique({
+            where: { availability_id },
+        });
+
+        if (!existing || existing.doctor_user_id !== doctor.user_id) {
+            return NextResponse.json({ error: "Availability not found" }, { status: 404 });
+        }
+
+        const effectiveDate = available_date ?? formatManilaDate(existing.available_date);
+        const newStart = available_timestart
+            ? buildManilaDate(effectiveDate, available_timestart)
+            : existing.available_timestart;
+        const newEnd = available_timeend
+            ? buildManilaDate(effectiveDate, available_timeend)
+            : existing.available_timeend;
+
+        if (newEnd <= newStart) {
+            return NextResponse.json(
+                { error: "End time must be after start time" },
+                { status: 400 }
+            );
+        }
+
+        const conflictingAvail = await prisma.doctorAvailability.findMany({
+            where: {
+                availability_id: { not: availability_id },
+                doctor_user_id: doctor.user_id,
+                available_date: {
+                    gte: startOfManilaDay(effectiveDate),
+                    lte: startOfManilaDay(effectiveDate),
+                },
+            },
+        });
+
+        const hasConflict = conflictingAvail.some((slot) =>
+            rangesOverlap(newStart, newEnd, slot.available_timestart, slot.available_timeend)
+        );
+
+        if (hasConflict) {
+            return NextResponse.json(
+                { error: "Updated schedule overlaps with an existing duty hour" },
+                { status: 409 }
+            );
+        }
+
+        const updateData: Prisma.DoctorAvailabilityUpdateInput = {
+            available_timestart: newStart,
+            available_timeend: newEnd,
+        };
 
         if (clinic_id) {
             updateData.clinic = { connect: { clinic_id } };
@@ -142,13 +279,6 @@ export async function PUT(req: Request) {
 
         if (available_date) {
             updateData.available_date = startOfManilaDay(available_date);
-        }
-
-        if (available_timestart && available_date) {
-            updateData.available_timestart = buildManilaDate(available_date, available_timestart);
-        }
-        if (available_timeend && available_date) {
-            updateData.available_timeend = buildManilaDate(available_date, available_timeend);
         }
 
         const updated = await prisma.doctorAvailability.update({

--- a/src/app/api/meta/doctor-availability/route.ts
+++ b/src/app/api/meta/doctor-availability/route.ts
@@ -48,7 +48,7 @@ export async function GET(req: Request) {
             where: {
                 doctor_user_id,
                 appointment_timestart: { gte: dayStart, lte: dayEnd },
-                status: { in: ["Pending", "Approved"] },
+                status: { in: ["Pending", "Approved", "Moved"] },
             },
             select: {
                 appointment_timestart: true,
@@ -94,7 +94,11 @@ export async function GET(req: Request) {
             }
         }
 
-        return NextResponse.json({ slots });
+        const unique = Array.from(
+            new Map(slots.map((slot) => [`${slot.start}-${slot.end}`, slot])).values()
+        );
+
+        return NextResponse.json({ slots: unique });
     } catch (err) {
         console.error("[GET /api/meta/doctor-availability]", err);
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });

--- a/src/app/api/patient/appointments/[id]/route.ts
+++ b/src/app/api/patient/appointments/[id]/route.ts
@@ -11,16 +11,35 @@ import {
     startOfManilaDay,
 } from "@/lib/time";
 
+// ✅ Define allowed statuses for modification (reschedule/cancel)
+const cancellableStatuses: AppointmentStatus[] = [
+    AppointmentStatus.Pending,
+    AppointmentStatus.Approved,
+    AppointmentStatus.Moved,
+];
+
+// ✅ Helper function for type-safe cancellation/rescheduling check
+function isCancellable(status: AppointmentStatus): boolean {
+    return cancellableStatuses.includes(status);
+}
+
+// ------------------------------------------------------------
+// PATCH — Reschedule an Appointment
+// ------------------------------------------------------------
 export async function PATCH(
     req: Request,
-    { params }: { params: { id: string } }
+    context: { params: { id: string } }
 ) {
     try {
+        const { params } = context;
         const session = await getServerSession(authOptions);
+
+        // 1️⃣ Ensure authenticated
         if (!session?.user?.id) {
             return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
         }
 
+        // 2️⃣ Validate request body
         const body = await req.json();
         const { date, time_start, time_end } = body || {};
 
@@ -28,27 +47,25 @@ export async function PATCH(
             return NextResponse.json({ message: "Missing fields" }, { status: 400 });
         }
 
+        // 3️⃣ Fetch appointment
         const appointment = await prisma.appointment.findUnique({
             where: { appointment_id: params.id },
         });
 
+        // 4️⃣ Verify ownership
         if (!appointment || appointment.patient_user_id !== session.user.id) {
             return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
         }
 
-        if (
-            ![
-                AppointmentStatus.Pending,
-                AppointmentStatus.Approved,
-                AppointmentStatus.Moved,
-            ].includes(appointment.status)
-        ) {
+        // 5️⃣ Ensure appointment is reschedulable
+        if (!isCancellable(appointment.status)) {
             return NextResponse.json(
                 { message: "Appointment can no longer be rescheduled" },
                 { status: 400 }
             );
         }
 
+        // 6️⃣ Validate time inputs
         const appointment_timestart = buildManilaDate(date, time_start);
         const appointment_timeend = buildManilaDate(date, time_end);
 
@@ -56,6 +73,7 @@ export async function PATCH(
             return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
         }
 
+        // 7️⃣ Ensure booking is at least 3 days in advance
         const now = manilaNow();
         const diffMs = appointment_timestart.getTime() - now.getTime();
         const diffDays = diffMs / (1000 * 60 * 60 * 24);
@@ -66,6 +84,7 @@ export async function PATCH(
             );
         }
 
+        // 8️⃣ Get doctor’s availability for that day
         const dayStart = startOfManilaDay(date);
         const dayEnd = endOfManilaDay(date);
 
@@ -90,17 +109,14 @@ export async function PATCH(
             );
         }
 
+        // 9️⃣ Check for conflicts with other appointments
         const conflictingAppointments = await prisma.appointment.findMany({
             where: {
                 appointment_id: { not: appointment.appointment_id },
                 doctor_user_id: appointment.doctor_user_id,
                 appointment_timestart: { gte: dayStart, lte: dayEnd },
                 status: {
-                    in: [
-                        AppointmentStatus.Pending,
-                        AppointmentStatus.Approved,
-                        AppointmentStatus.Moved,
-                    ],
+                    in: cancellableStatuses, // ✅ uses same list for consistency
                 },
             },
         });
@@ -118,6 +134,7 @@ export async function PATCH(
             return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
         }
 
+        // 🔟 Update appointment to new time (status reset to Pending)
         const updated = await prisma.appointment.update({
             where: { appointment_id: appointment.appointment_id },
             data: {
@@ -145,37 +162,41 @@ export async function PATCH(
     }
 }
 
+// ------------------------------------------------------------
+// DELETE — Cancel an Appointment
+// ------------------------------------------------------------
 export async function DELETE(
     _req: Request,
-    { params }: { params: { id: string } }
+    context: { params: { id: string } }
 ) {
     try {
+        const { params } = context;
         const session = await getServerSession(authOptions);
+
+        // 1️⃣ Ensure authenticated
         if (!session?.user?.id) {
             return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
         }
 
+        // 2️⃣ Fetch appointment
         const appointment = await prisma.appointment.findUnique({
             where: { appointment_id: params.id },
         });
 
+        // 3️⃣ Verify ownership
         if (!appointment || appointment.patient_user_id !== session.user.id) {
             return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
         }
 
-        if (
-            ![
-                AppointmentStatus.Pending,
-                AppointmentStatus.Approved,
-                AppointmentStatus.Moved,
-            ].includes(appointment.status)
-        ) {
+        // 4️⃣ Check if appointment can still be cancelled
+        if (!isCancellable(appointment.status)) {
             return NextResponse.json(
                 { message: "Appointment can no longer be cancelled" },
                 { status: 400 }
             );
         }
 
+        // 5️⃣ Update to Cancelled
         await prisma.appointment.update({
             where: { appointment_id: appointment.appointment_id },
             data: { status: AppointmentStatus.Cancelled },

--- a/src/app/api/patient/appointments/[id]/route.ts
+++ b/src/app/api/patient/appointments/[id]/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { AppointmentStatus } from "@prisma/client";
+import {
+    buildManilaDate,
+    endOfManilaDay,
+    manilaNow,
+    rangesOverlap,
+    startOfManilaDay,
+} from "@/lib/time";
+
+export async function PATCH(
+    req: Request,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await req.json();
+        const { date, time_start, time_end } = body || {};
+
+        if (!date || !time_start || !time_end) {
+            return NextResponse.json({ message: "Missing fields" }, { status: 400 });
+        }
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id: params.id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== session.user.id) {
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+        }
+
+        if (
+            ![
+                AppointmentStatus.Pending,
+                AppointmentStatus.Approved,
+                AppointmentStatus.Moved,
+            ].includes(appointment.status)
+        ) {
+            return NextResponse.json(
+                { message: "Appointment can no longer be rescheduled" },
+                { status: 400 }
+            );
+        }
+
+        const appointment_timestart = buildManilaDate(date, time_start);
+        const appointment_timeend = buildManilaDate(date, time_end);
+
+        if (appointment_timeend <= appointment_timestart) {
+            return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
+        }
+
+        const now = manilaNow();
+        const diffMs = appointment_timestart.getTime() - now.getTime();
+        const diffDays = diffMs / (1000 * 60 * 60 * 24);
+        if (diffDays < 3) {
+            return NextResponse.json(
+                { message: "Appointments must be booked at least 3 days in advance" },
+                { status: 400 }
+            );
+        }
+
+        const dayStart = startOfManilaDay(date);
+        const dayEnd = endOfManilaDay(date);
+
+        const availabilities = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                clinic_id: appointment.clinic_id,
+                available_date: { gte: dayStart, lte: dayEnd },
+            },
+        });
+
+        const withinAvailability = availabilities.some(
+            (av) =>
+                appointment_timestart >= av.available_timestart &&
+                appointment_timeend <= av.available_timeend
+        );
+
+        if (!withinAvailability) {
+            return NextResponse.json(
+                { message: "Selected time is outside doctor's availability" },
+                { status: 400 }
+            );
+        }
+
+        const conflictingAppointments = await prisma.appointment.findMany({
+            where: {
+                appointment_id: { not: appointment.appointment_id },
+                doctor_user_id: appointment.doctor_user_id,
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: {
+                    in: [
+                        AppointmentStatus.Pending,
+                        AppointmentStatus.Approved,
+                        AppointmentStatus.Moved,
+                    ],
+                },
+            },
+        });
+
+        const conflict = conflictingAppointments.some((existing) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                existing.appointment_timestart,
+                existing.appointment_timeend
+            )
+        );
+
+        if (conflict) {
+            return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+        }
+
+        const updated = await prisma.appointment.update({
+            where: { appointment_id: appointment.appointment_id },
+            data: {
+                appointment_date: dayStart,
+                appointment_timestart,
+                appointment_timeend,
+                status: AppointmentStatus.Pending,
+            },
+            select: {
+                appointment_id: true,
+                appointment_date: true,
+                appointment_timestart: true,
+                appointment_timeend: true,
+                status: true,
+            },
+        });
+
+        return NextResponse.json({
+            id: updated.appointment_id,
+            status: updated.status,
+        });
+    } catch (error) {
+        console.error("[PATCH /api/patient/appointments/:id]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    _req: Request,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+        }
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id: params.id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== session.user.id) {
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+        }
+
+        if (
+            ![
+                AppointmentStatus.Pending,
+                AppointmentStatus.Approved,
+                AppointmentStatus.Moved,
+            ].includes(appointment.status)
+        ) {
+            return NextResponse.json(
+                { message: "Appointment can no longer be cancelled" },
+                { status: 400 }
+            );
+        }
+
+        await prisma.appointment.update({
+            where: { appointment_id: appointment.appointment_id },
+            data: { status: AppointmentStatus.Cancelled },
+        });
+
+        return NextResponse.json({ message: "Appointment cancelled" });
+    } catch (error) {
+        console.error("[DELETE /api/patient/appointments/:id]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/src/app/api/patient/appointments/[id]/route.ts
+++ b/src/app/api/patient/appointments/[id]/route.ts
@@ -23,23 +23,23 @@ function isCancellable(status: AppointmentStatus): boolean {
     return cancellableStatuses.includes(status);
 }
 
+// ✅ Define context type for the route (no `any`, no inline type)
+interface RouteContext {
+    params: { id: string };
+}
+
 // ------------------------------------------------------------
 // PATCH — Reschedule an Appointment
 // ------------------------------------------------------------
-export async function PATCH(
-    req: Request,
-    context: { params: { id: string } }
-) {
+export async function PATCH(req: Request, context: RouteContext) {
     try {
         const { params } = context;
         const session = await getServerSession(authOptions);
 
-        // 1️⃣ Ensure authenticated
         if (!session?.user?.id) {
             return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
         }
 
-        // 2️⃣ Validate request body
         const body = await req.json();
         const { date, time_start, time_end } = body || {};
 
@@ -47,17 +47,14 @@ export async function PATCH(
             return NextResponse.json({ message: "Missing fields" }, { status: 400 });
         }
 
-        // 3️⃣ Fetch appointment
         const appointment = await prisma.appointment.findUnique({
             where: { appointment_id: params.id },
         });
 
-        // 4️⃣ Verify ownership
         if (!appointment || appointment.patient_user_id !== session.user.id) {
             return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
         }
 
-        // 5️⃣ Ensure appointment is reschedulable
         if (!isCancellable(appointment.status)) {
             return NextResponse.json(
                 { message: "Appointment can no longer be rescheduled" },
@@ -65,7 +62,6 @@ export async function PATCH(
             );
         }
 
-        // 6️⃣ Validate time inputs
         const appointment_timestart = buildManilaDate(date, time_start);
         const appointment_timeend = buildManilaDate(date, time_end);
 
@@ -73,7 +69,6 @@ export async function PATCH(
             return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
         }
 
-        // 7️⃣ Ensure booking is at least 3 days in advance
         const now = manilaNow();
         const diffMs = appointment_timestart.getTime() - now.getTime();
         const diffDays = diffMs / (1000 * 60 * 60 * 24);
@@ -84,7 +79,6 @@ export async function PATCH(
             );
         }
 
-        // 8️⃣ Get doctor’s availability for that day
         const dayStart = startOfManilaDay(date);
         const dayEnd = endOfManilaDay(date);
 
@@ -109,14 +103,13 @@ export async function PATCH(
             );
         }
 
-        // 9️⃣ Check for conflicts with other appointments
         const conflictingAppointments = await prisma.appointment.findMany({
             where: {
                 appointment_id: { not: appointment.appointment_id },
                 doctor_user_id: appointment.doctor_user_id,
                 appointment_timestart: { gte: dayStart, lte: dayEnd },
                 status: {
-                    in: cancellableStatuses, // ✅ uses same list for consistency
+                    in: cancellableStatuses,
                 },
             },
         });
@@ -134,7 +127,6 @@ export async function PATCH(
             return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
         }
 
-        // 🔟 Update appointment to new time (status reset to Pending)
         const updated = await prisma.appointment.update({
             where: { appointment_id: appointment.appointment_id },
             data: {
@@ -165,10 +157,7 @@ export async function PATCH(
 // ------------------------------------------------------------
 // DELETE — Cancel an Appointment
 // ------------------------------------------------------------
-export async function DELETE(
-    _req: Request,
-    context: { params: { id: string } }
-) {
+export async function DELETE(req: Request, context: RouteContext) {
     try {
         const { params } = context;
         const session = await getServerSession(authOptions);
@@ -203,4 +192,3 @@ export async function DELETE(
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
     }
 }
-

--- a/src/app/api/patient/appointments/[id]/route.ts
+++ b/src/app/api/patient/appointments/[id]/route.ts
@@ -173,22 +173,18 @@ export async function DELETE(
         const { params } = context;
         const session = await getServerSession(authOptions);
 
-        // 1️⃣ Ensure authenticated
         if (!session?.user?.id) {
             return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
         }
 
-        // 2️⃣ Fetch appointment
         const appointment = await prisma.appointment.findUnique({
             where: { appointment_id: params.id },
         });
 
-        // 3️⃣ Verify ownership
         if (!appointment || appointment.patient_user_id !== session.user.id) {
             return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
         }
 
-        // 4️⃣ Check if appointment can still be cancelled
         if (!isCancellable(appointment.status)) {
             return NextResponse.json(
                 { message: "Appointment can no longer be cancelled" },
@@ -196,7 +192,6 @@ export async function DELETE(
             );
         }
 
-        // 5️⃣ Update to Cancelled
         await prisma.appointment.update({
             where: { appointment_id: appointment.appointment_id },
             data: { status: AppointmentStatus.Cancelled },
@@ -208,3 +203,4 @@ export async function DELETE(
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
     }
 }
+

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -77,10 +77,10 @@ export default function DoctorConsultationPage() {
     const [clinics, setClinics] = useState<Clinic[]>([]);
     const [formData, setFormData] = useState({
         clinic_id: "",
-        available_date: "",
         available_timestart: "",
         available_timeend: "",
     });
+    const [editingDate, setEditingDate] = useState<string>("");
     const [editingSlot, setEditingSlot] = useState<Availability | null>(null);
     const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -126,7 +126,6 @@ export default function DoctorConsultationPage() {
         e.preventDefault();
         if (
             !formData.clinic_id ||
-            !formData.available_date ||
             !formData.available_timestart ||
             !formData.available_timeend
         ) {
@@ -135,7 +134,12 @@ export default function DoctorConsultationPage() {
         }
 
         const body = editingSlot
-            ? { availability_id: editingSlot.availability_id, ...formData }
+            ? {
+                  availability_id: editingSlot.availability_id,
+                  clinic_id: formData.clinic_id,
+                  available_timestart: formData.available_timestart,
+                  available_timeend: formData.available_timeend,
+              }
             : formData;
         const method = editingSlot ? "PUT" : "POST";
 
@@ -154,10 +158,10 @@ export default function DoctorConsultationPage() {
                 setDialogOpen(false);
                 setFormData({
                     clinic_id: "",
-                    available_date: "",
                     available_timestart: "",
                     available_timeend: "",
                 });
+                setEditingDate("");
                 setEditingSlot(null);
                 loadSlots();
             }
@@ -291,10 +295,10 @@ export default function DoctorConsultationPage() {
                                             setEditingSlot(null);
                                             setFormData({
                                                 clinic_id: "",
-                                                available_date: "",
                                                 available_timestart: "",
                                                 available_timeend: "",
                                             });
+                                            setEditingDate("");
                                         }}
                                     >
                                         <PlusCircle className="h-4 w-4" /> Add Slot
@@ -327,15 +331,18 @@ export default function DoctorConsultationPage() {
                                             </select>
                                         </div>
 
-                                        <div>
-                                            <Label>Date</Label>
-                                            <Input
-                                                type="date"
-                                                value={formData.available_date}
-                                                onChange={(e) => setFormData({ ...formData, available_date: e.target.value })}
-                                                required
-                                            />
-                                        </div>
+                                        {!editingSlot ? (
+                                            <p className="text-sm text-gray-500 bg-green-50 border border-green-100 rounded-md p-3">
+                                                Enter your start and end time once and we will automatically plot the duty hours
+                                                from Monday to Friday for physicians, or Monday to Saturday for dentists, based
+                                                on the current week.
+                                            </p>
+                                        ) : (
+                                            <div>
+                                                <Label>Date</Label>
+                                                <Input type="date" value={editingDate} disabled readOnly />
+                                            </div>
+                                        )}
 
                                         <div className="grid grid-cols-2 gap-4">
                                             <div>
@@ -343,7 +350,12 @@ export default function DoctorConsultationPage() {
                                                 <Input
                                                     type="time"
                                                     value={formData.available_timestart}
-                                                    onChange={(e) => setFormData({ ...formData, available_timestart: e.target.value })}
+                                                    onChange={(e) =>
+                                                        setFormData({
+                                                            ...formData,
+                                                            available_timestart: e.target.value,
+                                                        })
+                                                    }
                                                     required
                                                 />
                                             </div>
@@ -352,7 +364,12 @@ export default function DoctorConsultationPage() {
                                                 <Input
                                                     type="time"
                                                     value={formData.available_timeend}
-                                                    onChange={(e) => setFormData({ ...formData, available_timeend: e.target.value })}
+                                                    onChange={(e) =>
+                                                        setFormData({
+                                                            ...formData,
+                                                            available_timeend: e.target.value,
+                                                        })
+                                                    }
                                                     required
                                                 />
                                             </div>
@@ -405,10 +422,10 @@ export default function DoctorConsultationPage() {
                                                                 setEditingSlot(slot);
                                                                 setFormData({
                                                                     clinic_id: slot.clinic.clinic_id,
-                                                                    available_date: toManilaDateString(slot.available_date),
                                                                     available_timestart: toManilaTimeString(slot.available_timestart),
                                                                     available_timeend: toManilaTimeString(slot.available_timeend),
                                                                 });
+                                                                setEditingDate(toManilaDateString(slot.available_date));
                                                                 setDialogOpen(true);
                                                             }}
                                                             className="gap-2 text-green-700 border-green-200 hover:bg-green-50"

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -17,6 +17,36 @@ export function endOfManilaDay(date: string): Date {
 }
 
 /**
+ * ✅ Convert a JS Date into a Manila-local YYYY-MM-DD string
+ */
+export function formatManilaDate(date: Date): string {
+    return date.toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+}
+
+/**
+ * ✅ Return a new Date pinned to the Monday of the given week (Manila time)
+ */
+export function startOfManilaWeek(date: Date): Date {
+    const copy = new Date(date.getTime());
+    copy.setHours(0, 0, 0, 0);
+
+    const day = copy.getDay();
+    const diffToMonday = (day + 6) % 7; // 0 if Monday, 1 if Tuesday, ..., 6 if Sunday
+    copy.setDate(copy.getDate() - diffToMonday);
+
+    return copy;
+}
+
+/**
+ * ✅ Add days to a Date while keeping Manila timezone context
+ */
+export function addManilaDays(date: Date, days: number): Date {
+    const copy = new Date(date.getTime());
+    copy.setDate(copy.getDate() + days);
+    return copy;
+}
+
+/**
  * ✅ Range overlap check (used for appointments)
  */
 export function rangesOverlap(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) {


### PR DESCRIPTION
## Summary
- generate weekly duty schedules based on specialization from a single time range while blocking conflicts
- expose patient appointment reschedule and cancellation APIs with three-day lead validation and slot reuse controls
- update doctor and patient UIs to reflect automated scheduling, booking limits, and manage appointments with dialogs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f0d9f5f0f48333a1edf3a73b95c548