### PR TITLE
Align doctor panel with patient layout

### DIFF
--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -1,41 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { signOut } from "next-auth/react";
-import Link from "next/link";
 import { toast } from "sonner";
-import {
-    Menu,
-    X,
-    Home,
-    User,
-    Loader2,
-    Cog,
-    Eye,
-    EyeOff,
-    CalendarDays,
-    ClipboardList,
-    Clock4,
-    Pill,
-    FileText,
-} from "lucide-react";
+import { Cog, Eye, EyeOff, Loader2 } from "lucide-react";
 
+import DoctorLayout from "@/components/patient/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-    Card,
-    CardHeader,
-    CardTitle,
-    CardContent,
-} from "@/components/ui/card";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
     Dialog,
     DialogContent,
@@ -45,7 +18,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
-
 import {
     AlertDialog,
     AlertDialogAction,
@@ -56,7 +28,6 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-
 import {
     Select,
     SelectContent,
@@ -64,8 +35,6 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
-
-import Image from "next/image";
 
 type Profile = {
     user_id: string;
@@ -107,13 +76,9 @@ export default function DoctorAccountPage() {
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(false);
 
-    const [menuOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
-
     const [showCurrent, setShowCurrent] = useState(false);
     const [showNew, setShowNew] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
-
     const [passwordLoading, setPasswordLoading] = useState(false);
     const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
     const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
@@ -222,565 +187,449 @@ export default function DoctorAccountPage() {
         }
     }
 
-
-    // 🔹 Logout
-    async function handleLogout() {
-        try {
-            setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
-        } finally {
-            setIsLoggingOut(false);
-        }
-    }
-
     const bloodTypeOptions = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
 
     return (
-        <div className="flex flex-col md:flex-row min-h-screen bg-green-50">
-            {/* Sidebar */}
-            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
-                {/* Logo Section */}
-                <div className="flex items-center mb-12">
-                    <Image
-                        src="/clinic-illustration.svg"
-                        alt="clinic-logo"
-                        width={40}
-                        height={40}
-                        className="object-contain drop-shadow-sm"
-                    />
-                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">
-                        HNU Clinic
-                    </h1>
-                </div>
-                <nav className="flex flex-col gap-2 text-gray-700">
-                    <Link
-                        href="/doctor"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Home className="h-5 w-5" /> Dashboard
-                    </Link>
-                    <Link
-                        href="/doctor/account"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
-                    >
-                        <User className="h-5 w-5" /> Account
-                    </Link>
-                    <Link
-                        href="/doctor/consultation"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Clock4 className="h-5 w-5" /> Consultation
-                    </Link>
-                    <Link
-                        href="/doctor/appointments"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <CalendarDays className="h-5 w-5" /> Appointments
-                    </Link>
-                    <Link
-                        href="/doctor/dispense"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Pill className="h-5 w-5" /> Dispense
-                    </Link>
-                    <Link
-                        href="/doctor/patients"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <ClipboardList className="h-5 w-5" /> Patients
-                    </Link>
-                    <Link
-                        href="/doctor/certificates"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
-                        <FileText className="h-5 w-5" /> MedCerts
-                    </Link>
-                </nav>
-                <Separator className="my-8" />
-                <Button
-                    variant="default"
-                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                >
-                    {isLoggingOut ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Logging out...
-                        </>
-                    ) : (
-                        "Logout"
-                    )}
-                </Button>
-            </aside>
+        <DoctorLayout
+            title="Account Management"
+            description="Manage your professional profile, update credentials, and keep emergency information accurate."
+        >
+            <section className="px-4 sm:px-6 py-6 sm:py-8 space-y-10 w-full max-w-4xl mx-auto">
+                                {/* My Account */}
+                                {profile && (
+                                    <Card className="rounded-2xl shadow-lg hover:shadow-xl transition mb-10">
+                                        <CardHeader className="border-b flex items-center justify-between flex-wrap gap-3">
+                                            <CardTitle className="text-xl sm:text-2xl font-bold text-green-600">My Account</CardTitle>
 
-            {/* Main Content */}
-            <main className="flex-1 flex flex-col">
-                {/* Header */}
-                <header className="w-full bg-white shadow px-6 py-4 flex items-center justify-between sticky top-0 z-40">
-                    <h2 className="text-lg sm:text-xl font-bold text-green-600">Account Management</h2>
-                    {/* Mobile Menu */}
-                    <div className="md:hidden">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm">
-                                    {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                <DropdownMenuItem asChild><Link href="/doctor">Dashboard</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/account">Account</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/consultation">Consultation</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/appointments">Appointments</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/dispense">Dispense</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/patients">Patients</Link></DropdownMenuItem>
-                                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>Logout</DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
-
-                {/* Sections */}
-                <section className="px-4 sm:px-6 py-6 sm:py-8 space-y-10 w-full max-w-4xl mx-auto">
-                    {/* My Account */}
-                    {profile && (
-                        <Card className="rounded-2xl shadow-lg hover:shadow-xl transition mb-10">
-                            <CardHeader className="border-b flex items-center justify-between flex-wrap gap-3">
-                                <CardTitle className="text-xl sm:text-2xl font-bold text-green-600">My Account</CardTitle>
-
-                                {/* Password Update Dialog */}
-                                <Dialog
-                                    onOpenChange={(open) => {
-                                        if (!open) {
-                                            setPasswordErrors([]);
-                                            setPasswordMessage(null);
-                                            setPasswordLoading(false);
-                                        }
-                                    }}
-                                >
-                                    <DialogTrigger asChild>
-                                        <Button variant="outline" size="icon" className="hover:bg-green-50">
-                                            <Cog className="h-5 w-5 text-green-600" />
-                                        </Button>
-                                    </DialogTrigger>
-
-                                    <DialogContent className="w-[95%] max-w-sm sm:max-w-md lg:max-w-lg rounded-xl">
-                                        <DialogHeader>
-                                            <DialogTitle className="text-lg sm:text-xl">Update Password</DialogTitle>
-                                            <DialogDescription className="text-sm sm:text-base">
-                                                Change your account password securely. Enter your current password and set a new one.
-                                            </DialogDescription>
-                                        </DialogHeader>
-
-                                        {/* Password Form */}
-                                        <form
-                                            onSubmit={async (e) => {
-                                                e.preventDefault();
-                                                const form = e.currentTarget;
-                                                const oldPassword = (form.elements.namedItem("oldPassword") as HTMLInputElement).value;
-                                                const newPassword = (form.elements.namedItem("newPassword") as HTMLInputElement).value;
-                                                const confirmPassword = (form.elements.namedItem("confirmPassword") as HTMLInputElement).value;
-
-                                                const errors: string[] = [];
-                                                if (newPassword.length < 8) errors.push("Password must be at least 8 characters.");
-                                                if (!/[a-z]/.test(newPassword)) errors.push("Must contain a lowercase letter.");
-                                                if (!/[A-Z]/.test(newPassword)) errors.push("Must contain an uppercase letter.");
-                                                if (!/\d/.test(newPassword)) errors.push("Must contain a number.");
-                                                if (!/[^\w\s]/.test(newPassword)) errors.push("Must contain a symbol.");
-                                                if (newPassword !== confirmPassword) errors.push("Passwords do not match.");
-
-                                                if (errors.length > 0) {
-                                                    setPasswordErrors(errors);
-                                                    return;
-                                                }
-
-                                                try {
-                                                    setPasswordLoading(true);
-                                                    const res = await fetch("/api/doctor/account/password", {
-                                                        method: "PUT",
-                                                        headers: { "Content-Type": "application/json" },
-                                                        body: JSON.stringify({ oldPassword, newPassword }),
-                                                    });
-                                                    const data = await res.json();
-                                                    if (data.error) setPasswordErrors([data.error]);
-                                                    else {
-                                                        setPasswordMessage("Password updated successfully!");
-                                                        toast.success("Password updated successfully!");
-                                                        form.reset();
+                                            {/* Password Update Dialog */}
+                                            <Dialog
+                                                onOpenChange={(open) => {
+                                                    if (!open) {
+                                                        setPasswordErrors([]);
+                                                        setPasswordMessage(null);
+                                                        setPasswordLoading(false);
                                                     }
-                                                } catch {
-                                                    setPasswordErrors(["Failed to update password. Please try again."]);
-                                                } finally {
-                                                    setPasswordLoading(false);
-                                                }
-                                            }}
-                                            className="space-y-4"
-                                        >
-                                            {/* Password Fields */}
-                                            <div>
-                                                <Label className="block mb-1 font-medium">Current Password</Label>
-                                                <div className="relative">
-                                                    <Input type={showCurrent ? "text" : "password"} name="oldPassword" required className="pr-10" />
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        onClick={() => setShowCurrent(!showCurrent)}
-                                                        className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent"
-                                                    >
-                                                        {showCurrent ? <EyeOff className="h-5 w-5 text-gray-500" /> : <Eye className="h-5 w-5 text-gray-500" />}
+                                                }}
+                                            >
+                                                <DialogTrigger asChild>
+                                                    <Button variant="outline" size="icon" className="hover:bg-green-50">
+                                                        <Cog className="h-5 w-5 text-green-600" />
                                                     </Button>
-                                                </div>
-                                            </div>
+                                                </DialogTrigger>
 
-                                            <div>
-                                                <Label className="block mb-1 font-medium">New Password</Label>
-                                                <div className="relative">
-                                                    <Input
-                                                        type={showNew ? "text" : "password"}
-                                                        name="newPassword"
-                                                        required
-                                                        className="pr-10"
-                                                        onChange={(e) => {
-                                                            const val = e.target.value;
+                                                <DialogContent className="w-[95%] max-w-sm sm:max-w-md lg:max-w-lg rounded-xl">
+                                                    <DialogHeader>
+                                                        <DialogTitle className="text-lg sm:text-xl">Update Password</DialogTitle>
+                                                        <DialogDescription className="text-sm sm:text-base">
+                                                            Change your account password securely. Enter your current password and set a new one.
+                                                        </DialogDescription>
+                                                    </DialogHeader>
+
+                                                    {/* Password Form */}
+                                                    <form
+                                                        onSubmit={async (e) => {
+                                                            e.preventDefault();
+                                                            const form = e.currentTarget;
+                                                            const oldPassword = (form.elements.namedItem("oldPassword") as HTMLInputElement).value;
+                                                            const newPassword = (form.elements.namedItem("newPassword") as HTMLInputElement).value;
+                                                            const confirmPassword = (form.elements.namedItem("confirmPassword") as HTMLInputElement).value;
+
                                                             const errors: string[] = [];
-                                                            if (val.length < 8) errors.push("Password must be at least 8 characters.");
-                                                            if (!/[a-z]/.test(val)) errors.push("Must contain a lowercase letter.");
-                                                            if (!/[A-Z]/.test(val)) errors.push("Must contain an uppercase letter.");
-                                                            if (!/\d/.test(val)) errors.push("Must contain a number.");
-                                                            if (!/[^\w\s]/.test(val)) errors.push("Must contain a symbol.");
-                                                            setPasswordErrors(errors);
+                                                            if (newPassword.length < 8) errors.push("Password must be at least 8 characters.");
+                                                            if (!/[a-z]/.test(newPassword)) errors.push("Must contain a lowercase letter.");
+                                                            if (!/[A-Z]/.test(newPassword)) errors.push("Must contain an uppercase letter.");
+                                                            if (!/\d/.test(newPassword)) errors.push("Must contain a number.");
+                                                            if (!/[^\w\s]/.test(newPassword)) errors.push("Must contain a symbol.");
+                                                            if (newPassword !== confirmPassword) errors.push("Passwords do not match.");
+
+                                                            if (errors.length > 0) {
+                                                                setPasswordErrors(errors);
+                                                                return;
+                                                            }
+
+                                                            try {
+                                                                setPasswordLoading(true);
+                                                                const res = await fetch("/api/doctor/account/password", {
+                                                                    method: "PUT",
+                                                                    headers: { "Content-Type": "application/json" },
+                                                                    body: JSON.stringify({ oldPassword, newPassword }),
+                                                                });
+                                                                const data = await res.json();
+                                                                if (data.error) setPasswordErrors([data.error]);
+                                                                else {
+                                                                    setPasswordMessage("Password updated successfully!");
+                                                                    toast.success("Password updated successfully!");
+                                                                    form.reset();
+                                                                }
+                                                            } catch {
+                                                                setPasswordErrors(["Failed to update password. Please try again."]);
+                                                            } finally {
+                                                                setPasswordLoading(false);
+                                                            }
                                                         }}
+                                                        className="space-y-4"
+                                                    >
+                                                        {/* Password Fields */}
+                                                        <div>
+                                                            <Label className="block mb-1 font-medium">Current Password</Label>
+                                                            <div className="relative">
+                                                                <Input type={showCurrent ? "text" : "password"} name="oldPassword" required className="pr-10" />
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    onClick={() => setShowCurrent(!showCurrent)}
+                                                                    className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent"
+                                                                >
+                                                                    {showCurrent ? <EyeOff className="h-5 w-5 text-gray-500" /> : <Eye className="h-5 w-5 text-gray-500" />}
+                                                                </Button>
+                                                            </div>
+                                                        </div>
+
+                                                        <div>
+                                                            <Label className="block mb-1 font-medium">New Password</Label>
+                                                            <div className="relative">
+                                                                <Input
+                                                                    type={showNew ? "text" : "password"}
+                                                                    name="newPassword"
+                                                                    required
+                                                                    className="pr-10"
+                                                                    onChange={(e) => {
+                                                                        const val = e.target.value;
+                                                                        const errors: string[] = [];
+                                                                        if (val.length < 8) errors.push("Password must be at least 8 characters.");
+                                                                        if (!/[a-z]/.test(val)) errors.push("Must contain a lowercase letter.");
+                                                                        if (!/[A-Z]/.test(val)) errors.push("Must contain an uppercase letter.");
+                                                                        if (!/\d/.test(val)) errors.push("Must contain a number.");
+                                                                        if (!/[^\w\s]/.test(val)) errors.push("Must contain a symbol.");
+                                                                        setPasswordErrors(errors);
+                                                                    }}
+                                                                />
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    onClick={() => setShowNew(!showNew)}
+                                                                    className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent"
+                                                                >
+                                                                    {showNew ? <EyeOff className="h-5 w-5 text-gray-500" /> : <Eye className="h-5 w-5 text-gray-500" />}
+                                                                </Button>
+                                                            </div>
+                                                        </div>
+
+                                                        <div>
+                                                            <Label className="block mb-1 font-medium">Confirm Password</Label>
+                                                            <div className="relative">
+                                                                <Input type={showConfirm ? "text" : "password"} name="confirmPassword" required className="pr-10" />
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    onClick={() => setShowConfirm(!showConfirm)}
+                                                                    className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent"
+                                                                >
+                                                                    {showConfirm ? <EyeOff className="h-5 w-5 text-gray-500" /> : <Eye className="h-5 w-5 text-gray-500" />}
+                                                                </Button>
+                                                            </div>
+                                                        </div>
+
+                                                        {passwordErrors.length > 0 && (
+                                                            <ul className="text-sm text-red-600 space-y-1">
+                                                                {passwordErrors.map((err, idx) => (
+                                                                    <li key={idx}>• {err}</li>
+                                                                ))}
+                                                            </ul>
+                                                        )}
+                                                        {passwordMessage && <p className="text-sm text-green-600">{passwordMessage}</p>}
+
+                                                        <DialogFooter className="flex flex-col sm:flex-row sm:justify-end gap-3">
+                                                            <Button
+                                                                type="submit"
+                                                                className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white flex items-center gap-2"
+                                                                disabled={passwordLoading}
+                                                            >
+                                                                {passwordLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+                                                                {passwordLoading ? "Updating..." : "Update Password"}
+                                                            </Button>
+                                                        </DialogFooter>
+                                                    </form>
+                                                </DialogContent>
+                                            </Dialog>
+                                        </CardHeader>
+
+                                        {/* Profile Form */}
+                                        <CardContent className="pt-6">
+                                            <form onSubmit={handleProfileUpdate} className="space-y-6">
+                                                {/* Basic Info */}
+                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">User ID</Label>
+                                                        <Input value={profile.user_id} disabled />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Employee ID</Label>
+                                                        <Input value={profile.username} disabled />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Role</Label>
+                                                        <Input value={profile.role} disabled />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Status</Label>
+                                                        <Input value={profile.status} disabled />
+                                                    </div>
+                                                    {/* 🗓️ Date of Birth */}
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Date of Birth</Label>
+
+                                                        {/* If already set → disable input */}
+                                                        {profile.date_of_birth ? (
+                                                            <Input
+                                                                type="date"
+                                                                value={profile.date_of_birth?.slice(0, 10) || ""}
+                                                                disabled
+                                                            />
+                                                        ) : (
+                                                            <>
+                                                                <Input
+                                                                    type="date"
+                                                                    value={tempDOB}
+                                                                    onChange={(e) => setTempDOB(e.target.value)}
+                                                                />
+                                                                {tempDOB && (
+                                                                    <Button
+                                                                        type="button"
+                                                                        className="mt-2 bg-green-600 hover:bg-green-700 text-white text-sm"
+                                                                        onClick={() => setShowDOBConfirm(true)}
+                                                                    >
+                                                                        Confirm Date
+                                                                    </Button>
+                                                                )}
+                                                                <p className="text-xs text-gray-500 mt-1">
+                                                                    You can only set this once. Once saved, it cannot be changed.
+                                                                </p>
+
+                                                                {/* 🔒 Confirmation Dialog */}
+                                                                <AlertDialog open={showDOBConfirm} onOpenChange={setShowDOBConfirm}>
+                                                                    <AlertDialogContent className="max-w-sm sm:max-w-md">
+                                                                        <AlertDialogHeader>
+                                                                            <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
+                                                                            <AlertDialogDescription>
+                                                                                You are about to set your Date of Birth to{" "}
+                                                                                <span className="font-semibold text-green-700">{tempDOB}</span>.
+                                                                                <br />
+                                                                                This action can only be done once and cannot be changed later.
+                                                                            </AlertDialogDescription>
+                                                                        </AlertDialogHeader>
+
+                                                                        <AlertDialogFooter className="mt-4">
+                                                                            <AlertDialogCancel
+                                                                                onClick={() => {
+                                                                                    setTempDOB("");
+                                                                                    setShowDOBConfirm(false);
+                                                                                }}
+                                                                            >
+                                                                                Cancel
+                                                                            </AlertDialogCancel>
+                                                                            <AlertDialogAction
+                                                                                className="bg-green-600 hover:bg-green-700"
+                                                                                onClick={async () => {
+                                                                                    setProfile({ ...profile, date_of_birth: tempDOB });
+                                                                                    setShowDOBConfirm(false);
+
+                                                                                    try {
+                                                                                        setProfileLoading(true);
+                                                                                        const payload = {
+                                                                                            ...profile,
+                                                                                            date_of_birth: tempDOB,
+                                                                                            bloodtype:
+                                                                                                reverseBloodTypeEnumMap[profile?.bloodtype || ""] || null,
+                                                                                        };
+
+                                                                                        const res = await fetch("/api/doctor/account/me", {
+                                                                                            method: "PUT",
+                                                                                            headers: { "Content-Type": "application/json" },
+                                                                                            body: JSON.stringify({ profile: payload }),
+                                                                                        });
+
+                                                                                        const data = await res.json();
+                                                                                        if (data.error) {
+                                                                                            toast.error(data.error);
+                                                                                        } else {
+                                                                                            toast.success("Date of Birth saved!");
+                                                                                            await loadProfile(); // 🔄 refresh profile
+                                                                                        }
+                                                                                    } catch {
+                                                                                        toast.error("Failed to save Date of Birth");
+                                                                                    } finally {
+                                                                                        setProfileLoading(false);
+                                                                                    }
+                                                                                }}
+                                                                            >
+                                                                                Confirm
+                                                                            </AlertDialogAction>
+                                                                        </AlertDialogFooter>
+                                                                    </AlertDialogContent>
+                                                                </AlertDialog>
+                                                            </>
+                                                        )}
+                                                    </div>
+
+                                                </div>
+
+                                                {/* Personal Info */}
+                                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">First Name</Label>
+                                                        <Input
+                                                            value={profile.fname}
+                                                            onChange={(e) => setProfile({ ...profile, fname: e.target.value })}
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Middle Name</Label>
+                                                        <Input
+                                                            value={profile.mname || ""}
+                                                            onChange={(e) => setProfile({ ...profile, mname: e.target.value })}
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Last Name</Label>
+                                                        <Input
+                                                            value={profile.lname}
+                                                            onChange={(e) => setProfile({ ...profile, lname: e.target.value })}
+                                                        />
+                                                    </div>
+                                                </div>
+
+                                                {/* Contact Info */}
+                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Email</Label>
+                                                        <Input
+                                                            type="email"
+                                                            placeholder="example@hnu.edu.ph"
+                                                            value={profile.email || ""}
+                                                            onChange={(e) => setProfile({ ...profile, email: e.target.value })}
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Contact No</Label>
+                                                        <Input
+                                                            type="tel"
+                                                            placeholder="09XXXXXXXXX"
+                                                            value={profile.contactno || ""}
+                                                            onChange={(e) =>
+                                                                setProfile({ ...profile, contactno: e.target.value })
+                                                            }
+                                                        />
+                                                    </div>
+                                                </div>
+
+                                                {/* Address & Medical */}
+                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Address</Label>
+                                                        <Input
+                                                            value={profile.address || ""}
+                                                            onChange={(e) => setProfile({ ...profile, address: e.target.value })}
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Allergies</Label>
+                                                        <Input
+                                                            value={profile.allergies || ""}
+                                                            onChange={(e) =>
+                                                                setProfile({ ...profile, allergies: e.target.value })
+                                                            }
+                                                        />
+                                                    </div>
+                                                </div>
+
+                                                <div>
+                                                    <Label className="block mb-1 font-medium">Medical Conditions</Label>
+                                                    <Input
+                                                        value={profile.medical_cond || ""}
+                                                        onChange={(e) =>
+                                                            setProfile({ ...profile, medical_cond: e.target.value })
+                                                        }
                                                     />
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        onClick={() => setShowNew(!showNew)}
-                                                        className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent"
-                                                    >
-                                                        {showNew ? <EyeOff className="h-5 w-5 text-gray-500" /> : <Eye className="h-5 w-5 text-gray-500" />}
-                                                    </Button>
                                                 </div>
-                                            </div>
 
-                                            <div>
-                                                <Label className="block mb-1 font-medium">Confirm Password</Label>
-                                                <div className="relative">
-                                                    <Input type={showConfirm ? "text" : "password"} name="confirmPassword" required className="pr-10" />
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        onClick={() => setShowConfirm(!showConfirm)}
-                                                        className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent"
-                                                    >
-                                                        {showConfirm ? <EyeOff className="h-5 w-5 text-gray-500" /> : <Eye className="h-5 w-5 text-gray-500" />}
-                                                    </Button>
+                                                {/* Blood Type */}
+                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Blood Type</Label>
+                                                        <Select
+                                                            value={profile.bloodtype || ""}
+                                                            onValueChange={(val) =>
+                                                                setProfile({ ...profile, bloodtype: val })
+                                                            }
+                                                        >
+                                                            <SelectTrigger>
+                                                                <SelectValue placeholder="Select Blood Type" />
+                                                            </SelectTrigger>
+                                                            <SelectContent>
+                                                                {bloodTypeOptions.map((type) => (
+                                                                    <SelectItem key={type} value={type}>
+                                                                        {type}
+                                                                    </SelectItem>
+                                                                ))}
+                                                            </SelectContent>
+                                                        </Select>
+                                                    </div>
                                                 </div>
-                                            </div>
 
-                                            {passwordErrors.length > 0 && (
-                                                <ul className="text-sm text-red-600 space-y-1">
-                                                    {passwordErrors.map((err, idx) => (
-                                                        <li key={idx}>• {err}</li>
-                                                    ))}
-                                                </ul>
-                                            )}
-                                            {passwordMessage && <p className="text-sm text-green-600">{passwordMessage}</p>}
+                                                {/* Emergency Contact */}
+                                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">Emergency Contact Name</Label>
+                                                        <Input
+                                                            value={profile.emergencyco_name || ""}
+                                                            onChange={(e) =>
+                                                                setProfile({ ...profile, emergencyco_name: e.target.value })
+                                                            }
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">
+                                                            Emergency Contact Number
+                                                        </Label>
+                                                        <Input
+                                                            value={profile.emergencyco_num || ""}
+                                                            onChange={(e) =>
+                                                                setProfile({ ...profile, emergencyco_num: e.target.value })
+                                                            }
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <Label className="block mb-1 font-medium">
+                                                            Emergency Contact Relation
+                                                        </Label>
+                                                        <Input
+                                                            value={profile.emergencyco_relation || ""}
+                                                            onChange={(e) =>
+                                                                setProfile({ ...profile, emergencyco_relation: e.target.value })
+                                                            }
+                                                        />
+                                                    </div>
+                                                </div>
 
-                                            <DialogFooter className="flex flex-col sm:flex-row sm:justify-end gap-3">
                                                 <Button
                                                     type="submit"
-                                                    className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white flex items-center gap-2"
-                                                    disabled={passwordLoading}
+                                                    className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white text-sm sm:text-base"
+                                                    disabled={profileLoading}
                                                 >
-                                                    {passwordLoading && <Loader2 className="h-4 w-4 animate-spin" />}
-                                                    {passwordLoading ? "Updating..." : "Update Password"}
+                                                    {profileLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+                                                    {profileLoading ? "Saving..." : "Save Changes"}
                                                 </Button>
-                                            </DialogFooter>
-                                        </form>
-                                    </DialogContent>
-                                </Dialog>
-                            </CardHeader>
+                                            </form>
+                                        </CardContent>
 
-                            {/* Profile Form */}
-                            <CardContent className="pt-6">
-                                <form onSubmit={handleProfileUpdate} className="space-y-6">
-                                    {/* Basic Info */}
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">User ID</Label>
-                                            <Input value={profile.user_id} disabled />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Employee ID</Label>
-                                            <Input value={profile.username} disabled />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Role</Label>
-                                            <Input value={profile.role} disabled />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Status</Label>
-                                            <Input value={profile.status} disabled />
-                                        </div>
-                                        {/* 🗓️ Date of Birth */}
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Date of Birth</Label>
+                                    </Card>
+                                )}
+            </section>
 
-                                            {/* If already set → disable input */}
-                                            {profile.date_of_birth ? (
-                                                <Input
-                                                    type="date"
-                                                    value={profile.date_of_birth?.slice(0, 10) || ""}
-                                                    disabled
-                                                />
-                                            ) : (
-                                                <>
-                                                    <Input
-                                                        type="date"
-                                                        value={tempDOB}
-                                                        onChange={(e) => setTempDOB(e.target.value)}
-                                                    />
-                                                    {tempDOB && (
-                                                        <Button
-                                                            type="button"
-                                                            className="mt-2 bg-green-600 hover:bg-green-700 text-white text-sm"
-                                                            onClick={() => setShowDOBConfirm(true)}
-                                                        >
-                                                            Confirm Date
-                                                        </Button>
-                                                    )}
-                                                    <p className="text-xs text-gray-500 mt-1">
-                                                        You can only set this once. Once saved, it cannot be changed.
-                                                    </p>
-
-                                                    {/* 🔒 Confirmation Dialog */}
-                                                    <AlertDialog open={showDOBConfirm} onOpenChange={setShowDOBConfirm}>
-                                                        <AlertDialogContent className="max-w-sm sm:max-w-md">
-                                                            <AlertDialogHeader>
-                                                                <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
-                                                                <AlertDialogDescription>
-                                                                    You are about to set your Date of Birth to{" "}
-                                                                    <span className="font-semibold text-green-700">{tempDOB}</span>.
-                                                                    <br />
-                                                                    This action can only be done once and cannot be changed later.
-                                                                </AlertDialogDescription>
-                                                            </AlertDialogHeader>
-
-                                                            <AlertDialogFooter className="mt-4">
-                                                                <AlertDialogCancel
-                                                                    onClick={() => {
-                                                                        setTempDOB("");
-                                                                        setShowDOBConfirm(false);
-                                                                    }}
-                                                                >
-                                                                    Cancel
-                                                                </AlertDialogCancel>
-                                                                <AlertDialogAction
-                                                                    className="bg-green-600 hover:bg-green-700"
-                                                                    onClick={async () => {
-                                                                        setProfile({ ...profile, date_of_birth: tempDOB });
-                                                                        setShowDOBConfirm(false);
-
-                                                                        try {
-                                                                            setProfileLoading(true);
-                                                                            const payload = {
-                                                                                ...profile,
-                                                                                date_of_birth: tempDOB,
-                                                                                bloodtype:
-                                                                                    reverseBloodTypeEnumMap[profile?.bloodtype || ""] || null,
-                                                                            };
-
-                                                                            const res = await fetch("/api/doctor/account/me", {
-                                                                                method: "PUT",
-                                                                                headers: { "Content-Type": "application/json" },
-                                                                                body: JSON.stringify({ profile: payload }),
-                                                                            });
-
-                                                                            const data = await res.json();
-                                                                            if (data.error) {
-                                                                                toast.error(data.error);
-                                                                            } else {
-                                                                                toast.success("Date of Birth saved!");
-                                                                                await loadProfile(); // 🔄 refresh profile
-                                                                            }
-                                                                        } catch {
-                                                                            toast.error("Failed to save Date of Birth");
-                                                                        } finally {
-                                                                            setProfileLoading(false);
-                                                                        }
-                                                                    }}
-                                                                >
-                                                                    Confirm
-                                                                </AlertDialogAction>
-                                                            </AlertDialogFooter>
-                                                        </AlertDialogContent>
-                                                    </AlertDialog>
-                                                </>
-                                            )}
-                                        </div>
-
-                                    </div>
-
-                                    {/* Personal Info */}
-                                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">First Name</Label>
-                                            <Input
-                                                value={profile.fname}
-                                                onChange={(e) => setProfile({ ...profile, fname: e.target.value })}
-                                            />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Middle Name</Label>
-                                            <Input
-                                                value={profile.mname || ""}
-                                                onChange={(e) => setProfile({ ...profile, mname: e.target.value })}
-                                            />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Last Name</Label>
-                                            <Input
-                                                value={profile.lname}
-                                                onChange={(e) => setProfile({ ...profile, lname: e.target.value })}
-                                            />
-                                        </div>
-                                    </div>
-
-                                    {/* Contact Info */}
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Email</Label>
-                                            <Input
-                                                type="email"
-                                                placeholder="example@hnu.edu.ph"
-                                                value={profile.email || ""}
-                                                onChange={(e) => setProfile({ ...profile, email: e.target.value })}
-                                            />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Contact No</Label>
-                                            <Input
-                                                type="tel"
-                                                placeholder="09XXXXXXXXX"
-                                                value={profile.contactno || ""}
-                                                onChange={(e) =>
-                                                    setProfile({ ...profile, contactno: e.target.value })
-                                                }
-                                            />
-                                        </div>
-                                    </div>
-
-                                    {/* Address & Medical */}
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Address</Label>
-                                            <Input
-                                                value={profile.address || ""}
-                                                onChange={(e) => setProfile({ ...profile, address: e.target.value })}
-                                            />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Allergies</Label>
-                                            <Input
-                                                value={profile.allergies || ""}
-                                                onChange={(e) =>
-                                                    setProfile({ ...profile, allergies: e.target.value })
-                                                }
-                                            />
-                                        </div>
-                                    </div>
-
-                                    <div>
-                                        <Label className="block mb-1 font-medium">Medical Conditions</Label>
-                                        <Input
-                                            value={profile.medical_cond || ""}
-                                            onChange={(e) =>
-                                                setProfile({ ...profile, medical_cond: e.target.value })
-                                            }
-                                        />
-                                    </div>
-
-                                    {/* Blood Type */}
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Blood Type</Label>
-                                            <Select
-                                                value={profile.bloodtype || ""}
-                                                onValueChange={(val) =>
-                                                    setProfile({ ...profile, bloodtype: val })
-                                                }
-                                            >
-                                                <SelectTrigger>
-                                                    <SelectValue placeholder="Select Blood Type" />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    {bloodTypeOptions.map((type) => (
-                                                        <SelectItem key={type} value={type}>
-                                                            {type}
-                                                        </SelectItem>
-                                                    ))}
-                                                </SelectContent>
-                                            </Select>
-                                        </div>
-                                    </div>
-
-                                    {/* Emergency Contact */}
-                                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Emergency Contact Name</Label>
-                                            <Input
-                                                value={profile.emergencyco_name || ""}
-                                                onChange={(e) =>
-                                                    setProfile({ ...profile, emergencyco_name: e.target.value })
-                                                }
-                                            />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">
-                                                Emergency Contact Number
-                                            </Label>
-                                            <Input
-                                                value={profile.emergencyco_num || ""}
-                                                onChange={(e) =>
-                                                    setProfile({ ...profile, emergencyco_num: e.target.value })
-                                                }
-                                            />
-                                        </div>
-                                        <div>
-                                            <Label className="block mb-1 font-medium">
-                                                Emergency Contact Relation
-                                            </Label>
-                                            <Input
-                                                value={profile.emergencyco_relation || ""}
-                                                onChange={(e) =>
-                                                    setProfile({ ...profile, emergencyco_relation: e.target.value })
-                                                }
-                                            />
-                                        </div>
-                                    </div>
-
-                                    <Button
-                                        type="submit"
-                                        className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white text-sm sm:text-base"
-                                        disabled={profileLoading}
-                                    >
-                                        {profileLoading && <Loader2 className="h-5 w-5 animate-spin" />}
-                                        {profileLoading ? "Saving..." : "Save Changes"}
-                                    </Button>
-                                </form>
-                            </CardContent>
-
-                        </Card>
-                    )}
-                </section>
-
-                {/* Footer */}
-                <footer className="bg-white py-6 text-center text-gray-600 mt-auto text-sm sm:text-base">
-                    © {new Date().getFullYear()} HNU Clinic – Doctor Panel
-                </footer>
-            </main>
-        </div>
+        </DoctorLayout>
     );
 }

--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -1,47 +1,37 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import { signOut } from "next-auth/react";
 import { toast } from "sonner";
 import {
-    Menu,
-    X,
-    User,
     CalendarDays,
-    ClipboardList,
-    ClipboardCheck,
-    FileText,
-    Home,
-    Loader2,
-    Clock4,
     Check,
-    XCircle,
-    Move,
+    ClipboardCheck,
+    Loader2,
     MoreHorizontal,
-    Pill,
+    Move,
     Trash2,
+    XCircle,
 } from "lucide-react";
+
+import DoctorLayout from "@/components/patient/doctor-layout";
 import { Button } from "@/components/ui/button";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
 import {
     Dialog,
     DialogContent,
-    DialogHeader,
-    DialogTitle,
     DialogDescription,
     DialogFooter,
+    DialogHeader,
+    DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import Image from "next/image";
 
 interface Appointment {
     id: string;
@@ -54,8 +44,6 @@ interface Appointment {
 }
 
 export default function DoctorAppointmentsPage() {
-    const [menuOpen, setMenuOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
     const [appointments, setAppointments] = useState<Appointment[]>([]);
     const [loading, setLoading] = useState(true);
     const [actionType, setActionType] = useState<"cancel" | "move" | null>(null);
@@ -65,15 +53,6 @@ export default function DoctorAppointmentsPage() {
     const [newTimeStart, setNewTimeStart] = useState("");
     const [newTimeEnd, setNewTimeEnd] = useState("");
     const [dialogOpen, setDialogOpen] = useState(false);
-
-    async function handleLogout() {
-        try {
-            setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
-        } finally {
-            setIsLoggingOut(false);
-        }
-    }
 
     async function loadAppointments() {
         try {
@@ -196,117 +175,11 @@ export default function DoctorAppointmentsPage() {
     }
 
     return (
-        <div className="flex flex-col md:flex-row min-h-screen bg-green-50">
-            {/* Sidebar */}
-            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
-                {/* Logo Section */}
-                <div className="flex items-center mb-12">
-                    <Image
-                        src="/clinic-illustration.svg"
-                        alt="clinic-logo"
-                        width={40}
-                        height={40}
-                        className="object-contain drop-shadow-sm"
-                    />
-                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">
-                        HNU Clinic
-                    </h1>
-                </div>
-                <nav className="flex flex-col gap-2 text-gray-700">
-                    <Link
-                        href="/doctor"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Home className="h-5 w-5" /> Dashboard
-                    </Link>
-                    <Link
-                        href="/doctor/account"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <User className="h-5 w-5" /> Account
-                    </Link>
-                    <Link
-                        href="/doctor/consultation"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Clock4 className="h-5 w-5" /> Consultation
-                    </Link>
-                    <Link
-                        href="/doctor/appointments"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
-                    >
-                        <CalendarDays className="h-5 w-5" /> Appointments
-                    </Link>
-                    <Link
-                        href="/doctor/dispense"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Pill className="h-5 w-5" /> Dispense
-                    </Link>
-                    <Link
-                        href="/doctor/patients"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <ClipboardList className="h-5 w-5" /> Patients
-                    </Link>
-                    <Link
-                        href="/doctor/certificates"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
-                        <FileText className="h-5 w-5" /> MedCerts
-                    </Link>
-                </nav>
-                <Separator className="my-8" />
-                <Button
-                    variant="default"
-                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                >
-                    {isLoggingOut ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Logging out...
-                        </>
-                    ) : (
-                        "Logout"
-                    )}
-                </Button>
-            </aside>
-
-            {/* Main */}
-            <main className="flex-1 flex flex-col">
-                {/* Header */}
-                <header className="w-full bg-white shadow px-4 sm:px-6 py-4 flex items-center justify-between sticky top-0 z-40">
-                    <h2 className="text-lg sm:text-xl font-bold text-green-600">
-                        Manage Appointments
-                    </h2>
-
-                    {/* Mobile Menu */}
-                    <div className="md:hidden">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm" onClick={() => setMenuOpen(!menuOpen)}>
-                                    {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                <DropdownMenuItem asChild><Link href="/doctor">Dashboard</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/account">Account</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/consultation">Consultation</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/appointments">Appointments</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/dispense">Dispense</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/patients">Patients</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/certificates">MedCerts</Link></DropdownMenuItem>
-                                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>
-                                    Logout
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
-
-                {/* Appointments Section */}
-                <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
+        <DoctorLayout
+            title="Manage Appointments"
+            description="Review schedules, take action on requests, and keep your clinic day running smoothly."
+        >
+            <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
                     <Card className="rounded-2xl shadow-lg hover:shadow-xl transition flex flex-col">
                         <CardHeader className="border-b flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                             <CardTitle className="flex items-center gap-2 text-green-600 text-lg sm:text-xl">
@@ -409,7 +282,7 @@ export default function DoctorAppointmentsPage() {
                             )}
                         </CardContent>
                     </Card>
-                </section>
+            </section>
 
                 {/* Dialog */}
                 <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -477,11 +350,6 @@ export default function DoctorAppointmentsPage() {
                     </DialogContent>
                 </Dialog>
 
-                {/* Footer */}
-                <footer className="bg-white py-6 text-center text-gray-600 mt-auto text-sm sm:text-base">
-                    © {new Date().getFullYear()} HNU Clinic – Doctor Panel
-                </footer>
-            </main>
-        </div>
+        </DoctorLayout>
     );
 }

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -1,42 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import { signOut } from "next-auth/react";
 import { toast } from "sonner";
-import {
-    Menu,
-    X,
-    Home,
-    User,
-    CalendarDays,
-    ClipboardList,
-    Clock4,
-    Loader2,
-    PlusCircle,
-    Pencil,
-    Pill,
-    FileText,
-} from "lucide-react";
+import { Loader2, Pencil, PlusCircle } from "lucide-react";
 
+import DoctorLayout from "@/components/patient/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
     Dialog,
     DialogContent,
-    DialogHeader,
-    DialogTitle,
     DialogDescription,
     DialogFooter,
+    DialogHeader,
+    DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
 import {
@@ -54,8 +33,6 @@ import {
     toManilaTimeString,
 } from "@/lib/time";
 
-import Image from "next/image";
-
 type Clinic = {
     clinic_id: string;
     clinic_name: string;
@@ -70,8 +47,6 @@ type Availability = {
 };
 
 export default function DoctorConsultationPage() {
-    const [menuOpen, setMenuOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
     const [loading, setLoading] = useState(false);
     const [slots, setSlots] = useState<Availability[]>([]);
     const [clinics, setClinics] = useState<Clinic[]>([]);
@@ -83,15 +58,6 @@ export default function DoctorConsultationPage() {
     });
     const [editingSlot, setEditingSlot] = useState<Availability | null>(null);
     const [dialogOpen, setDialogOpen] = useState(false);
-
-    async function handleLogout() {
-        try {
-            setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
-        } finally {
-            setIsLoggingOut(false);
-        }
-    }
 
     async function loadSlots() {
         try {
@@ -194,114 +160,11 @@ export default function DoctorConsultationPage() {
     }
 
     return (
-        <div className="flex flex-col md:flex-row min-h-screen bg-green-50">
-            {/* Sidebar */}
-            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
-                {/* Logo Section */}
-                <div className="flex items-center mb-12">
-                    <Image
-                        src="/clinic-illustration.svg"
-                        alt="clinic-logo"
-                        width={40}
-                        height={40}
-                        className="object-contain drop-shadow-sm"
-                    />
-                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">
-                        HNU Clinic
-                    </h1>
-                </div>
-                <nav className="flex flex-col gap-2 text-gray-700">
-                    <Link
-                        href="/doctor"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Home className="h-5 w-5" /> Dashboard
-                    </Link>
-                    <Link
-                        href="/doctor/account"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <User className="h-5 w-5" /> Account
-                    </Link>
-                    <Link
-                        href="/doctor/consultation"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
-                    >
-                        <Clock4 className="h-5 w-5" /> Consultation
-                    </Link>
-                    <Link
-                        href="/doctor/appointments"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <CalendarDays className="h-5 w-5" /> Appointments
-                    </Link>
-                    <Link
-                        href="/doctor/dispense"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Pill className="h-5 w-5" /> Dispense
-                    </Link>
-                    <Link
-                        href="/doctor/patients"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <ClipboardList className="h-5 w-5" /> Patients
-                    </Link>
-                    <Link
-                        href="/doctor/certificates"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
-                        <FileText className="h-5 w-5" /> MedCerts
-                    </Link>
-                </nav>
-                <Separator className="my-8" />
-                <Button
-                    variant="default"
-                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                >
-                    {isLoggingOut ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Logging out...
-                        </>
-                    ) : (
-                        "Logout"
-                    )}
-                </Button>
-            </aside>
-
-            {/* Main */}
-            <main className="flex-1 w-full overflow-x-hidden flex flex-col">
-                {/* Header */}
-                <header className="w-full bg-white shadow px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between sticky top-0 z-40">
-                    <h2 className="text-lg sm:text-xl font-bold text-green-600">Consultation Slots</h2>
-
-                    {/* Mobile Menu */}
-                    <div className="md:hidden">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm" onClick={() => setMenuOpen(!menuOpen)}>
-                                    {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                <DropdownMenuItem asChild><Link href="/doctor">Dashboard</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/account">Account</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/consultation">Consultation</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/appointments">Appointments</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/dispense">Dispense</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/patients">Patients</Link></DropdownMenuItem>
-                                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>
-                                    Logout
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
-
-                {/* Consultation Section */}
-                <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
+        <DoctorLayout
+            title="Consultation Schedule"
+            description="Oversee duty hours, manage availability, and keep consultation slots up to date."
+        >
+            <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
                     <Card className="rounded-2xl shadow-lg hover:shadow-xl transition flex flex-col">
                         <CardHeader className="border-b flex justify-between items-center">
                             <CardTitle className="text-xl sm:text-2xl font-bold text-green-600">
@@ -467,12 +330,8 @@ export default function DoctorConsultationPage() {
                             )}
                         </CardContent>
                     </Card>
-                </section>
+            </section>
 
-                <footer className="bg-white py-6 text-center text-gray-600 mt-auto text-sm sm:text-base">
-                    © {new Date().getFullYear()} HNU Clinic – Doctor Panel
-                </footer>
-            </main>
-        </div>
+        </DoctorLayout>
     );
 }

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -1,31 +1,12 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { signOut } from "next-auth/react";
 import { toast } from "sonner";
-import {
-    Menu,
-    X,
-    User,
-    CalendarDays,
-    ClipboardList,
-    FileText,
-    Home,
-    Loader2,
-    Clock4,
-    Pill,
-} from "lucide-react";
+import { Loader2 } from "lucide-react";
 
+import DoctorLayout from "@/components/patient/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -44,7 +25,6 @@ import {
     TableRow,
 } from "@/components/ui/table";
 import { formatManilaDateTime } from "@/lib/time";
-import Image from "next/image";
 
 type DispenseRecord = {
     dispense_id: string;
@@ -115,8 +95,6 @@ function formatDate(value: string | null | undefined) {
 }
 
 export default function DoctorDispensePage() {
-    const [menuOpen, setMenuOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
     const [loading, setLoading] = useState(true);
     const [submitting, setSubmitting] = useState(false);
     const [dispenses, setDispenses] = useState<DispenseRecord[]>([]);
@@ -127,15 +105,6 @@ export default function DoctorDispensePage() {
         med_id: "",
         quantity: "",
     });
-
-    async function handleLogout() {
-        try {
-            setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
-        } finally {
-            setIsLoggingOut(false);
-        }
-    }
 
     const selectedMedicine = useMemo(
         () => medicines.find((med) => med.med_id === form.med_id) || null,
@@ -225,109 +194,11 @@ export default function DoctorDispensePage() {
     }
 
     return (
-        <div className="flex flex-col md:flex-row min-h-screen bg-green-50">
-            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
-                {/* Logo Section */}
-                <div className="flex items-center mb-12">
-                    <Image
-                        src="/clinic-illustration.svg"
-                        alt="clinic-logo"
-                        width={40}
-                        height={40}
-                        className="object-contain drop-shadow-sm"
-                    />
-                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">
-                        HNU Clinic
-                    </h1>
-                </div>
-                <nav className="flex flex-col gap-2 text-gray-700">
-                    <Link
-                        href="/doctor"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Home className="h-5 w-5" /> Dashboard
-                    </Link>
-                    <Link
-                        href="/doctor/account"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <User className="h-5 w-5" /> Account
-                    </Link>
-                    <Link
-                        href="/doctor/consultation"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Clock4 className="h-5 w-5" /> Consultation
-                    </Link>
-                    <Link
-                        href="/doctor/appointments"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <CalendarDays className="h-5 w-5" /> Appointments
-                    </Link>
-                    <Link
-                        href="/doctor/dispense"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
-                    >
-                        <Pill className="h-5 w-5" /> Dispense
-                    </Link>
-                    <Link
-                        href="/doctor/patients"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <ClipboardList className="h-5 w-5" /> Patients
-                    </Link>
-                    <Link
-                        href="/doctor/certificates"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
-                        <FileText className="h-5 w-5" /> MedCerts
-                    </Link>
-                </nav>
-                <Separator className="my-8" />
-                <Button
-                    variant="default"
-                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                >
-                    {isLoggingOut ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Logging out...
-                        </>
-                    ) : (
-                        "Logout"
-                    )}
-                </Button>
-            </aside>
-
-            <main className="flex-1 flex flex-col">
-                <header className="w-full bg-white shadow px-6 py-4 flex items-center justify-between sticky top-0 z-40">
-                    <h2 className="text-xl font-bold text-green-600">Dispense Management</h2>
-                    <div className="md:hidden">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm" onClick={() => setMenuOpen(!menuOpen)}>
-                                    {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                <DropdownMenuItem asChild><Link href="/doctor">Dashboard</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/account">Account</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/consultation">Consultation</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/appointments">Appointments</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/dispense">Dispense</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/patients">Patients</Link></DropdownMenuItem>
-                                <DropdownMenuItem asChild><Link href="/doctor/certificates">MedCerts</Link></DropdownMenuItem>
-                                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>
-                                    Logout
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
-
-                <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col gap-6">
+        <DoctorLayout
+            title="Dispense Management"
+            description="Log prescribed medicines, confirm quantities, and keep inventory usage synchronized."
+        >
+            <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col gap-6">
                     <Card className="shadow-lg rounded-2xl">
                         <CardHeader>
                             <CardTitle className="text-lg sm:text-xl text-green-600 font-semibold">
@@ -514,12 +385,8 @@ export default function DoctorDispensePage() {
                             )}
                         </CardContent>
                     </Card>
-                </section>
+            </section>
 
-                <footer className="bg-white py-6 text-center text-gray-600 mt-auto text-sm sm:text-base">
-                    © {new Date().getFullYear()} HNU Clinic – Doctor Panel
-                </footer>
-            </main>
-        </div>
+        </DoctorLayout>
     );
 }

--- a/src/app/doctor/page.tsx
+++ b/src/app/doctor/page.tsx
@@ -1,290 +1,109 @@
 "use client";
 
-import { useState } from "react";
-import Link from "next/link";
-import { signOut, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import {
-    Menu,
-    X,
-    User,
     CalendarDays,
-    ClipboardList,
     FileText,
-    Stethoscope,
-    Home,
-    Loader2,
-    Clock4,
     Pill,
+    Stethoscope,
+    User,
+    Users,
 } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
-import Image from "next/image";
+import DoctorLayout from "@/components/patient/doctor-layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function DoctorDashboardPage() {
     const { data: session } = useSession();
-    const [menuOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
-
-    const fullName = session?.user?.name || "School Doctor";
-
-    async function handleLogout() {
-        try {
-            setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
-        } finally {
-            setIsLoggingOut(false);
-        }
-    }
+    const fullName = session?.user?.name ?? "School Doctor";
 
     return (
-        <div className="flex min-h-screen bg-green-50">
-            {/* Sidebar */}
-            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
-                {/* Logo Section */}
-                <div className="flex items-center mb-12">
-                    <Image
-                        src="/clinic-illustration.svg"
-                        alt="clinic-logo"
-                        width={40}
-                        height={40}
-                        className="object-contain drop-shadow-sm"
-                    />
-                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">
-                        HNU Clinic
-                    </h1>
-                </div>
-                <nav className="flex flex-col gap-2 text-gray-700">
-                    <Link
-                        href="/doctor"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
-                    >
-                        <Home className="h-5 w-5" /> Dashboard
-                    </Link>
-                    <Link
-                        href="/doctor/account"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <User className="h-5 w-5" /> Account
-                    </Link>
-                    <Link
-                        href="/doctor/consultation"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Clock4 className="h-5 w-5" /> Consultation
-                    </Link>
-                    <Link
-                        href="/doctor/appointments"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <CalendarDays className="h-5 w-5" /> Appointments
-                    </Link>
-                    <Link
-                        href="/doctor/dispense"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Pill className="h-5 w-5" /> Dispense
-                    </Link>
-                    <Link
-                        href="/doctor/patients"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <ClipboardList className="h-5 w-5" /> Patients
-                    </Link>
-                    <Link
-                        href="/doctor/certificates"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
-                        <FileText className="h-5 w-5" /> MedCerts
-                    </Link>
-                </nav>
-                <Separator className="my-8" />
-                <Button
-                    variant="default"
-                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                >
-                    {isLoggingOut ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Logging out...
-                        </>
-                    ) : (
-                        "Logout"
-                    )}
-                </Button>
-            </aside>
+        <DoctorLayout
+            title="Dashboard Overview"
+            description="Monitor your clinic responsibilities, track upcoming consultations, and keep patient care organized in one professional workspace."
+        >
+            <section className="rounded-3xl border border-green-100/80 bg-white/80 px-6 py-10 text-center shadow-sm backdrop-blur">
+                <h2 className="text-2xl font-semibold text-green-700 md:text-3xl">
+                    Welcome back, {fullName}
+                </h2>
+                <p className="mt-3 text-sm text-muted-foreground md:text-base">
+                    Manage appointments, consultations, medication dispensing, and patient relationships with clarity and confidence.
+                </p>
+            </section>
 
-            {/* Main Content */}
-            <main className="flex-1 flex flex-col">
-                {/* Header */}
-                <header className="w-full bg-white shadow px-6 py-4 flex items-center justify-between sticky top-0 z-40">
-                    <h2 className="text-xl font-bold text-green-600">
-                        Doctor Panel Dashboard
-                    </h2>
+            <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                <Card className="border border-green-100/80 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-green-700">
+                            <User className="h-5 w-5" /> Account
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-1 text-sm text-muted-foreground">
+                        <p>Review your profile details and update credentials securely.</p>
+                        <p>Manage password settings and professional information.</p>
+                    </CardContent>
+                </Card>
 
-                    {/* Mobile Menu */}
-                    <div className="md:hidden">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm">
-                                    {menuOpen ? (
-                                        <X className="w-5 h-5" />
-                                    ) : (
-                                        <Menu className="w-5 h-5" />
-                                    )}
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor">Dashboard</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/account">Account</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/consultation">Consultation</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/appointments">Appointments</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/dispense">Dispense</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/patients">Patients</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                    onClick={() =>
-                                        signOut({ callbackUrl: "/login?logout=success" })
-                                    }
-                                >
-                                    Logout
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
+                <Card className="border border-green-100/80 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-green-700">
+                            <Stethoscope className="h-5 w-5" /> Consultation
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-1 text-sm text-muted-foreground">
+                        <p>Set availability, adjust duty hours, and approve schedule changes.</p>
+                        <p>Coordinate clinic coverage and ensure patient access.</p>
+                    </CardContent>
+                </Card>
 
-                {/* Welcome Section */}
-                <section className="px-6 py-8 bg-white shadow-sm">
-                    <div className="text-center">
-                        <h2 className="text-2xl md:text-3xl font-bold text-green-600">
-                            Welcome, {fullName}
-                        </h2>
-                        <p className="text-gray-700 mt-2">
-                            Manage your account, consultations, appointments, dispenses, and medical
-                            certificates.
-                        </p>
-                    </div>
-                </section>
+                <Card className="border border-green-100/80 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-green-700">
+                            <CalendarDays className="h-5 w-5" /> Appointments
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-1 text-sm text-muted-foreground">
+                        <p>Approve, reschedule, or cancel appointments with a single view.</p>
+                        <p>Track daily schedules and stay informed of upcoming visits.</p>
+                    </CardContent>
+                </Card>
 
-                {/* Cards */}
-                <section className="px-6 py-12 grid gap-6 md:grid-cols-3 max-w-6xl mx-auto">
-                    {/* Account */}
-                    <Card className="shadow-lg rounded-2xl hover:shadow-xl transition">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-green-600">
-                                <User className="w-6 h-6" /> Account
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <ul className="list-disc list-inside text-gray-700 text-sm space-y-1">
-                                <li>View and edit profile details</li>
-                                <li>Change account password</li>
-                            </ul>
-                        </CardContent>
-                    </Card>
+                <Card className="border border-green-100/80 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-green-700">
+                            <Pill className="h-5 w-5" /> Dispense
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-1 text-sm text-muted-foreground">
+                        <p>Document prescribed medicines tied to consultations.</p>
+                        <p>Monitor stock usage in sync with the clinic inventory.</p>
+                    </CardContent>
+                </Card>
 
-                    {/* Consultation */}
-                    <Card className="shadow-lg rounded-2xl hover:shadow-xl transition">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-green-600">
-                                <Clock4 className="w-6 h-6" /> Consultation
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <ul className="list-disc list-inside text-gray-700 text-sm space-y-1">
-                                <li>Set duty hours and availability</li>
-                                <li>Modify consultation slots</li>
-                                <li>Approve schedule changes</li>
-                            </ul>
-                        </CardContent>
-                    </Card>
+                <Card className="border border-green-100/80 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-green-700">
+                            <Users className="h-5 w-5" /> Patients
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-1 text-sm text-muted-foreground">
+                        <p>Review patient history, vital notes, and consultation records.</p>
+                        <p>Coordinate care plans and follow-up treatments.</p>
+                    </CardContent>
+                </Card>
 
-                    {/* Appointments */}
-                    <Card className="shadow-lg rounded-2xl hover:shadow-xl transition">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-green-600">
-                                <CalendarDays className="w-6 h-6" /> Appointments
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <ul className="list-disc list-inside text-gray-700 text-sm space-y-1">
-                                <li>Approve, move, or cancel appointments</li>
-                                <li>View all scheduled patients</li>
-                            </ul>
-                        </CardContent>
-                    </Card>
-
-                    {/* Dispense */}
-                    <Card className="shadow-lg rounded-2xl hover:shadow-xl transition">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-green-600">
-                                <Pill className="w-6 h-6" /> Dispense
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <ul className="list-disc list-inside text-gray-700 text-sm space-y-1">
-                                <li>Record consultation-linked medicine usage</li>
-                                <li>Monitor inventory impact in real time</li>
-                            </ul>
-                        </CardContent>
-                    </Card>
-
-                    {/* Patients */}
-                    <Card className="shadow-lg rounded-2xl hover:shadow-xl transition">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-green-600">
-                                <Stethoscope className="w-6 h-6" /> Patients
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <ul className="list-disc list-inside text-gray-700 text-sm space-y-1">
-                                <li>View patient history and records</li>
-                                <li>Update patient consultation data</li>
-                            </ul>
-                        </CardContent>
-                    </Card>
-
-                    {/* Medical Certificates */}
-                    <Card className="shadow-lg rounded-2xl hover:shadow-xl transition">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2 text-green-600">
-                                <FileText className="w-6 h-6" /> Medical Certificates
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <ul className="list-disc list-inside text-gray-700 text-sm space-y-1">
-                                <li>Generate medical certificates</li>
-                                <li>Track issued certificates</li>
-                            </ul>
-                        </CardContent>
-                    </Card>
-                </section>
-
-                {/* Footer */}
-                <footer className="bg-white py-6 text-center text-gray-600 mt-auto">
-                    © {new Date().getFullYear()} HNU Clinic – Doctor Panel
-                </footer>
-            </main>
-        </div>
+                <Card className="border border-green-100/80 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2 text-green-700">
+                            <FileText className="h-5 w-5" /> Medical Certificates
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-1 text-sm text-muted-foreground">
+                        <p>Generate medical certificates with verified patient details.</p>
+                        <p>Track issued documents for compliance and reporting.</p>
+                    </CardContent>
+                </Card>
+            </section>
+        </DoctorLayout>
     );
 }

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -1,33 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { signOut } from "next-auth/react";
 import { toast } from "sonner";
-import {
-    Menu,
-    X,
-    Home,
-    User,
-    CalendarDays,
-    ClipboardList,
-    FileText,
-    Clock4,
-    Loader2,
-    Pill,
-    Search,
-    Stethoscope,
-} from "lucide-react";
+import { Loader2, Search, Stethoscope } from "lucide-react";
 
+import DoctorLayout from "@/components/patient/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -57,7 +36,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { formatManilaDateTime } from "@/lib/time";
 import { BLOOD_TYPES } from "@/lib/patient-records-update";
-import Image from "next/image";
+import { Separator } from "@/components/ui/separator";
 
 type PatientRecord = {
     id: string;
@@ -215,8 +194,6 @@ function formatStaffName(staff?: { fullName: string | null; username: string } |
 }
 
 export default function DoctorPatientsPage() {
-    const [menuOpen, setMenuOpen] = useState(false);
-    const [isLoggingOut, setIsLoggingOut] = useState(false);
     const [records, setRecords] = useState<PatientRecord[]>([]);
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("All");
@@ -224,15 +201,6 @@ export default function DoctorPatientsPage() {
     const [loadingRecords, setLoadingRecords] = useState(false);
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
-
-    async function handleLogout() {
-        try {
-            setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
-        } finally {
-            setIsLoggingOut(false);
-        }
-    }
 
     const loadRecords = useCallback(async () => {
         try {
@@ -289,123 +257,11 @@ export default function DoctorPatientsPage() {
     );
 
     return (
-        <div className="flex flex-col md:flex-row min-h-screen bg-green-50">
-            <aside className="hidden md:flex w-64 flex-col bg-white shadow-xl border-r p-6">
-                {/* Logo Section */}
-                <div className="flex items-center mb-12">
-                    <Image
-                        src="/clinic-illustration.svg"
-                        alt="clinic-logo"
-                        width={40}
-                        height={40}
-                        className="object-contain drop-shadow-sm"
-                    />
-                    <h1 className="text-2xl font-extrabold text-green-600 tracking-tight leading-none">
-                        HNU Clinic
-                    </h1>
-                </div>
-                <nav className="flex flex-col gap-2 text-gray-700">
-                    <Link
-                        href="/doctor"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Home className="h-5 w-5" /> Dashboard
-                    </Link>
-                    <Link
-                        href="/doctor/account"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <User className="h-5 w-5" /> Account
-                    </Link>
-                    <Link
-                        href="/doctor/consultation"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Clock4 className="h-5 w-5" /> Consultation
-                    </Link>
-                    <Link
-                        href="/doctor/appointments"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <CalendarDays className="h-5 w-5" /> Appointments
-                    </Link>
-                    <Link
-                        href="/doctor/dispense"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200"
-                    >
-                        <Pill className="h-5 w-5" /> Dispense
-                    </Link>
-                    <Link
-                        href="/doctor/patients"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg text-green-600 font-semibold bg-green-100 hover:bg-green-200 transition-colors duration-200"
-                    >
-                        <ClipboardList className="h-5 w-5" /> Patients
-                    </Link>
-                    <Link
-                        href="/doctor/certificates"
-                        className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-green-50 hover:text-green-700 transition-all duration-200">
-                        <FileText className="h-5 w-5" /> MedCerts
-                    </Link>
-                </nav>
-                <Separator className="my-8" />
-                <Button
-                    variant="default"
-                    className="bg-green-600 hover:bg-green-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center justify-center gap-2 py-2"
-                    onClick={handleLogout}
-                    disabled={isLoggingOut}
-                >
-                    {isLoggingOut ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Logging out...
-                        </>
-                    ) : (
-                        "Logout"
-                    )}
-                </Button>
-            </aside>
-
-            <main className="flex-1 flex flex-col">
-                <header className="w-full bg-white shadow px-4 sm:px-6 py-4 flex items-center justify-between sticky top-0 z-40">
-                    <h2 className="text-lg sm:text-xl font-bold text-green-600">Patient Records</h2>
-                    <div className="md:hidden">
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <Button variant="outline" size="sm" onClick={() => setMenuOpen((prev) => !prev)}>
-                                    {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor">Dashboard</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/account">Account</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/consultation">Consultation</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/appointments">Appointments</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/dispense">Dispense</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/certificates">MedCerts</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem asChild>
-                                    <Link href="/doctor/patients">Patients</Link>
-                                </DropdownMenuItem>
-                                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?logout=success" })}>
-                                    Logout
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    </div>
-                </header>
-
-                <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
+        <DoctorLayout
+            title="Patient Management"
+            description="Search records, review consultation history, and monitor patient health details with clarity."
+        >
+            <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
                         <Card className="shadow-sm">
                             <CardHeader className="pb-2">
@@ -816,12 +672,8 @@ export default function DoctorPatientsPage() {
                             )}
                         </CardContent>
                     </Card>
-                </section>
+            </section>
 
-                <footer className="bg-white py-6 text-center text-gray-600 mt-auto text-sm sm:text-base">
-                    © {new Date().getFullYear()} HNU Clinic – Doctor Panel
-                </footer>
-            </main>
-        </div>
+        </DoctorLayout>
     );
 }

--- a/src/components/patient/doctor-layout.tsx
+++ b/src/components/patient/doctor-layout.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { ReactNode, useMemo, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { signOut, useSession } from "next-auth/react";
+import {
+    CalendarDays,
+    Home,
+    LogOut,
+    Menu,
+    Pill,
+    Stethoscope,
+    User,
+    Users,
+} from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+const NAV_ITEMS = [
+    { href: "/doctor", label: "Dashboard", icon: Home },
+    { href: "/doctor/patients", label: "Patients", icon: Users },
+    { href: "/doctor/appointments", label: "Appointments", icon: CalendarDays },
+    { href: "/doctor/consultation", label: "Consultation", icon: Stethoscope },
+    { href: "/doctor/dispense", label: "Dispense", icon: Pill },
+    { href: "/doctor/account", label: "Account", icon: User },
+] as const;
+
+type DoctorLayoutProps = {
+    title: string;
+    description?: string;
+    actions?: ReactNode;
+    children: ReactNode;
+    footerNote?: ReactNode;
+};
+
+export function DoctorLayout({
+    title,
+    description,
+    actions,
+    children,
+    footerNote,
+}: DoctorLayoutProps) {
+    const pathname = usePathname();
+    const { data: session } = useSession();
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
+    const [mobileOpen, setMobileOpen] = useState(false);
+
+    const fullName = session?.user?.name ?? "School Doctor";
+
+    const avatarFallback = useMemo(() => {
+        const [first = "", second = ""] = fullName.split(" ");
+        return `${first.charAt(0)}${second.charAt(0)}`.toUpperCase() || "DR";
+    }, [fullName]);
+
+    async function handleLogout() {
+        try {
+            setIsLoggingOut(true);
+            await signOut({ callbackUrl: "/login?logout=success" });
+        } finally {
+            setIsLoggingOut(false);
+        }
+    }
+
+    const navLinks = (
+        <nav className="flex flex-col gap-1">
+            {NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                const isActive = pathname === item.href;
+
+                return (
+                    <Link
+                        key={item.href}
+                        href={item.href}
+                        className={cn(
+                            "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
+                            "hover:bg-green-100/70 hover:text-green-700",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-green-50",
+                            isActive && "bg-white text-green-700 shadow-sm"
+                        )}
+                        onClick={() => setMobileOpen(false)}
+                    >
+                        <Icon
+                            className={cn(
+                                "h-4 w-4",
+                                isActive ? "text-green-700" : "text-gray-600"
+                            )}
+                        />
+                        {item.label}
+                    </Link>
+                );
+            })}
+        </nav>
+    );
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-100">
+            <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 pb-8 pt-6 md:flex-row md:gap-8 md:px-6 lg:px-8">
+                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-green-100/80 bg-white/80 p-6 shadow-sm backdrop-blur lg:flex">
+                    <div className="flex items-center gap-3 pb-6">
+                        <Image
+                            src="/clinic-illustration.svg"
+                            alt="HNU Clinic"
+                            width={44}
+                            height={44}
+                            className="h-11 w-11 object-contain drop-shadow"
+                        />
+                        <div>
+                            <p className="text-xs uppercase tracking-wide text-green-500">Health &amp; Wellness</p>
+                            <h1 className="text-xl font-semibold text-green-700">HNU Clinic</h1>
+                        </div>
+                    </div>
+                    <div className="mb-6 flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
+                        <Avatar className="h-12 w-12 border border-green-100">
+                            <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                            <AvatarFallback className="bg-green-200 text-green-800">
+                                {avatarFallback}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div>
+                            <p className="text-xs text-green-500">Signed in as</p>
+                            <p className="text-sm font-semibold text-green-700">{fullName}</p>
+                        </div>
+                    </div>
+                    {navLinks}
+                    <Separator className="my-6" />
+                    <Button
+                        variant="default"
+                        className="mt-auto w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-green-700"
+                        onClick={handleLogout}
+                        disabled={isLoggingOut}
+                    >
+                        {isLoggingOut ? (
+                            "Signing out..."
+                        ) : (
+                            <>
+                                <LogOut className="h-4 w-4" />
+                                Logout
+                            </>
+                        )}
+                    </Button>
+                </aside>
+
+                <div className="flex flex-1 flex-col">
+                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-green-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/60 md:px-6">
+                        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                            <div className="space-y-3">
+                                <Link
+                                    href="/doctor"
+                                    className="flex items-center gap-3 rounded-2xl border border-green-100 bg-white/90 px-3 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:bg-green-100/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                >
+                                    <Image
+                                        src="/clinic-illustration.svg"
+                                        alt="HNU Clinic"
+                                        width={36}
+                                        height={36}
+                                        className="h-9 w-9 object-contain"
+                                    />
+                                    <span>HNU Clinic</span>
+                                </Link>
+                                <p className="text-xs font-semibold uppercase tracking-wider text-green-500">Doctor Panel</p>
+                                <h2 className="text-2xl font-semibold text-green-700 md:text-3xl">{title}</h2>
+                                {description ? (
+                                    <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
+                                ) : null}
+                            </div>
+                            <div className="flex items-center gap-3 self-start md:self-auto">
+                                {actions}
+                                <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+                                    <SheetTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            size="icon"
+                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                            aria-label="Open doctor navigation"
+                                        >
+                                            <Menu className="h-5 w-5" />
+                                        </Button>
+                                    </SheetTrigger>
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0">
+                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6">
+                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700">
+                                                <Menu className="h-5 w-5" />
+                                                Doctor Navigation
+                                            </SheetTitle>
+                                        </SheetHeader>
+                                        <div className="space-y-6 px-6 py-6">
+                                            <div className="flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
+                                                <Avatar className="h-11 w-11 border border-green-100">
+                                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                                                    <AvatarFallback className="bg-green-200 text-green-800">
+                                                        {avatarFallback}
+                                                    </AvatarFallback>
+                                                </Avatar>
+                                                <div>
+                                                    <p className="text-xs text-green-500">Signed in as</p>
+                                                    <p className="text-sm font-semibold text-green-700">{fullName}</p>
+                                                </div>
+                                            </div>
+                                            {navLinks}
+                                            <Button
+                                                variant="default"
+                                                className="w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm hover:bg-green-700"
+                                                onClick={handleLogout}
+                                                disabled={isLoggingOut}
+                                            >
+                                                {isLoggingOut ? (
+                                                    "Signing out..."
+                                                ) : (
+                                                    <>
+                                                        <LogOut className="h-4 w-4" />
+                                                        Logout
+                                                    </>
+                                                )}
+                                            </Button>
+                                        </div>
+                                    </SheetContent>
+                                </Sheet>
+                            </div>
+                        </div>
+                    </header>
+
+                    <main className="flex-1 space-y-6">{children}</main>
+
+                    <footer className="mt-10 rounded-3xl border border-green-100/70 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
+                        {footerNote ?? <>© {new Date().getFullYear()} HNU Clinic – Doctor Panel</>}
+                    </footer>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default DoctorLayout;


### PR DESCRIPTION
## Summary
- add a shared DoctorLayout that mirrors the patient panel styling with responsive navigation
- refactor every doctor route to consume the new layout and polish copy, spacing, and actions
- refresh the doctor dashboard cards for a cohesive, professional presentation across pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f144f141cc8333a78556cfc46a8b55