### PR TITLE
Implement weekly duty scheduling and patient appointment controls

### DIFF
--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -7,8 +7,13 @@ import {
     buildManilaDate,
     startOfManilaDay,
     endOfManilaDay,
+    manilaNow,
+    toManilaDateString,
+    toManilaTimeString,
 } from "@/lib/time";
 import { AppointmentStatus, Role, ServiceType } from "@prisma/client";
+
+const MIN_BOOKING_LEAD_MS = 3 * 24 * 60 * 60 * 1000;
 
 export async function GET() {
     try {
@@ -44,6 +49,8 @@ export async function GET() {
             return {
                 id: a.appointment_id,
                 clinic: a.clinic?.clinic_name ?? "-",
+                clinic_id: a.clinic_id,
+                doctor_user_id: a.doctor_user_id,
                 doctor: doctorName,
                 date: new Date(a.appointment_timestart).toLocaleDateString("en-CA", {
                     timeZone: "Asia/Manila",
@@ -54,7 +61,11 @@ export async function GET() {
                     hour12: true,
                     timeZone: "Asia/Manila",
                 }),
+                date_raw: toManilaDateString(a.appointment_timestart.toISOString()),
+                time_start: toManilaTimeString(a.appointment_timestart.toISOString()),
+                time_end: toManilaTimeString(a.appointment_timeend.toISOString()),
                 status: a.status,
+                service_type: a.service_type,
             };
         });
 
@@ -95,9 +106,16 @@ export async function POST(req: Request) {
         const appointment_timeend = buildManilaDate(date, time_end);
         const dayStart = startOfManilaDay(date);
         const dayEnd = endOfManilaDay(date);
+        const now = manilaNow();
 
         if (!(appointment_timestart < appointment_timeend))
             return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
+
+        if (appointment_timestart.getTime() - now.getTime() < MIN_BOOKING_LEAD_MS)
+            return NextResponse.json(
+                { message: "Appointments must be booked at least 3 days in advance" },
+                { status: 400 }
+            );
 
         // ✅ Check if within availability
         const availabilities = await prisma.doctorAvailability.findMany({
@@ -125,7 +143,9 @@ export async function POST(req: Request) {
             where: {
                 doctor_user_id,
                 appointment_timestart: { gte: dayStart, lte: dayEnd },
-                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+                status: {
+                    in: [AppointmentStatus.Pending, AppointmentStatus.Approved, AppointmentStatus.Moved],
+                },
             },
         });
 
@@ -161,6 +181,144 @@ export async function POST(req: Request) {
         });
     } catch (error) {
         console.error("[POST /api/patient/appointments]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function PUT(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+        const patient_user_id = session.user.id as string;
+        const body = await req.json();
+        const { appointment_id, date, time_start, time_end } = body || {};
+
+        if (!appointment_id || !date || !time_start || !time_end)
+            return NextResponse.json({ message: "Missing required fields" }, { status: 400 });
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== patient_user_id)
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+
+        if (appointment.status === AppointmentStatus.Cancelled)
+            return NextResponse.json(
+                { message: "Cancelled appointments cannot be rescheduled" },
+                { status: 400 }
+            );
+
+        const appointment_date = startOfManilaDay(date);
+        const appointment_timestart = buildManilaDate(date, time_start);
+        const appointment_timeend = buildManilaDate(date, time_end);
+        const dayStart = startOfManilaDay(date);
+        const dayEnd = endOfManilaDay(date);
+
+        if (!(appointment_timestart < appointment_timeend))
+            return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
+
+        const now = manilaNow();
+        if (appointment_timestart.getTime() - now.getTime() < MIN_BOOKING_LEAD_MS)
+            return NextResponse.json(
+                { message: "Appointments must be booked at least 3 days in advance" },
+                { status: 400 }
+            );
+
+        const availabilities = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                clinic_id: appointment.clinic_id,
+                available_date: { gte: dayStart, lte: dayEnd },
+            },
+        });
+
+        const withinAvailability = availabilities.some(
+            (av) =>
+                appointment_timestart >= av.available_timestart &&
+                appointment_timeend <= av.available_timeend
+        );
+
+        if (!withinAvailability)
+            return NextResponse.json(
+                { message: "Selected time is outside doctor's availability" },
+                { status: 400 }
+            );
+
+        const existing = await prisma.appointment.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: {
+                    in: [AppointmentStatus.Pending, AppointmentStatus.Approved, AppointmentStatus.Moved],
+                },
+                appointment_id: { not: appointment_id },
+            },
+        });
+
+        const conflict = existing.some((e) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                e.appointment_timestart,
+                e.appointment_timeend
+            )
+        );
+
+        if (conflict)
+            return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+
+        const updated = await prisma.appointment.update({
+            where: { appointment_id },
+            data: {
+                appointment_date,
+                appointment_timestart,
+                appointment_timeend,
+                status: AppointmentStatus.Moved,
+            },
+        });
+
+        return NextResponse.json({
+            appointment_id: updated.appointment_id,
+            status: updated.status,
+        });
+    } catch (error) {
+        console.error("[PUT /api/patient/appointments]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function DELETE(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+        const patient_user_id = session.user.id as string;
+        const body = await req.json();
+        const { appointment_id } = body || {};
+
+        if (!appointment_id)
+            return NextResponse.json({ message: "Missing appointment ID" }, { status: 400 });
+
+        const appointment = await prisma.appointment.findUnique({ where: { appointment_id } });
+
+        if (!appointment || appointment.patient_user_id !== patient_user_id)
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+
+        if (appointment.status === AppointmentStatus.Cancelled)
+            return NextResponse.json({ message: "Appointment already cancelled" }, { status: 200 });
+
+        await prisma.appointment.update({
+            where: { appointment_id },
+            data: { status: AppointmentStatus.Cancelled },
+        });
+
+        return NextResponse.json({ message: "Appointment cancelled" });
+    } catch (error) {
+        console.error("[DELETE /api/patient/appointments]", error);
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
     }
 }

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -75,8 +75,11 @@ export default function DoctorConsultationPage() {
     const [loading, setLoading] = useState(false);
     const [slots, setSlots] = useState<Availability[]>([]);
     const [clinics, setClinics] = useState<Clinic[]>([]);
+    const [doctorType, setDoctorType] = useState<"Physician" | "Dentist" | null>(null);
     const [formData, setFormData] = useState({
         clinic_id: "",
+        start_time: "",
+        end_time: "",
         available_date: "",
         available_timestart: "",
         available_timeend: "",
@@ -99,7 +102,10 @@ export default function DoctorConsultationPage() {
             const res = await fetch("/api/doctor/consultation", { cache: "no-store" });
             const data = await res.json();
             if (data.error) toast.error(data.error);
-            else setSlots(data);
+            else {
+                setSlots(data.slots ?? []);
+                setDoctorType(data.specialization ?? null);
+            }
         } catch {
             toast.error("Failed to load consultation slots");
         } finally {
@@ -124,20 +130,40 @@ export default function DoctorConsultationPage() {
 
     async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
-        if (
-            !formData.clinic_id ||
-            !formData.available_date ||
-            !formData.available_timestart ||
-            !formData.available_timeend
-        ) {
-            toast.error("All fields are required.");
+        if (!formData.clinic_id) {
+            toast.error("Clinic is required.");
             return;
         }
 
-        const body = editingSlot
-            ? { availability_id: editingSlot.availability_id, ...formData }
-            : formData;
-        const method = editingSlot ? "PUT" : "POST";
+        let body: Record<string, string> & { availability_id?: string } = {
+            clinic_id: formData.clinic_id,
+        };
+        let method: "POST" | "PUT" = "POST";
+
+        if (editingSlot) {
+            if (!formData.available_date || !formData.available_timestart || !formData.available_timeend) {
+                toast.error("Date and time are required.");
+                return;
+            }
+            body = {
+                availability_id: editingSlot.availability_id,
+                clinic_id: formData.clinic_id,
+                available_date: formData.available_date,
+                available_timestart: formData.available_timestart,
+                available_timeend: formData.available_timeend,
+            };
+            method = "PUT";
+        } else {
+            if (!formData.start_time || !formData.end_time) {
+                toast.error("Start and end time are required.");
+                return;
+            }
+            body = {
+                clinic_id: formData.clinic_id,
+                start_time: formData.start_time,
+                end_time: formData.end_time,
+            };
+        }
 
         try {
             setLoading(true);
@@ -154,6 +180,8 @@ export default function DoctorConsultationPage() {
                 setDialogOpen(false);
                 setFormData({
                     clinic_id: "",
+                    start_time: "",
+                    end_time: "",
                     available_date: "",
                     available_timestart: "",
                     available_timeend: "",
@@ -291,6 +319,8 @@ export default function DoctorConsultationPage() {
                                             setEditingSlot(null);
                                             setFormData({
                                                 clinic_id: "",
+                                                start_time: "",
+                                                end_time: "",
                                                 available_date: "",
                                                 available_timestart: "",
                                                 available_timeend: "",
@@ -303,9 +333,11 @@ export default function DoctorConsultationPage() {
 
                                 <DialogContent className="rounded-xl">
                                     <DialogHeader>
-                                        <DialogTitle>{editingSlot ? "Edit Consultation Slot" : "Add Consultation Slot"}</DialogTitle>
+                                        <DialogTitle>{editingSlot ? "Edit Consultation Slot" : "Set Weekly Duty Hours"}</DialogTitle>
                                         <DialogDescription>
-                                            {editingSlot ? "Modify your existing consultation slot." : "Add a new consultation slot."}
+                                            {editingSlot
+                                                ? "Modify your existing consultation slot."
+                                                : "Provide your daily duty window and we'll schedule the upcoming week for you."}
                                         </DialogDescription>
                                     </DialogHeader>
 
@@ -327,36 +359,82 @@ export default function DoctorConsultationPage() {
                                             </select>
                                         </div>
 
-                                        <div>
-                                            <Label>Date</Label>
-                                            <Input
-                                                type="date"
-                                                value={formData.available_date}
-                                                onChange={(e) => setFormData({ ...formData, available_date: e.target.value })}
-                                                required
-                                            />
-                                        </div>
-
-                                        <div className="grid grid-cols-2 gap-4">
-                                            <div>
-                                                <Label>Start Time</Label>
-                                                <Input
-                                                    type="time"
-                                                    value={formData.available_timestart}
-                                                    onChange={(e) => setFormData({ ...formData, available_timestart: e.target.value })}
-                                                    required
-                                                />
-                                            </div>
-                                            <div>
-                                                <Label>End Time</Label>
-                                                <Input
-                                                    type="time"
-                                                    value={formData.available_timeend}
-                                                    onChange={(e) => setFormData({ ...formData, available_timeend: e.target.value })}
-                                                    required
-                                                />
-                                            </div>
-                                        </div>
+                                        {!editingSlot ? (
+                                            <>
+                                                <p className="text-sm text-gray-600 bg-green-50 border border-green-100 rounded-md px-3 py-2">
+                                                    {doctorType === "Dentist"
+                                                        ? "Dentist schedules run Monday through Saturday."
+                                                        : doctorType === "Physician"
+                                                            ? "Physician schedules run Monday through Friday."
+                                                            : "Physicians run Monday–Friday, while dentists run Monday–Saturday."}
+                                                    {" "}We&rsquo;ll automatically plot the upcoming week based on the times you provide.
+                                                </p>
+                                                <div className="grid grid-cols-2 gap-4">
+                                                    <div>
+                                                        <Label>Start Time</Label>
+                                                        <Input
+                                                            type="time"
+                                                            value={formData.start_time}
+                                                            onChange={(e) => setFormData({ ...formData, start_time: e.target.value })}
+                                                            required
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label>End Time</Label>
+                                                        <Input
+                                                            type="time"
+                                                            value={formData.end_time}
+                                                            onChange={(e) => setFormData({ ...formData, end_time: e.target.value })}
+                                                            required
+                                                        />
+                                                    </div>
+                                                </div>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <div>
+                                                    <Label>Date</Label>
+                                                    <Input
+                                                        type="date"
+                                                        value={formData.available_date}
+                                                        onChange={(e) =>
+                                                            setFormData({ ...formData, available_date: e.target.value })
+                                                        }
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="grid grid-cols-2 gap-4">
+                                                    <div>
+                                                        <Label>Start Time</Label>
+                                                        <Input
+                                                            type="time"
+                                                            value={formData.available_timestart}
+                                                            onChange={(e) =>
+                                                                setFormData({
+                                                                    ...formData,
+                                                                    available_timestart: e.target.value,
+                                                                })
+                                                            }
+                                                            required
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label>End Time</Label>
+                                                        <Input
+                                                            type="time"
+                                                            value={formData.available_timeend}
+                                                            onChange={(e) =>
+                                                                setFormData({
+                                                                    ...formData,
+                                                                    available_timeend: e.target.value,
+                                                                })
+                                                            }
+                                                            required
+                                                        />
+                                                    </div>
+                                                </div>
+                                            </>
+                                        )}
 
                                         <DialogFooter>
                                             <Button type="submit" disabled={loading} className="bg-green-600 hover:bg-green-700 text-white">


### PR DESCRIPTION
## Summary
- generate physician and dentist duty hours for the upcoming week based on a single start/end time entry
- restrict patients to booking appointments at least three days ahead and expose reschedule and cancel actions
- extend availability and appointment APIs to support weekly plotting, patient-owned updates, and richer metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f0f09da7688333904a6401183268dc