### PR TITLE
Implement weekly duty scheduling and enforce appointment rules

### DIFF
--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -2,8 +2,16 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { Role, Prisma } from "@prisma/client";
-import { buildManilaDate, startOfManilaDay } from "@/lib/time";
+import { Role } from "@prisma/client";
+import {
+    addManilaDays,
+    buildManilaDate,
+    manilaNow,
+    nextManilaMonday,
+    startOfManilaDay,
+    startOfManilaWeek,
+    toManilaISODate,
+} from "@/lib/time";
 
 /**
  * ✅ GET — Fetch all consultation slots for logged-in doctor
@@ -31,7 +39,10 @@ export async function GET() {
             orderBy: [{ available_date: "asc" }, { available_timestart: "asc" }],
         });
 
-        return NextResponse.json(slots);
+        return NextResponse.json({
+            specialization: doctor.specialization ?? null,
+            slots,
+        });
     } catch (err) {
         console.error("[GET /api/doctor/consultation]", err);
         return NextResponse.json(
@@ -42,7 +53,7 @@ export async function GET() {
 }
 
 /**
- * ✅ POST — Create new consultation slot (Manila-local)
+ * ✅ POST — Generate duty hours for the upcoming week
  */
 export async function POST(req: Request) {
     try {
@@ -59,19 +70,18 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { clinic_id, available_date, available_timestart, available_timeend } =
-            await req.json();
+        const { clinic_id, week_of, start_time, end_time } = await req.json();
 
-        if (!clinic_id || !available_date || !available_timestart || !available_timeend) {
-            return NextResponse.json({ error: "All fields are required" }, { status: 400 });
+        if (!clinic_id || !start_time || !end_time) {
+            return NextResponse.json(
+                { error: "Clinic, start time, and end time are required" },
+                { status: 400 }
+            );
         }
 
-        const start = buildManilaDate(available_date, available_timestart);
-        const end = buildManilaDate(available_date, available_timeend);
-
-        if (end <= start) {
+        if (!/^\d{2}:\d{2}$/.test(start_time) || !/^\d{2}:\d{2}$/.test(end_time)) {
             return NextResponse.json(
-                { error: "End time must be after start time" },
+                { error: "Time fields must be in HH:mm format" },
                 { status: 400 }
             );
         }
@@ -81,89 +91,97 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Clinic not found" }, { status: 404 });
         }
 
-        const newSlot = await prisma.doctorAvailability.create({
-            data: {
+        const baseDate = week_of ? startOfManilaDay(week_of) : nextManilaMonday(manilaNow());
+        const reference = startOfManilaWeek(baseDate);
+        const totalDays = doctor.specialization === "Dentist" ? 6 : 5;
+
+        const weekDates = Array.from({ length: totalDays }, (_, idx) => addManilaDays(reference, idx));
+        const slotsToCreate = weekDates.map((date) => {
+            const iso = toManilaISODate(date);
+            const dayStart = buildManilaDate(iso, start_time);
+            const dayEnd = buildManilaDate(iso, end_time);
+
+            if (dayEnd <= dayStart) {
+                throw new Error("invalid-range");
+            }
+
+            return {
+                iso,
+                dayStart,
+                dayEnd,
+            };
+        });
+
+        const weekStart = startOfManilaDay(slotsToCreate[0].iso);
+        const weekEnd = addManilaDays(startOfManilaDay(slotsToCreate[slotsToCreate.length - 1].iso), 1);
+
+        const existingAppointments = await prisma.appointment.findMany({
+            where: {
                 doctor_user_id: doctor.user_id,
                 clinic_id,
-                available_date: startOfManilaDay(available_date),
-                available_timestart: start,
-                available_timeend: end,
-            },
-            include: {
-                clinic: { select: { clinic_id: true, clinic_name: true } },
+                appointment_timestart: { gte: weekStart, lt: weekEnd },
+                status: { in: ["Pending", "Approved"] },
             },
         });
 
-        return NextResponse.json(newSlot);
+        const hasConflict = existingAppointments.some((appt) => {
+            const dayIso = toManilaISODate(appt.appointment_timestart);
+            const slot = slotsToCreate.find((s) => s.iso === dayIso);
+            if (!slot) return true;
+            return appt.appointment_timestart < slot.dayStart || appt.appointment_timeend > slot.dayEnd;
+        });
+
+        if (hasConflict) {
+            return NextResponse.json(
+                {
+                    error: "Existing appointments fall outside the new duty hours. Please resolve them first.",
+                },
+                { status: 409 }
+            );
+        }
+
+        await prisma.$transaction([
+            prisma.doctorAvailability.deleteMany({
+                where: {
+                    doctor_user_id: doctor.user_id,
+                    clinic_id,
+                    available_timestart: { gte: weekStart, lt: weekEnd },
+                },
+            }),
+            prisma.doctorAvailability.createMany({
+                data: slotsToCreate.map((slot) => ({
+                    doctor_user_id: doctor.user_id,
+                    clinic_id,
+                    available_date: startOfManilaDay(slot.iso),
+                    available_timestart: slot.dayStart,
+                    available_timeend: slot.dayEnd,
+                })),
+            }),
+        ]);
+
+        const refreshedSlots = await prisma.doctorAvailability.findMany({
+            where: { doctor_user_id: doctor.user_id },
+            include: {
+                clinic: { select: { clinic_id: true, clinic_name: true } },
+            },
+            orderBy: [{ available_date: "asc" }, { available_timestart: "asc" }],
+        });
+
+        return NextResponse.json({
+            specialization: doctor.specialization ?? null,
+            slots: refreshedSlots,
+        });
     } catch (err) {
+        if (err instanceof Error && err.message === "invalid-range") {
+            return NextResponse.json(
+                { error: "End time must be after start time" },
+                { status: 400 }
+            );
+        }
+
         console.error("[POST /api/doctor/consultation]", err);
         return NextResponse.json(
-            { error: "Failed to add consultation slot" },
-            { status: 500 }
-        );
-    }
-}
-
-/**
- * ✅ PUT — Update existing consultation slot (Manila-local)
- */
-export async function PUT(req: Request) {
-    try {
-        const session = await getServerSession(authOptions);
-        if (!session?.user?.id) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const doctor = await prisma.users.findUnique({
-            where: { user_id: session.user.id },
-        });
-
-        if (!doctor || doctor.role !== Role.DOCTOR) {
-            return NextResponse.json({ error: "Access denied" }, { status: 403 });
-        }
-
-        const {
-            availability_id,
-            clinic_id,
-            available_date,
-            available_timestart,
-            available_timeend,
-        } = await req.json();
-
-        if (!availability_id) {
-            return NextResponse.json({ error: "Missing availability ID" }, { status: 400 });
-        }
-
-        const updateData: Prisma.DoctorAvailabilityUpdateInput = {};
-
-        if (clinic_id) {
-            updateData.clinic = { connect: { clinic_id } };
-        }
-
-        if (available_date) {
-            updateData.available_date = startOfManilaDay(available_date);
-        }
-
-        if (available_timestart && available_date) {
-            updateData.available_timestart = buildManilaDate(available_date, available_timestart);
-        }
-        if (available_timeend && available_date) {
-            updateData.available_timeend = buildManilaDate(available_date, available_timeend);
-        }
-
-        const updated = await prisma.doctorAvailability.update({
-            where: { availability_id },
-            data: updateData,
-            include: {
-                clinic: { select: { clinic_id: true, clinic_name: true } },
-            },
-        });
-
-        return NextResponse.json(updated);
-    } catch (err) {
-        console.error("[PUT /api/doctor/consultation]", err);
-        return NextResponse.json(
-            { error: "Failed to update consultation slot" },
+            { error: "Failed to update duty hours" },
             { status: 500 }
         );
     }

--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -7,6 +7,8 @@ import {
     buildManilaDate,
     startOfManilaDay,
     endOfManilaDay,
+    manilaNow,
+    addManilaDays,
 } from "@/lib/time";
 import { AppointmentStatus, Role, ServiceType } from "@prisma/client";
 
@@ -24,6 +26,7 @@ export async function GET() {
                 doctor: {
                     select: {
                         username: true,
+                        specialization: true,
                         employee: { select: { fname: true, lname: true } },
                         student: { select: { fname: true, lname: true } },
                     },
@@ -41,10 +44,32 @@ export async function GET() {
                         ? `${a.doctor.student.fname} ${a.doctor.student.lname}`
                         : a.doctor?.username ?? "-";
 
+            const manilaDate = new Date(a.appointment_timestart).toLocaleDateString("en-CA", {
+                timeZone: "Asia/Manila",
+            });
+
+            const start24 = new Date(a.appointment_timestart).toLocaleTimeString("en-GB", {
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false,
+                timeZone: "Asia/Manila",
+            });
+
+            const end24 = new Date(a.appointment_timeend).toLocaleTimeString("en-GB", {
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false,
+                timeZone: "Asia/Manila",
+            });
+
             return {
                 id: a.appointment_id,
+                clinicId: a.clinic_id,
                 clinic: a.clinic?.clinic_name ?? "-",
                 doctor: doctorName,
+                doctorId: a.doctor_user_id,
+                doctorSpecialization: a.doctor?.specialization ?? null,
+                dateISO: manilaDate,
                 date: new Date(a.appointment_timestart).toLocaleDateString("en-CA", {
                     timeZone: "Asia/Manila",
                 }),
@@ -54,6 +79,8 @@ export async function GET() {
                     hour12: true,
                     timeZone: "Asia/Manila",
                 }),
+                timeStart: start24,
+                timeEnd: end24,
                 status: a.status,
             };
         });
@@ -82,6 +109,12 @@ export async function POST(req: Request) {
         if (!clinic_id || !doctor_user_id || !service_type || !date || !time_start || !time_end)
             return NextResponse.json({ message: "Missing required fields" }, { status: 400 });
 
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(date))
+            return NextResponse.json({ message: "Invalid date format" }, { status: 400 });
+
+        if (!/^\d{2}:\d{2}$/.test(time_start) || !/^\d{2}:\d{2}$/.test(time_end))
+            return NextResponse.json({ message: "Invalid time format" }, { status: 400 });
+
         const clinic = await prisma.clinic.findUnique({ where: { clinic_id } });
         if (!clinic) return NextResponse.json({ message: "Clinic not found" }, { status: 404 });
 
@@ -98,6 +131,13 @@ export async function POST(req: Request) {
 
         if (!(appointment_timestart < appointment_timeend))
             return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
+
+        const minStart = addManilaDays(manilaNow(), 3);
+        if (appointment_timestart < minStart)
+            return NextResponse.json(
+                { message: "Appointments must be booked at least 3 days in advance" },
+                { status: 400 }
+            );
 
         // ✅ Check if within availability
         const availabilities = await prisma.doctorAvailability.findMany({
@@ -141,6 +181,29 @@ export async function POST(req: Request) {
         if (conflict)
             return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
 
+        const patientConflicts = await prisma.appointment.findMany({
+            where: {
+                patient_user_id,
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+            },
+        });
+
+        const patientOverlap = patientConflicts.some((appt) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                appt.appointment_timestart,
+                appt.appointment_timeend
+            )
+        );
+
+        if (patientOverlap)
+            return NextResponse.json(
+                { message: "You already have an appointment scheduled for this time" },
+                { status: 409 }
+            );
+
         // ✅ Create the appointment
         const created = await prisma.appointment.create({
             data: {
@@ -161,6 +224,163 @@ export async function POST(req: Request) {
         });
     } catch (error) {
         console.error("[POST /api/patient/appointments]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function PUT(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+        const patient_user_id = session.user.id as string;
+        const body = await req.json();
+        const { appointment_id, date, time_start, time_end } = body || {};
+
+        if (!appointment_id || !date || !time_start || !time_end)
+            return NextResponse.json({ message: "Missing required fields" }, { status: 400 });
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== patient_user_id)
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !/^\d{2}:\d{2}$/.test(time_start) || !/^\d{2}:\d{2}$/.test(time_end))
+            return NextResponse.json({ message: "Invalid date or time format" }, { status: 400 });
+
+        const appointment_timestart = buildManilaDate(date, time_start);
+        const appointment_timeend = buildManilaDate(date, time_end);
+
+        if (!(appointment_timestart < appointment_timeend))
+            return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
+
+        const minStart = addManilaDays(manilaNow(), 3);
+        if (appointment_timestart < minStart)
+            return NextResponse.json(
+                { message: "Rescheduled appointments must be at least 3 days ahead" },
+                { status: 400 }
+            );
+
+        const dayStart = startOfManilaDay(date);
+        const dayEnd = endOfManilaDay(date);
+
+        const availabilities = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                clinic_id: appointment.clinic_id,
+                available_date: { gte: dayStart, lte: dayEnd },
+            },
+        });
+
+        const withinAvailability = availabilities.some(
+            (av) =>
+                appointment_timestart >= av.available_timestart &&
+                appointment_timeend <= av.available_timeend
+        );
+
+        if (!withinAvailability)
+            return NextResponse.json(
+                { message: "Selected time is outside doctor's availability" },
+                { status: 400 }
+            );
+
+        const doctorConflicts = await prisma.appointment.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+                NOT: { appointment_id },
+            },
+        });
+
+        const doctorOverlap = doctorConflicts.some((e) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                e.appointment_timestart,
+                e.appointment_timeend
+            )
+        );
+
+        if (doctorOverlap)
+            return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+
+        const patientConflicts = await prisma.appointment.findMany({
+            where: {
+                patient_user_id,
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+                NOT: { appointment_id },
+            },
+        });
+
+        const patientOverlap = patientConflicts.some((appt) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                appt.appointment_timestart,
+                appt.appointment_timeend
+            )
+        );
+
+        if (patientOverlap)
+            return NextResponse.json(
+                { message: "You already have an appointment scheduled for this time" },
+                { status: 409 }
+            );
+
+        const updated = await prisma.appointment.update({
+            where: { appointment_id },
+            data: {
+                appointment_date: startOfManilaDay(date),
+                appointment_timestart,
+                appointment_timeend,
+                status: AppointmentStatus.Moved,
+            },
+            select: {
+                appointment_id: true,
+                appointment_timestart: true,
+                appointment_timeend: true,
+                status: true,
+            },
+        });
+
+        return NextResponse.json(updated);
+    } catch (error) {
+        console.error("[PUT /api/patient/appointments]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function DELETE(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+        const patient_user_id = session.user.id as string;
+        const { appointment_id } = await req.json();
+
+        if (!appointment_id)
+            return NextResponse.json({ message: "Missing appointment ID" }, { status: 400 });
+
+        const appointment = await prisma.appointment.findUnique({ where: { appointment_id } });
+
+        if (!appointment || appointment.patient_user_id !== patient_user_id)
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+
+        const cancelled = await prisma.appointment.update({
+            where: { appointment_id },
+            data: { status: AppointmentStatus.Cancelled },
+            select: { appointment_id: true, status: true },
+        });
+
+        return NextResponse.json(cancelled);
+    } catch (error) {
+        console.error("[DELETE /api/patient/appointments]", error);
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
     }
 }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -133,3 +133,56 @@ export function formatManilaDateTime(
 
     return date.toLocaleString("en-PH", finalOptions);
 }
