### PR TITLE
Add patient notification page and email alerts for moved appointments

### DIFF
--- a/src/app/api/doctor/appointments/[id]/route.ts
+++ b/src/app/api/doctor/appointments/[id]/route.ts
@@ -2,7 +2,69 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import type { AppointmentStatus } from "@prisma/client";
+import { AppointmentStatus } from "@prisma/client";
+import {
+    buildManilaDate,
+    endOfManilaDay,
+    formatManilaDateTime,
+    formatManilaISODate,
+    manilaNow,
+    rangesOverlap,
+    startOfManilaDay,
+} from "@/lib/time";
+import { sendEmail } from "@/lib/email";
+
+function escapeHtml(input: string) {
+    return input
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function formatPatientName(patient: {
+    username: string;
+    student: { fname: string | null; lname: string | null } | null;
+    employee: { fname: string | null; lname: string | null } | null;
+}) {
+    if (patient.student?.fname && patient.student?.lname) {
+        return `${patient.student.fname} ${patient.student.lname}`;
+    }
+    if (patient.employee?.fname && patient.employee?.lname) {
+        return `${patient.employee.fname} ${patient.employee.lname}`;
+    }
+    return patient.username;
+}
+
+function shapeResponse(appointment: {
+    appointment_id: string;
+    appointment_timestart: Date;
+    status: AppointmentStatus;
+    clinic: { clinic_name: string };
+    patient: {
+        username: string;
+        student: { fname: string | null; lname: string | null } | null;
+        employee: { fname: string | null; lname: string | null } | null;
+    };
+}) {
+    const patientName = formatPatientName(appointment.patient);
+    const time = new Date(appointment.appointment_timestart).toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+        timeZone: "Asia/Manila",
+    });
+
+    return {
+        id: appointment.appointment_id,
+        patientName,
+        clinic: appointment.clinic.clinic_name,
+        date: formatManilaISODate(appointment.appointment_timestart),
+        time,
+        status: appointment.status,
+    };
+}
 
 // ✅ Use Promise in context parameter (Next.js 14+ correct typing)
 export async function PATCH(
@@ -18,28 +80,25 @@ export async function PATCH(
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
-        const { action } = await request.json();
+        const body = (await request.json()) as Record<string, unknown>;
+        const action = typeof body.action === "string" ? body.action : null;
 
-        // ✅ Map frontend actions to Prisma enum
-        let newStatus: AppointmentStatus;
-        switch (action) {
-            case "approve":
-                newStatus = "Approved";
-                break;
-            case "cancel":
-                newStatus = "Cancelled";
-                break;
-            case "complete":
-                newStatus = "Completed";
-                break;
-            default:
-                return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+        if (!action) {
+            return NextResponse.json({ error: "Invalid action" }, { status: 400 });
         }
 
         const appointment = await prisma.appointment.findUnique({
             where: { appointment_id: id },
             include: {
                 consultation: { select: { consultation_id: true } },
+                patient: {
+                    select: {
+                        username: true,
+                        student: { select: { fname: true, lname: true, email: true } },
+                        employee: { select: { fname: true, lname: true, email: true } },
+                    },
+                },
+                clinic: { select: { clinic_name: true } },
             },
         });
 
@@ -51,11 +110,187 @@ export async function PATCH(
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
+        if (action === "move") {
+            const { reason, newDate, newTimeStart, newTimeEnd } = body;
+
+            if (
+                typeof reason !== "string" ||
+                typeof newDate !== "string" ||
+                typeof newTimeStart !== "string" ||
+                typeof newTimeEnd !== "string"
+            ) {
+                return NextResponse.json({ error: "Missing move details" }, { status: 400 });
+            }
+
+            const trimmedReason = reason.trim();
+            if (!trimmedReason || !newDate || !newTimeStart || !newTimeEnd) {
+                return NextResponse.json({ error: "Incomplete move details" }, { status: 400 });
+            }
+
+            const appointmentDate = startOfManilaDay(newDate);
+            const appointmentStart = buildManilaDate(newDate, newTimeStart);
+            const appointmentEnd = buildManilaDate(newDate, newTimeEnd);
+
+            if (!(appointmentStart < appointmentEnd)) {
+                return NextResponse.json({ error: "Invalid time range" }, { status: 400 });
+            }
+
+            const now = manilaNow();
+            if (appointmentStart <= now) {
+                return NextResponse.json(
+                    { error: "Cannot move to a past schedule" },
+                    { status: 400 }
+                );
+            }
+
+            const dayStart = startOfManilaDay(newDate);
+            const dayEnd = endOfManilaDay(newDate);
+
+            const availabilities = await prisma.doctorAvailability.findMany({
+                where: {
+                    doctor_user_id: appointment.doctor_user_id,
+                    clinic_id: appointment.clinic_id,
+                    available_date: { gte: dayStart, lte: dayEnd },
+                },
+            });
+
+            const withinAvailability = availabilities.some(
+                (availability) =>
+                    appointmentStart >= availability.available_timestart &&
+                    appointmentEnd <= availability.available_timeend
+            );
+
+            if (!withinAvailability) {
+                return NextResponse.json(
+                    { error: "Selected time is outside doctor's availability" },
+                    { status: 400 }
+                );
+            }
+
+            const overlapping = await prisma.appointment.findMany({
+                where: {
+                    doctor_user_id: appointment.doctor_user_id,
+                    appointment_timestart: { gte: dayStart, lte: dayEnd },
+                    status: {
+                        in: [
+                            AppointmentStatus.Pending,
+                            AppointmentStatus.Approved,
+                            AppointmentStatus.Moved,
+                        ],
+                    },
+                    appointment_id: { not: appointment.appointment_id },
+                },
+            });
+
+            const hasConflict = overlapping.some((entry) =>
+                rangesOverlap(
+                    appointmentStart,
+                    appointmentEnd,
+                    entry.appointment_timestart,
+                    entry.appointment_timeend
+                )
+            );
+
+            if (hasConflict) {
+                return NextResponse.json(
+                    { error: "Time slot already booked" },
+                    { status: 409 }
+                );
+            }
+
+            const updated = await prisma.appointment.update({
+                where: { appointment_id: id },
+                data: {
+                    appointment_date: appointmentDate,
+                    appointment_timestart: appointmentStart,
+                    appointment_timeend: appointmentEnd,
+                    status: AppointmentStatus.Moved,
+                    remarks: trimmedReason,
+                },
+                include: {
+                    patient: {
+                        select: {
+                            username: true,
+                            student: { select: { fname: true, lname: true, email: true } },
+                            employee: { select: { fname: true, lname: true, email: true } },
+                        },
+                    },
+                    clinic: { select: { clinic_name: true } },
+                },
+            });
+
+            const patientName = formatPatientName(updated.patient);
+            const patientEmail =
+                appointment.patient.student?.email ||
+                appointment.patient.employee?.email ||
+                (appointment.patient.username.includes("@")
+                    ? appointment.patient.username
+                    : "");
+
+            if (patientEmail) {
+                const oldSchedule = formatManilaDateTime(appointment.appointment_timestart);
+                const newSchedule = formatManilaDateTime(updated.appointment_timestart);
+                const html = `
+                    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f0fdf4; padding: 24px; border-radius: 16px; border: 1px solid #bbf7d0; color: #065f46;">
+                        <h2 style="margin-top: 0; color: #047857;">Appointment Update</h2>
+                        <p>Hello <strong>${escapeHtml(patientName)}</strong>,</p>
+                        <p>Your appointment at <strong>${escapeHtml(updated.clinic.clinic_name)}</strong> has been moved by your doctor.</p>
+                        <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+                            <tbody>
+                                <tr>
+                                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">Previous Schedule</td>
+                                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${escapeHtml(oldSchedule)}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">New Schedule</td>
+                                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${escapeHtml(newSchedule)}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">Doctor's Note</td>
+                                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${escapeHtml(trimmedReason)}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <p>Please log in to your patient portal if you need to reschedule again or have any questions.</p>
+                        <p style="margin-bottom: 0;">Thank you,<br/>HNU Clinic</p>
+                    </div>
+                `;
+
+                try {
+                    await sendEmail({
+                        to: patientEmail,
+                        subject: "Your appointment has been moved",
+                        html,
+                    });
+                } catch (emailErr) {
+                    console.error("[PATCH /api/doctor/appointments/:id] email error", emailErr);
+                }
+            }
+
+            return NextResponse.json(shapeResponse(updated));
+        }
+
         if (action === "complete" && !appointment.consultation) {
             return NextResponse.json(
                 { error: "Record the consultation before completing the appointment" },
                 { status: 400 }
             );
+        }
+
+        // ✅ Map frontend actions to Prisma enum
+        let newStatus: AppointmentStatus;
+        switch (action) {
+            case "approve":
+                newStatus = AppointmentStatus.Approved;
+                break;
+            case "cancel":
+                newStatus = AppointmentStatus.Cancelled;
+                break;
+            case "complete":
+                newStatus = AppointmentStatus.Completed;
+                break;
+            default:
+                return NextResponse.json({ error: "Invalid action" }, { status: 400 });
         }
 
         // ✅ Update appointment and include relations
@@ -74,25 +309,7 @@ export async function PATCH(
             },
         });
 
-        // ✅ Format for frontend
-        const patientName =
-            updated.patient.student?.fname && updated.patient.student?.lname
-                ? `${updated.patient.student.fname} ${updated.patient.student.lname}`
-                : updated.patient.employee?.fname && updated.patient.employee?.lname
-                    ? `${updated.patient.employee.fname} ${updated.patient.employee.lname}`
-                    : updated.patient.username;
-
-        return NextResponse.json({
-            id: updated.appointment_id,
-            patientName,
-            clinic: updated.clinic.clinic_name,
-            date: updated.appointment_date.toISOString().split("T")[0],
-            time: new Date(updated.appointment_timestart).toLocaleTimeString([], {
-                hour: "2-digit",
-                minute: "2-digit",
-            }),
-            status: updated.status,
-        });
+        return NextResponse.json(shapeResponse(updated));
     } catch (error) {
         console.error("[PATCH /api/doctor/appointments/:id]", error);
         return NextResponse.json({ error: "Server error" }, { status: 500 });

--- a/src/app/patient/account/page.tsx
+++ b/src/app/patient/account/page.tsx
@@ -356,7 +356,7 @@ export default function PatientAccountPage() {
                         <CalendarDays className="h-5 w-5" />
                         Appointments
                     </Link>
-                    <Link href="/patient/notifications" className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
+                    <Link href="/patient/notification" className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
                         <Bell className="h-5 w-5" />
                         Notifications
                     </Link>
@@ -408,7 +408,7 @@ export default function PatientAccountPage() {
                                 <DropdownMenuItem asChild><Link href="/patient">Dashboard</Link></DropdownMenuItem>
                                 <DropdownMenuItem asChild><Link href="/patient/account">Account</Link></DropdownMenuItem>
                                 <DropdownMenuItem asChild><Link href="/patient/appointments">Appointments</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/patient/notifications">Notifications</Link></DropdownMenuItem>
+                                <DropdownMenuItem asChild><Link href="/patient/notification">Notifications</Link></DropdownMenuItem>
                                 <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>Logout</DropdownMenuItem>
                             </DropdownMenuContent>
                         </DropdownMenu>

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -459,7 +459,7 @@ export default function PatientAppointmentsPage() {
                         <CalendarDays className="h-5 w-5" />
                         Appointments
                     </Link>
-                    <Link href="/patient/notifications" className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
+                    <Link href="/patient/notification" className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
                         <Bell className="h-5 w-5" />
                         Notifications
                     </Link>
@@ -500,7 +500,7 @@ export default function PatientAppointmentsPage() {
                                 <DropdownMenuItem asChild><Link href="/patient">Dashboard</Link></DropdownMenuItem>
                                 <DropdownMenuItem asChild><Link href="/patient/account">Account</Link></DropdownMenuItem>
                                 <DropdownMenuItem asChild><Link href="/patient/appointments">Appointments</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/patient/notifications">Notifications</Link></DropdownMenuItem>
+                                <DropdownMenuItem asChild><Link href="/patient/notification">Notifications</Link></DropdownMenuItem>
                                 <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>
                                     Logout
                                 </DropdownMenuItem>

--- a/src/app/patient/notification/page.tsx
+++ b/src/app/patient/notification/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { signOut, useSession } from "next-auth/react";
+import {
+    Bell,
+    CalendarCheck,
+    CalendarDays,
+    Home,
+    Info,
+    Loader2,
+    Mail,
+    Menu,
+    User,
+    X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+
+const notificationHighlights = [
+    {
+        icon: Mail,
+        title: "Email Alerts",
+        description:
+            "We will send an email every time a doctor moves your appointment so you have a written record of the new schedule.",
+    },
+    {
+        icon: CalendarCheck,
+        title: "Portal Reminders",
+        description:
+            "Review upcoming visits from the patient portal. Double-check the rescheduled date, time, and clinic in one glance.",
+    },
+    {
+        icon: Info,
+        title: "Doctor Notes",
+        description:
+            "Moved appointments include a short note from the doctor explaining the change, helping you prepare ahead of time.",
+    },
+];
+
+const followUpTips = [
+    "Confirm that the new schedule fits your availability and plan to arrive 10 minutes early.",
+    "Update personal reminders on your phone or calendar with the revised appointment details.",
+    "Contact the clinic if you need additional adjustments or medical assistance before your visit.",
+];
+
+export default function PatientNotificationPage() {
+    const { data: session } = useSession();
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
+
+    const fullName = session?.user?.name ?? "Patient";
+
+    async function handleLogout() {
+        try {
+            setIsLoggingOut(true);
+            await signOut({ callbackUrl: "/login?logout=success" });
+        } finally {
+            setIsLoggingOut(false);
+        }
+    }
+
+    return (
+        <div className="flex min-h-screen bg-green-50">
+            {/* Sidebar */}
+            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
+                <div className="flex items-center mb-12">
+                    <Image
+                        src="/clinic-illustration.svg"
+                        alt="clinic-logo"
+                        width={40}
+                        height={40}
+                        className="object-contain drop-shadow-sm"
+                    />
+                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">HNU Clinic</h1>
+                </div>
+
+                <nav className="flex flex-col gap-2 text-gray-700">
+                    <Link
+                        href="/patient"
+                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
+                    >
+                        <Home className="h-5 w-5" /> Dashboard
+                    </Link>
+                    <Link
+                        href="/patient/account"
+                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
+                    >
+                        <User className="h-5 w-5" /> Account
+                    </Link>
+                    <Link
+                        href="/patient/appointments"
+                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
+                    >
+                        <CalendarDays className="h-5 w-5" /> Appointments
+                    </Link>
+                    <Link
+                        href="/patient/notification"
+                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
+                    >
+                        <Bell className="h-5 w-5" /> Notifications
+                    </Link>
+                </nav>
+
+                <Separator className="my-8" />
+
+                <Button
+                    variant="default"
+                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
+                    onClick={handleLogout}
+                    disabled={isLoggingOut}
+                >
+                    {isLoggingOut ? (
+                        <>
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Logging out...
+                        </>
+                    ) : (
+                        "Logout"
+                    )}
+                </Button>
+            </aside>
+
+            {/* Main */}
+            <main className="flex-1 flex flex-col">
+                <header className="w-full bg-white shadow px-6 py-4 flex items-center justify-between sticky top-0 z-40">
+                    <h2 className="text-xl font-bold text-green-600">Notification Center</h2>
+                    <div className="md:hidden">
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" size="sm" onClick={() => setMenuOpen(prev => !prev)}>
+                                    {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem asChild>
+                                    <Link href="/patient">Dashboard</Link>
+                                </DropdownMenuItem>
+                                <DropdownMenuItem asChild>
+                                    <Link href="/patient/account">Account</Link>
+                                </DropdownMenuItem>
+                                <DropdownMenuItem asChild>
+                                    <Link href="/patient/appointments">Appointments</Link>
+                                </DropdownMenuItem>
+                                <DropdownMenuItem asChild>
+                                    <Link href="/patient/notification">Notifications</Link>
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>
+                                    Logout
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                </header>
+
+                <section className="px-6 py-10 bg-white shadow-sm">
+                    <div className="max-w-4xl mx-auto text-center">
+                        <h2 className="text-2xl md:text-3xl font-bold text-green-600">Stay Informed, Stay Prepared</h2>
+                        <p className="text-gray-700 mt-3 leading-relaxed">
+                            Hello <span className="font-semibold">{fullName}</span>! Each time your doctor moves an appointment,
+                            we notify you through email and highlight the change here in the portal. Keep an eye on this
+                            page for quick summaries and helpful tips after every update.
+                        </p>
+                    </div>
+                </section>
+
+                <section className="px-6 py-12 bg-green-50">
+                    <div className="grid gap-6 md:grid-cols-3 max-w-6xl mx-auto">
+                        {notificationHighlights.map(({ icon: Icon, title, description }) => (
+                            <Card key={title} className="shadow-lg rounded-2xl border-green-100">
+                                <CardHeader>
+                                    <CardTitle className="flex items-center gap-2 text-green-600">
+                                        <Icon className="w-6 h-6" /> {title}
+                                    </CardTitle>
+                                </CardHeader>
+                                <CardContent>
+                                    <p className="text-gray-700 text-sm leading-relaxed">{description}</p>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="px-6 py-12 bg-white">
+                    <div className="max-w-3xl mx-auto">
+                        <Card className="shadow-lg rounded-2xl">
+                            <CardHeader>
+                                <CardTitle className="flex items-center gap-2 text-green-600">
+                                    <Bell className="w-6 h-6" /> After You Receive a Notification
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <ul className="list-disc list-inside text-gray-700 space-y-3">
+                                    {followUpTips.map(tip => (
+                                        <li key={tip}>{tip}</li>
+                                    ))}
+                                </ul>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </section>
+
+                <footer className="bg-white py-6 text-center text-gray-600 mt-auto text-sm sm:text-base">
+                    © {new Date().getFullYear()} HNU Clinic – Patient Notifications
+                </footer>
+            </main>
+        </div>
+    );
+}

--- a/src/app/patient/page.tsx
+++ b/src/app/patient/page.tsx
@@ -77,7 +77,7 @@ export default function PatientDashboardPage() {
                         <CalendarDays className="h-5 w-5" />
                         Appointments
                     </Link>
-                    <Link href="/patient/notifications" className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
+                    <Link href="/patient/notification" className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
                         <Bell className="h-5 w-5" />
                         Notifications
                     </Link>
@@ -129,7 +129,7 @@ export default function PatientDashboardPage() {
                                     <Link href="/patient/appointments">Appointments</Link>
                                 </DropdownMenuItem>
                                 <DropdownMenuItem asChild>
-                                    <Link href="/patient/notifications">Notifications</Link>
+                                    <Link href="/patient/notification">Notifications</Link>
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
                                     onClick={() => signOut({ callbackUrl: "/login?logout=success" })}


### PR DESCRIPTION
## Summary
- validate doctor-driven appointment moves, update schedules, and notify patients by email
- return timezone-aware appointment data when actions modify status
- add a patient notification page and update navigation links to point to it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f1029c9578833391cdad7e254f3e94