### PR TITLE
Automate doctor duty scheduling and enhance patient appointment management

### DIFF
--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -2,8 +2,16 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { Role, Prisma } from "@prisma/client";
-import { buildManilaDate, startOfManilaDay } from "@/lib/time";
+import { DoctorSpecialization, Prisma, Role } from "@prisma/client";
+import {
+    buildManilaDate,
+    endOfManilaDay,
+    formatManilaISODate,
+    manilaNow,
+    startOfManilaDay,
+} from "@/lib/time";
+const DEFAULT_WEEKS = 4;
+const MAX_WEEKS = 12;
 
 /**
  * ✅ GET — Fetch all consultation slots for logged-in doctor
@@ -59,17 +67,22 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { clinic_id, available_date, available_timestart, available_timeend } =
-            await req.json();
+        const {
+            clinic_id,
+            available_timestart,
+            available_timeend,
+            weeks = DEFAULT_WEEKS,
+        } = await req.json();
 
-        if (!clinic_id || !available_date || !available_timestart || !available_timeend) {
+        if (!clinic_id || !available_timestart || !available_timeend) {
             return NextResponse.json({ error: "All fields are required" }, { status: 400 });
         }
 
-        const start = buildManilaDate(available_date, available_timestart);
-        const end = buildManilaDate(available_date, available_timeend);
+        const sampleDate = "2000-01-01";
+        const sampleStart = buildManilaDate(sampleDate, available_timestart);
+        const sampleEnd = buildManilaDate(sampleDate, available_timeend);
 
-        if (end <= start) {
+        if (sampleEnd <= sampleStart) {
             return NextResponse.json(
                 { error: "End time must be after start time" },
                 { status: 400 }
@@ -81,24 +94,84 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Clinic not found" }, { status: 404 });
         }
 
-        const newSlot = await prisma.doctorAvailability.create({
-            data: {
+        const allowedDays = new Set<number>(
+            doctor.specialization === DoctorSpecialization.Dentist
+                ? [1, 2, 3, 4, 5, 6]
+                : [1, 2, 3, 4, 5]
+        );
+
+        const scheduleWeeks = Math.max(1, Math.min(Number(weeks) || DEFAULT_WEEKS, MAX_WEEKS));
+        const daysToGenerate = scheduleWeeks * 7;
+
+        const base = manilaNow();
+        const toCreate: Prisma.DoctorAvailabilityCreateManyInput[] = [];
+        const generatedDates: string[] = [];
+
+        for (let i = 0; i < daysToGenerate; i += 1) {
+            const current = new Date(base);
+            current.setUTCDate(current.getUTCDate() + i);
+
+            const manilaDate = formatManilaISODate(current);
+            const weekday = new Date(`${manilaDate}T00:00:00+08:00`).getUTCDay();
+
+            if (!allowedDays.has(weekday)) continue;
+
+            generatedDates.push(manilaDate);
+            toCreate.push({
                 doctor_user_id: doctor.user_id,
                 clinic_id,
-                available_date: startOfManilaDay(available_date),
-                available_timestart: start,
-                available_timeend: end,
-            },
+                available_date: startOfManilaDay(manilaDate),
+                available_timestart: buildManilaDate(manilaDate, available_timestart),
+                available_timeend: buildManilaDate(manilaDate, available_timeend),
+            });
+        }
+
+        if (toCreate.length === 0) {
+            return NextResponse.json(
+                {
+                    error:
+                        "No working days available for the selected timeframe. Check doctor specialization settings.",
+                },
+                { status: 400 }
+            );
+        }
+
+        const rangeStart = startOfManilaDay(generatedDates[0]);
+        const rangeEnd = endOfManilaDay(generatedDates[generatedDates.length - 1]);
+
+        await prisma.$transaction(async (tx) => {
+            await tx.doctorAvailability.deleteMany({
+                where: {
+                    doctor_user_id: doctor.user_id,
+                    clinic_id,
+                    available_date: { gte: rangeStart, lte: rangeEnd },
+                },
+            });
+
+            await tx.doctorAvailability.createMany({ data: toCreate });
+        });
+
+        const refreshed = await prisma.doctorAvailability.findMany({
+            where: { doctor_user_id: doctor.user_id },
             include: {
                 clinic: { select: { clinic_id: true, clinic_name: true } },
             },
+            orderBy: [{ available_date: "asc" }, { available_timestart: "asc" }],
         });
 
-        return NextResponse.json(newSlot);
+        const firstDay = generatedDates[0];
+        const lastDay = generatedDates[generatedDates.length - 1];
+
+        return NextResponse.json({
+            message: `Duty hours generated for ${generatedDates.length} day${
+                generatedDates.length === 1 ? "" : "s"
+            } (${firstDay} to ${lastDay}).`,
+            slots: refreshed,
+        });
     } catch (err) {
         console.error("[POST /api/doctor/consultation]", err);
         return NextResponse.json(
-            { error: "Failed to add consultation slot" },
+            { error: "Failed to add consultation slots" },
             { status: 500 }
         );
     }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -53,6 +53,14 @@ export function formatTimeRange(start: string, end: string): string {
     return `${formatTimeString12(start)} – ${formatTimeString12(end)}`;
 }
 
+const manilaISOFormatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Manila",
+});
+
+export function formatManilaISODate(date: Date): string {
+    return manilaISOFormatter.format(date);
+}
+
 export function toManilaTimeString(dateStr: string): string {
     if (!dateStr) return "";
     const date = new Date(dateStr);


### PR DESCRIPTION
## Summary
- generate recurring duty hours based on a doctor’s specialization and a single start/end time entry, while keeping slot editing available
- enforce a three-day lead time and add patient reschedule/cancel endpoints with safety checks in the appointment API
- refresh doctor and patient UIs to surface the new scheduling flow, including bulk duty-hour generation and patient reschedule/cancel dialogs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f0f09da7688333904a6401183268dc