### PR TITLE
Implement weekly duty scheduling and patient appointment updates

### DIFF
--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -2,8 +2,16 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { Role, Prisma } from "@prisma/client";
-import { buildManilaDate, startOfManilaDay } from "@/lib/time";
+import { Role, Prisma, DoctorSpecialization } from "@prisma/client";
+import {
+    addDays,
+    buildManilaDate,
+    endOfManilaDay,
+    formatAsManilaDate,
+    rangesOverlap,
+    startOfManilaDay,
+    startOfNextOrSameManilaMonday,
+} from "@/lib/time";
 
 /**
  * ✅ GET — Fetch all consultation slots for logged-in doctor
@@ -59,21 +67,17 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { clinic_id, available_date, available_timestart, available_timeend } =
-            await req.json();
-
-        if (!clinic_id || !available_date || !available_timestart || !available_timeend) {
-            return NextResponse.json({ error: "All fields are required" }, { status: 400 });
-        }
-
-        const start = buildManilaDate(available_date, available_timestart);
-        const end = buildManilaDate(available_date, available_timeend);
-
-        if (end <= start) {
+        if (!doctor.specialization) {
             return NextResponse.json(
-                { error: "End time must be after start time" },
+                { error: "Doctor specialization is required to set duty hours" },
                 { status: 400 }
             );
+        }
+
+        const { clinic_id, time_start, time_end } = await req.json();
+
+        if (!clinic_id || !time_start || !time_end) {
+            return NextResponse.json({ error: "Clinic and duty hours are required" }, { status: 400 });
         }
 
         const clinic = await prisma.clinic.findUnique({ where: { clinic_id } });
@@ -81,20 +85,102 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Clinic not found" }, { status: 404 });
         }
 
-        const newSlot = await prisma.doctorAvailability.create({
-            data: {
+        const upcomingMonday = startOfNextOrSameManilaMonday();
+        const activeDays =
+            doctor.specialization === DoctorSpecialization.Dentist ? 6 : 5;
+
+        const scheduleDays = Array.from({ length: activeDays }, (_, idx) => {
+            const date = addDays(upcomingMonday, idx);
+            const dateStr = formatAsManilaDate(date);
+            const start = buildManilaDate(dateStr, time_start);
+            const end = buildManilaDate(dateStr, time_end);
+            return { date, dateStr, start, end };
+        });
+
+        for (const slot of scheduleDays) {
+            if (slot.end <= slot.start) {
+                return NextResponse.json(
+                    { error: "Duty end time must be after start time" },
+                    { status: 400 }
+                );
+            }
+        }
+
+        const weekStart = scheduleDays[0]?.dateStr;
+        const weekEnd = scheduleDays[scheduleDays.length - 1]?.dateStr;
+
+        if (!weekStart || !weekEnd) {
+            return NextResponse.json(
+                { error: "Unable to determine schedule range" },
+                { status: 500 }
+            );
+        }
+
+        const existingConflicts = await prisma.doctorAvailability.findMany({
+            where: {
                 doctor_user_id: doctor.user_id,
-                clinic_id,
-                available_date: startOfManilaDay(available_date),
-                available_timestart: start,
-                available_timeend: end,
-            },
-            include: {
-                clinic: { select: { clinic_id: true, clinic_name: true } },
+                clinic_id: { not: clinic_id },
+                available_date: {
+                    gte: startOfManilaDay(weekStart),
+                    lte: endOfManilaDay(weekEnd),
+                },
             },
         });
 
-        return NextResponse.json(newSlot);
+        const conflict = scheduleDays.some((slot) =>
+            existingConflicts.some((existing) =>
+                rangesOverlap(
+                    slot.start,
+                    slot.end,
+                    existing.available_timestart,
+                    existing.available_timeend
+                ) &&
+                formatAsManilaDate(existing.available_timestart) === slot.dateStr
+            )
+        );
+
+        if (conflict) {
+            return NextResponse.json(
+                {
+                    error: "Duty hours conflict with existing availability in another clinic",
+                },
+                { status: 409 }
+            );
+        }
+
+        const created = await prisma.$transaction(async (tx) => {
+            await tx.doctorAvailability.deleteMany({
+                where: {
+                    doctor_user_id: doctor.user_id,
+                    clinic_id,
+                    available_date: {
+                        gte: startOfManilaDay(weekStart),
+                        lte: endOfManilaDay(weekEnd),
+                    },
+                },
+            });
+
+            const entries = await Promise.all(
+                scheduleDays.map((slot) =>
+                    tx.doctorAvailability.create({
+                        data: {
+                            doctor_user_id: doctor.user_id,
+                            clinic_id,
+                            available_date: startOfManilaDay(slot.dateStr),
+                            available_timestart: slot.start,
+                            available_timeend: slot.end,
+                        },
+                        include: {
+                            clinic: { select: { clinic_id: true, clinic_name: true } },
+                        },
+                    })
+                )
+            );
+
+            return entries;
+        });
+
+        return NextResponse.json(created);
     } catch (err) {
         console.error("[POST /api/doctor/consultation]", err);
         return NextResponse.json(

--- a/src/app/api/patient/appointments/[id]/route.ts
+++ b/src/app/api/patient/appointments/[id]/route.ts
@@ -1,0 +1,216 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import {
+    buildManilaDate,
+    endOfManilaDay,
+    isAtLeastNDaysAway,
+    rangesOverlap,
+    startOfManilaDay,
+} from "@/lib/time";
+import { AppointmentStatus } from "@prisma/client";
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id: params.id },
+            include: {
+                clinic: { select: { clinic_name: true } },
+                doctor: {
+                    select: {
+                        username: true,
+                        employee: { select: { fname: true, lname: true } },
+                        student: { select: { fname: true, lname: true } },
+                    },
+                },
+            },
+        });
+
+        if (!appointment || appointment.patient_user_id !== session.user.id)
+            return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
+
+        if ([AppointmentStatus.Cancelled, AppointmentStatus.Completed].includes(appointment.status)) {
+            return NextResponse.json(
+                { error: "This appointment can no longer be rescheduled" },
+                { status: 400 }
+            );
+        }
+
+        const { date, time_start, time_end } = await req.json();
+
+        if (!date || !time_start || !time_end)
+            return NextResponse.json({ error: "Missing new schedule details" }, { status: 400 });
+
+        const appointment_date = startOfManilaDay(date);
+        const appointment_timestart = buildManilaDate(date, time_start);
+        const appointment_timeend = buildManilaDate(date, time_end);
+
+        if (!(appointment_timestart < appointment_timeend))
+            return NextResponse.json({ error: "Invalid time range" }, { status: 400 });
+
+        if (!isAtLeastNDaysAway(appointment_timestart, 3))
+            return NextResponse.json(
+                { error: "Reschedules must be at least 3 days before the appointment" },
+                { status: 400 }
+            );
+
+        const dayStart = startOfManilaDay(date);
+        const dayEnd = endOfManilaDay(date);
+
+        const availabilities = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                clinic_id: appointment.clinic_id,
+                available_date: { gte: dayStart, lte: dayEnd },
+            },
+        });
+
+        const withinAvailability = availabilities.some(
+            (av) =>
+                appointment_timestart >= av.available_timestart &&
+                appointment_timeend <= av.available_timeend
+        );
+
+        if (!withinAvailability)
+            return NextResponse.json(
+                { error: "Selected time is outside doctor's availability" },
+                { status: 400 }
+            );
+
+        const doctorConflicts = await prisma.appointment.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                appointment_id: { not: appointment.appointment_id },
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+            },
+        });
+
+        const doctorConflict = doctorConflicts.some((e) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                e.appointment_timestart,
+                e.appointment_timeend
+            )
+        );
+
+        if (doctorConflict)
+            return NextResponse.json(
+                { error: "Time slot already booked" },
+                { status: 409 }
+            );
+
+        const patientConflicts = await prisma.appointment.findMany({
+            where: {
+                patient_user_id: appointment.patient_user_id,
+                appointment_id: { not: appointment.appointment_id },
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+            },
+        });
+
+        const patientConflict = patientConflicts.some((e) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                e.appointment_timestart,
+                e.appointment_timeend
+            )
+        );
+
+        if (patientConflict)
+            return NextResponse.json(
+                { error: "You already have an appointment at this time" },
+                { status: 409 }
+            );
+
+        const updated = await prisma.appointment.update({
+            where: { appointment_id: appointment.appointment_id },
+            data: {
+                appointment_date,
+                appointment_timestart,
+                appointment_timeend,
+                status: AppointmentStatus.Moved,
+            },
+            include: {
+                clinic: { select: { clinic_name: true } },
+                doctor: {
+                    select: {
+                        username: true,
+                        employee: { select: { fname: true, lname: true } },
+                        student: { select: { fname: true, lname: true } },
+                    },
+                },
+            },
+        });
+
+        const doctorName =
+            updated.doctor?.employee?.fname && updated.doctor?.employee?.lname
+                ? `${updated.doctor.employee.fname} ${updated.doctor.employee.lname}`
+                : updated.doctor?.student?.fname && updated.doctor?.student?.lname
+                    ? `${updated.doctor.student.fname} ${updated.doctor.student.lname}`
+                    : updated.doctor?.username ?? "-";
+
+        return NextResponse.json({
+            id: updated.appointment_id,
+            clinic: updated.clinic?.clinic_name ?? "-",
+            clinic_id: updated.clinic_id,
+            doctor: doctorName,
+            doctor_user_id: updated.doctor_user_id,
+            service_type: updated.service_type ?? null,
+            date: updated.appointment_timestart.toLocaleDateString("en-CA", {
+                timeZone: "Asia/Manila",
+            }),
+            time: updated.appointment_timestart.toLocaleTimeString("en-US", {
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: true,
+                timeZone: "Asia/Manila",
+            }),
+            status: updated.status,
+        });
+    } catch (err) {
+        console.error("[PATCH /api/patient/appointments/:id]", err);
+        return NextResponse.json({ error: "Failed to reschedule appointment" }, { status: 500 });
+    }
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id: params.id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== session.user.id)
+            return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
+
+        if ([AppointmentStatus.Cancelled, AppointmentStatus.Completed].includes(appointment.status))
+            return NextResponse.json(
+                { error: "This appointment is already closed" },
+                { status: 400 }
+            );
+
+        const cancelled = await prisma.appointment.update({
+            where: { appointment_id: appointment.appointment_id },
+            data: { status: AppointmentStatus.Cancelled },
+        });
+
+        return NextResponse.json({
+            id: cancelled.appointment_id,
+            status: cancelled.status,
+        });
+    } catch (err) {
+        console.error("[DELETE /api/patient/appointments/:id]", err);
+        return NextResponse.json({ error: "Failed to cancel appointment" }, { status: 500 });
+    }
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -102,6 +102,34 @@ export function manilaNow(): Date {
     return new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}+08:00`);
 }
 
+export function formatAsManilaDate(date: Date): string {
+    return date.toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+}
+
+export function startOfNextOrSameManilaMonday(fromDate?: Date): Date {
+    const reference = fromDate ? new Date(fromDate) : manilaNow();
+    reference.setHours(0, 0, 0, 0);
+    const day = reference.getDay();
+    const daysUntilMonday = (1 - day + 7) % 7;
+    const monday = new Date(reference);
+    monday.setDate(monday.getDate() + daysUntilMonday);
+    monday.setHours(0, 0, 0, 0);
+    return monday;
+}
+
+export function addDays(date: Date, days: number): Date {
+    const copy = new Date(date);
+    copy.setDate(copy.getDate() + days);
+    return copy;
+}
+
+export function isAtLeastNDaysAway(target: Date, days: number): boolean {
+    const threshold = manilaNow();
+    threshold.setHours(0, 0, 0, 0);
+    threshold.setDate(threshold.getDate() + days);
+    return target >= threshold;
+}
+
 /**
  * ✅ Format a date/time value into a Manila-localized string
  */


### PR DESCRIPTION
## Summary
- generate weekly duty hours for physicians and dentists by deriving weekday availabilities from a single start/end input while blocking conflicts across clinics
- enforce three-day advance booking, patient overlap checks, and expose reschedule/cancel APIs with conflict validation and status updates
- refresh doctor and patient UIs to use the new workflows, including weekly duty configuration, three-day date limits, available slot fetches, and reschedule/cancel controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f0d9f5f0f48333a1edf3a73b95c548