### PR TITLE
Automate weekly duty creation and enhance patient appointment workflows

### DIFF
--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -2,8 +2,40 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { Role, Prisma } from "@prisma/client";
-import { buildManilaDate, startOfManilaDay } from "@/lib/time";
+import { Role, Prisma, DoctorSpecialization } from "@prisma/client";
+import { buildManilaDate, endOfManilaDay, manilaNow, startOfManilaDay } from "@/lib/time";
+
+const MANILA_WEEKDAY_MAP: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+};
+
+function getManilaWeekday(date: Date): number {
+    const weekday = new Intl.DateTimeFormat("en-US", {
+        timeZone: "Asia/Manila",
+        weekday: "short",
+    }).format(date);
+    return MANILA_WEEKDAY_MAP[weekday];
+}
+
+function addUtcDays(date: Date, days: number) {
+    const clone = new Date(date.getTime());
+    clone.setUTCDate(clone.getUTCDate() + days);
+    return clone;
+}
+
+function formatManilaDate(date: Date): string {
+    return date.toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+}
+
+type AvailabilityWithClinic = Prisma.DoctorAvailabilityGetPayload<{
+    include: { clinic: { select: { clinic_id: true; clinic_name: true } } };
+}>;
 
 /**
  * ✅ GET — Fetch all consultation slots for logged-in doctor
@@ -59,21 +91,10 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { clinic_id, available_date, available_timestart, available_timeend } =
-            await req.json();
+        const { clinic_id, available_timestart, available_timeend } = await req.json();
 
-        if (!clinic_id || !available_date || !available_timestart || !available_timeend) {
+        if (!clinic_id || !available_timestart || !available_timeend) {
             return NextResponse.json({ error: "All fields are required" }, { status: 400 });
-        }
-
-        const start = buildManilaDate(available_date, available_timestart);
-        const end = buildManilaDate(available_date, available_timeend);
-
-        if (end <= start) {
-            return NextResponse.json(
-                { error: "End time must be after start time" },
-                { status: 400 }
-            );
         }
 
         const clinic = await prisma.clinic.findUnique({ where: { clinic_id } });
@@ -81,20 +102,76 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Clinic not found" }, { status: 404 });
         }
 
-        const newSlot = await prisma.doctorAvailability.create({
-            data: {
-                doctor_user_id: doctor.user_id,
-                clinic_id,
-                available_date: startOfManilaDay(available_date),
-                available_timestart: start,
-                available_timeend: end,
-            },
-            include: {
-                clinic: { select: { clinic_id: true, clinic_name: true } },
-            },
+        const now = manilaNow();
+        const currentWeekday = getManilaWeekday(now);
+        const daysUntilMonday = (1 - currentWeekday + 7) % 7;
+        const monday = addUtcDays(now, daysUntilMonday);
+        const scheduleLength =
+            doctor.specialization === DoctorSpecialization.Dentist ? 6 : 5;
+
+        const scheduleDates: string[] = [];
+        for (let i = 0; i < scheduleLength; i++) {
+            const day = addUtcDays(monday, i);
+            scheduleDates.push(formatManilaDate(day));
+        }
+
+        const firstDate = scheduleDates[0];
+        const lastDate = scheduleDates[scheduleDates.length - 1];
+        const sampleStart = buildManilaDate(firstDate, available_timestart);
+        const sampleEnd = buildManilaDate(firstDate, available_timeend);
+
+        if (sampleEnd <= sampleStart) {
+            return NextResponse.json(
+                { error: "End time must be after start time" },
+                { status: 400 }
+            );
+        }
+
+        const results = await prisma.$transaction(async (tx) => {
+            await tx.doctorAvailability.deleteMany({
+                where: {
+                    doctor_user_id: doctor.user_id,
+                    clinic_id,
+                    available_date: {
+                        gte: startOfManilaDay(firstDate),
+                        lte: endOfManilaDay(lastDate),
+                    },
+                },
+            });
+
+            const created: AvailabilityWithClinic[] = [];
+
+            for (const date of scheduleDates) {
+                const dayStart = startOfManilaDay(date);
+                const start = buildManilaDate(date, available_timestart);
+                const end = buildManilaDate(date, available_timeend);
+
+                const slot = await tx.doctorAvailability.create({
+                    data: {
+                        doctor_user_id: doctor.user_id,
+                        clinic_id,
+                        available_date: dayStart,
+                        available_timestart: start,
+                        available_timeend: end,
+                    },
+                    include: {
+                        clinic: { select: { clinic_id: true, clinic_name: true } },
+                    },
+                });
+
+                created.push(slot);
+            }
+
+            return created;
         });
 
-        return NextResponse.json(newSlot);
+        return NextResponse.json({
+            message:
+                doctor.specialization === DoctorSpecialization.Dentist
+                    ? "Duty hours generated from Monday to Saturday"
+                    : "Duty hours generated from Monday to Friday",
+            slots: results,
+        });
     } catch (err) {
         console.error("[POST /api/doctor/consultation]", err);
         return NextResponse.json(

--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -7,6 +7,7 @@ import {
     buildManilaDate,
     startOfManilaDay,
     endOfManilaDay,
+    manilaNow,
 } from "@/lib/time";
 import { AppointmentStatus, Role, ServiceType } from "@prisma/client";
 
@@ -33,6 +34,20 @@ export async function GET() {
             orderBy: { appointment_timestart: "asc" },
         });
 
+        const timeFormatter = new Intl.DateTimeFormat("en-GB", {
+            timeZone: "Asia/Manila",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+        });
+
+        const displayFormatter = new Intl.DateTimeFormat("en-US", {
+            timeZone: "Asia/Manila",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: true,
+        });
+
         const formatted = appointments.map((a) => {
             const doctorName =
                 a.doctor?.employee?.fname && a.doctor?.employee?.lname
@@ -41,19 +56,23 @@ export async function GET() {
                         ? `${a.doctor.student.fname} ${a.doctor.student.lname}`
                         : a.doctor?.username ?? "-";
 
+            const startTime = timeFormatter.format(a.appointment_timestart);
+            const endTime = timeFormatter.format(a.appointment_timeend);
+
             return {
                 id: a.appointment_id,
                 clinic: a.clinic?.clinic_name ?? "-",
+                clinic_id: a.clinic_id,
                 doctor: doctorName,
+                doctor_user_id: a.doctor_user_id,
                 date: new Date(a.appointment_timestart).toLocaleDateString("en-CA", {
                     timeZone: "Asia/Manila",
                 }),
-                time: new Date(a.appointment_timestart).toLocaleTimeString("en-US", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    hour12: true,
-                    timeZone: "Asia/Manila",
-                }),
+                time: `${displayFormatter.format(a.appointment_timestart)} - ${displayFormatter.format(
+                    a.appointment_timeend,
+                )}`,
+                timeStart: startTime,
+                timeEnd: endTime,
                 status: a.status,
             };
         });
@@ -95,6 +114,20 @@ export async function POST(req: Request) {
         const appointment_timeend = buildManilaDate(date, time_end);
         const dayStart = startOfManilaDay(date);
         const dayEnd = endOfManilaDay(date);
+        const now = manilaNow();
+        const minimumLeadMs = 3 * 24 * 60 * 60 * 1000;
+
+        if (appointment_timestart <= now)
+            return NextResponse.json(
+                { message: "Appointment must be scheduled in the future" },
+                { status: 400 }
+            );
+
+        if (appointment_timestart.getTime() - now.getTime() < minimumLeadMs)
+            return NextResponse.json(
+                { message: "Appointments must be booked at least 3 days in advance" },
+                { status: 400 }
+            );
 
         if (!(appointment_timestart < appointment_timeend))
             return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
@@ -161,6 +194,167 @@ export async function POST(req: Request) {
         });
     } catch (error) {
         console.error("[POST /api/patient/appointments]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function PUT(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+        const patient_user_id = session.user.id as string;
+        const body = await req.json();
+        const { appointment_id, date, time_start, time_end } = body || {};
+
+        if (!appointment_id || !date || !time_start || !time_end)
+            return NextResponse.json({ message: "Missing required fields" }, { status: 400 });
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== patient_user_id)
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+
+        if (
+            ![
+                AppointmentStatus.Pending,
+                AppointmentStatus.Approved,
+                AppointmentStatus.Moved,
+            ].includes(appointment.status)
+        ) {
+            return NextResponse.json(
+                { message: "Only pending or approved appointments can be rescheduled" },
+                { status: 400 }
+            );
+        }
+
+        const appointment_date = startOfManilaDay(date);
+        const appointment_timestart = buildManilaDate(date, time_start);
+        const appointment_timeend = buildManilaDate(date, time_end);
+        const dayStart = startOfManilaDay(date);
+        const dayEnd = endOfManilaDay(date);
+        const now = manilaNow();
+        const minimumLeadMs = 3 * 24 * 60 * 60 * 1000;
+
+        if (!(appointment_timestart < appointment_timeend))
+            return NextResponse.json({ message: "Invalid time range" }, { status: 400 });
+
+        if (appointment_timestart <= now)
+            return NextResponse.json(
+                { message: "Appointment must be scheduled in the future" },
+                { status: 400 }
+            );
+
+        if (appointment_timestart.getTime() - now.getTime() < minimumLeadMs)
+            return NextResponse.json(
+                { message: "Appointments must be booked at least 3 days in advance" },
+                { status: 400 }
+            );
+
+        const availabilities = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                clinic_id: appointment.clinic_id,
+                available_date: { gte: dayStart, lte: dayEnd },
+            },
+        });
+
+        const withinAvailability = availabilities.some(
+            (av) =>
+                appointment_timestart >= av.available_timestart &&
+                appointment_timeend <= av.available_timeend,
+        );
+
+        if (!withinAvailability)
+            return NextResponse.json(
+                { message: "Selected time is outside doctor's availability" },
+                { status: 400 }
+            );
+
+        const existing = await prisma.appointment.findMany({
+            where: {
+                doctor_user_id: appointment.doctor_user_id,
+                appointment_timestart: { gte: dayStart, lte: dayEnd },
+                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
+                NOT: { appointment_id },
+            },
+        });
+
+        const conflict = existing.some((e) =>
+            rangesOverlap(
+                appointment_timestart,
+                appointment_timeend,
+                e.appointment_timestart,
+                e.appointment_timeend,
+            ),
+        );
+
+        if (conflict)
+            return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+
+        const updated = await prisma.appointment.update({
+            where: { appointment_id },
+            data: {
+                appointment_date,
+                appointment_timestart,
+                appointment_timeend,
+                status: AppointmentStatus.Moved,
+            },
+        });
+
+        return NextResponse.json({
+            appointment_id: updated.appointment_id,
+            status: updated.status,
+        });
+    } catch (error) {
+        console.error("[PUT /api/patient/appointments]", error);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export async function DELETE(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id)
+            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+
+        const patient_user_id = session.user.id as string;
+        const body = await req.json();
+        const { appointment_id } = body || {};
+
+        if (!appointment_id)
+            return NextResponse.json({ message: "Missing appointment id" }, { status: 400 });
+
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id },
+        });
+
+        if (!appointment || appointment.patient_user_id !== patient_user_id)
+            return NextResponse.json({ message: "Appointment not found" }, { status: 404 });
+
+        if (appointment.status === AppointmentStatus.Completed)
+            return NextResponse.json(
+                { message: "Completed appointments cannot be cancelled" },
+                { status: 400 }
+            );
+
+        if (appointment.status === AppointmentStatus.Cancelled)
+            return NextResponse.json(
+                { message: "Appointment is already cancelled" },
+                { status: 400 }
+            );
+
+        await prisma.appointment.update({
+            where: { appointment_id },
+            data: { status: AppointmentStatus.Cancelled },
+        });
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("[DELETE /api/patient/appointments]", error);
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
     }
 }


### PR DESCRIPTION
## Summary
- generate weekly duty availability blocks for doctors based on specialization, eliminating manual per-day entry
- enforce a three-day lead time on patient bookings and expose endpoints for rescheduling or cancelling appointments
- refresh doctor and patient dashboards to surface the new scheduling flow, reschedule dialog, and action controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f0f09da7688333904a6401183268dc