+
+const WEEKDAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/**
+ * ✅ Return the day-of-week index (0 = Sunday .. 6 = Saturday) for a Manila-local date
+ */
+export function manilaWeekdayIndex(date: Date): number {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+        weekday: "short",
+        timeZone: "Asia/Manila",
+    });
+
+    const weekday = formatter.format(date);
+    return WEEKDAYS_SHORT.indexOf(weekday as (typeof WEEKDAYS_SHORT)[number]);
+}
+
+/**
+ * ✅ Add a number of calendar days to a Date using UTC math (stable for Manila)
+ */
+export function addManilaDays(date: Date, days: number): Date {
+    const copy = new Date(date.getTime());
+    copy.setUTCDate(copy.getUTCDate() + days);
+    return copy;
+}
+
+/**
+ * ✅ Format a Manila-local ISO date string (YYYY-MM-DD) from a Date instance
+ */
+export function toManilaISODate(date: Date): string {
+    return date.toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+}
+
+/**
+ * ✅ Compute the Monday (start of week) for a Manila-local Date
+ */
+export function startOfManilaWeek(date: Date): Date {
+    const dayIndex = manilaWeekdayIndex(date);
+    const offset = (7 + 1 - dayIndex) % 7; // 1 = Monday
+    const monday = addManilaDays(date, -((7 - offset) % 7));
+    const iso = toManilaISODate(monday);
+    return startOfManilaDay(iso);
+}
+
+/**
+ * ✅ Get the next Monday relative to a Manila-local Date (if already Monday, returns same day)
+ */
+export function nextManilaMonday(date: Date): Date {
+    const dayIndex = manilaWeekdayIndex(date);
+    const offset = (7 + 1 - dayIndex) % 7;
+    const next = addManilaDays(date, offset);
+    const iso = toManilaISODate(next);
+    return startOfManilaDay(iso);
+}


### PR DESCRIPTION
## Summary
- generate weekly duty hours based on doctor specialization with conflict checks and refreshed availability data
- enforce three-day lead time, availability validation, and overlapping checks for patient bookings with reschedule/cancel support
- refresh doctor and patient UIs to reflect automated scheduling, available slots, and duplicate booking prevention

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f0d9f5f0f48333a1edf3a73b95c548