### PR TITLE
Align staff dashboards with patient panel design

### DIFF
--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -9,7 +9,7 @@ import {
     EyeOff,
 } from "lucide-react";
 
-import DoctorLayout from "@/components/patient/doctor-layout";
+import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -12,7 +12,7 @@ import {
     MoreHorizontal,
     Trash2,
 } from "lucide-react";
-import DoctorLayout from "@/components/patient/doctor-layout";
+import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import {

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Loader2, PlusCircle, Pencil } from "lucide-react";
 
-import DoctorLayout from "@/components/patient/doctor-layout";
+import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 
-import DoctorLayout from "@/components/patient/doctor-layout";
+import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";

--- a/src/app/doctor/page.tsx
+++ b/src/app/doctor/page.tsx
@@ -13,7 +13,7 @@ import {
     Clock4,
 } from "lucide-react";
 
-import DoctorLayout from "@/components/patient/doctor-layout";
+import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -77,38 +77,38 @@ export default function DoctorDashboardPage() {
             title="Clinical operations overview"
             description="Monitor your upcoming schedule, manage patient interactions, and streamline coordination with the HNU Clinic team."
             actions={
-                <Button asChild className="hidden rounded-xl bg-emerald-600 px-5 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 md:flex">
+                <Button asChild className="hidden rounded-xl bg-green-600 px-5 text-sm font-semibold text-white shadow-sm hover:bg-green-700 md:flex">
                     <Link href="/doctor/consultation">Update availability</Link>
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-emerald-100/70 bg-gradient-to-r from-emerald-100/70 via-white to-emerald-50/80 p-6 shadow-sm">
+            <section className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 p-6 shadow-sm">
                 <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
                     <div className="space-y-3">
-                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-500">
+                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-green-500">
                             Welcome back
                         </p>
-                        <h3 className="text-3xl font-semibold text-emerald-700 md:text-4xl">
+                        <h3 className="text-3xl font-semibold text-green-700 md:text-4xl">
                             Good day, Dr. {firstName}
                         </h3>
                         <p className="max-w-2xl text-sm text-muted-foreground">
                             Review key updates for the day, respond to appointment movements, and keep your consultation schedule aligned with campus demand.
                         </p>
                     </div>
-                    <div className="flex w-full flex-col gap-3 rounded-2xl border border-emerald-100 bg-white/80 p-4 text-sm text-muted-foreground shadow-sm md:w-80">
+                    <div className="flex w-full flex-col gap-3 rounded-2xl border border-green-100 bg-white/80 p-4 text-sm text-muted-foreground shadow-sm md:w-80">
                         <div className="flex items-center gap-3">
-                            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-600/10 text-emerald-700">
+                            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-green-600/10 text-green-700">
                                 <ClipboardCheck className="h-4 w-4" />
                             </span>
                             <div>
-                                <p className="text-xs uppercase tracking-wide text-emerald-500">Today&apos;s reminders</p>
-                                <p className="font-semibold text-emerald-700">
+                                <p className="text-xs uppercase tracking-wide text-green-500">Today&apos;s reminders</p>
+                                <p className="font-semibold text-green-700">
                                     Confirm pending appointments before 4:00 PM.
                                 </p>
                             </div>
                         </div>
-                        <Separator className="border-emerald-100" />
-                        <Button asChild variant="outline" className="rounded-xl border-emerald-200 text-emerald-700 hover:bg-emerald-100/70">
+                        <Separator className="border-green-100" />
+                        <Button asChild variant="outline" className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70">
                             <Link href="/doctor/appointments">Open appointment hub</Link>
                         </Button>
                     </div>
@@ -119,12 +119,12 @@ export default function DoctorDashboardPage() {
                 {managementAreas.map(({ title, description, href, icon: Icon, cta }) => (
                     <Card
                         key={title}
-                        className="h-full rounded-3xl border-emerald-100/70 bg-white/85 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+                        className="h-full rounded-3xl border-green-100/70 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
                     >
                         <CardHeader className="flex flex-row items-start justify-between gap-3">
                             <div className="space-y-1">
-                                <CardTitle className="flex items-center gap-3 text-lg text-emerald-700">
-                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-emerald-600/10 text-emerald-700">
+                                <CardTitle className="flex items-center gap-3 text-lg text-green-700">
+                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-green-600/10 text-green-700">
                                         <Icon className="h-5 w-5" />
                                     </span>
                                     {title}
@@ -133,13 +133,13 @@ export default function DoctorDashboardPage() {
                             </div>
                         </CardHeader>
                         <CardContent>
-                            <Button asChild variant="ghost" className="rounded-xl bg-emerald-600/10 px-3 text-sm font-semibold text-emerald-700 hover:bg-emerald-600/20">
+                            <Button asChild variant="ghost" className="rounded-xl bg-green-600/10 px-3 text-sm font-semibold text-green-700 hover:bg-green-600/20">
                                 <Link href={href}>{cta}</Link>
                             </Button>
                         </CardContent>
                     </Card>
                 ))}
-                <Card className="h-full rounded-3xl border-emerald-100/70 bg-gradient-to-br from-emerald-600 via-emerald-500 to-teal-500 text-white shadow-md">
+                <Card className="h-full rounded-3xl border-green-100/70 bg-gradient-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-md">
                     <CardHeader>
                         <CardTitle className="flex items-center gap-3 text-lg">
                             <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
@@ -160,33 +160,33 @@ export default function DoctorDashboardPage() {
             </section>
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
-                <Card className="rounded-3xl border-emerald-100/70 bg-white/85 shadow-sm">
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg text-emerald-700">Operational checklist</CardTitle>
+                        <CardTitle className="text-lg text-green-700">Operational checklist</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3 text-sm text-muted-foreground">
                         <ul className="space-y-2">
                             {operationalHighlights.map((item) => (
-                                <li key={item} className="flex items-start gap-2 rounded-2xl bg-emerald-600/5 p-3">
-                                    <span className="mt-1 flex h-2.5 w-2.5 shrink-0 rounded-full bg-emerald-500" />
+                                <li key={item} className="flex items-start gap-2 rounded-2xl bg-green-600/5 p-3">
+                                    <span className="mt-1 flex h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
                                     <span>{item}</span>
                                 </li>
                             ))}
                         </ul>
                     </CardContent>
                 </Card>
-                <Card className="rounded-3xl border-emerald-100/70 bg-white/85 shadow-sm">
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg text-emerald-700">Resources</CardTitle>
+                        <CardTitle className="text-lg text-green-700">Resources</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3 text-sm text-muted-foreground">
                         <p>
                             Access updated clinic forms, incident templates, and medication guides to keep documentation consistent across the team.
                         </p>
-                        <Button asChild variant="outline" className="w-full rounded-xl border-emerald-200 text-emerald-700 hover:bg-emerald-100/70">
+                        <Button asChild variant="outline" className="w-full rounded-xl border-green-200 text-green-700 hover:bg-green-100/70">
                             <Link href="/doctor/dispense">Go to dispensing log</Link>
                         </Button>
-                        <Button asChild variant="ghost" className="w-full rounded-xl bg-emerald-600/10 text-emerald-700 hover:bg-emerald-600/20">
+                        <Button asChild variant="ghost" className="w-full rounded-xl bg-green-600/10 text-green-700 hover:bg-green-600/20">
                             <Link href="/doctor/patients">Browse patient registry</Link>
                         </Button>
                     </CardContent>

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -8,7 +8,7 @@ import {
     Stethoscope,
 } from "lucide-react";
 
-import DoctorLayout from "@/components/patient/doctor-layout";
+import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";

--- a/src/app/nurse/page.tsx
+++ b/src/app/nurse/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
     BarChart3,
+    ClipboardCheck,
     ClipboardList,
     Package,
-    Pill,
     Users,
 } from "lucide-react";
 
@@ -18,152 +19,161 @@ import {
     CardHeader,
     CardTitle,
 } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
-const CAPABILITIES = [
+const quickActions = [
     {
-        title: "Accounts Management",
-        icon: Users,
-        items: [
-            "Create user accounts",
-            "Update and verify credentials",
-            "Activate or suspend access instantly",
-        ],
-    },
-    {
-        title: "Patient Records",
-        icon: ClipboardList,
-        items: [
-            "Search complete patient histories",
-            "Maintain consultation notes",
-            "Monitor vitals and treatment plans",
-        ],
-    },
-    {
-        title: "Medicine Dispensing",
-        icon: Pill,
-        items: [
-            "Log dispensed medicines accurately",
-            "Track dosage and frequency",
-            "Preserve a clear audit trail",
-        ],
-    },
-    {
-        title: "Inventory Oversight",
+        title: "Supervise inventory",
+        description: "Monitor critical stock levels, log replenishments, and flag expiring supplies.",
+        href: "/nurse/inventory",
         icon: Package,
-        items: [
-            "Record replenishments and adjustments",
-            "Prioritize FIFO expiries",
-            "Maintain optimal stock levels",
-        ],
+        cta: "Review inventory",
     },
     {
-        title: "Performance Insights",
-        icon: BarChart3,
-        items: [
-            "Generate clinic utilization reports",
-            "Monitor medicine turnover",
-            "Share metrics with administrators",
-        ],
+        title: "Support patient records",
+        description: "Update consultation notes, upload vitals, and prepare charts for the medical team.",
+        href: "/nurse/records",
+        icon: ClipboardCheck,
+        cta: "View records",
+    },
+    {
+        title: "Administer accounts",
+        description: "Create new profiles, reset credentials, and keep access permissions current.",
+        href: "/nurse/accounts",
+        icon: Users,
+        cta: "Manage accounts",
     },
 ];
 
-const QUICK_LINKS = [
-    {
-        title: "Manage Inventory",
-        description: "Check stock levels and manage replenishment queues.",
-        href: "/nurse/inventory",
-    },
-    {
-        title: "Manage Clinic",
-        description: "Coordinate with clinic location and availability.",
-        href: "/nurse/clinic",
-    },
-    {
-        title: "Manage Accounts",
-        description: "Create new users and keep records current.",
-        href: "/nurse/accounts",
-    },
+const shiftReminders = [
+    "Verify tomorrow's appointment queue and prepare intake forms by 3:00 PM.",
+    "Coordinate with physicians on urgent follow-ups and note special care instructions.",
+    "Audit essential medicines before closing to keep the dispensary fully stocked.",
 ];
 
 export default function NurseDashboardPage() {
     const { data: session } = useSession();
     const fullName = session?.user?.name ?? "Nurse";
+    const firstName = useMemo(() => fullName.split(" ")[0] || fullName, [fullName]);
 
     return (
         <NurseLayout
             title="Dashboard Overview"
             description="Manage accounts, clinic schedules, inventory, and records with a clear operational snapshot."
             actions={
-                <Button asChild className="rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm hover:bg-green-700">
+                <Button asChild className="hidden rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm hover:bg-green-700 md:flex">
                     <Link href="/nurse/records">View Records</Link>
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-green-100/70 bg-white/80 p-6 shadow-sm backdrop-blur md:p-8">
-                <div className="grid gap-6 md:grid-cols-[1.4fr,1fr] md:items-start">
-                    <div className="space-y-4">
-                        <p className="text-sm font-semibold uppercase tracking-wider text-green-500">
-                            Welcome back
-                        </p>
-                        <h3 className="text-3xl font-semibold text-green-700 sm:text-4xl">
-                            {fullName}
-                        </h3>
-                        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-                            Keep the clinic running smoothly with quick visibility into patient appointments, supply levels,
-                            and team coordination. Use the quick actions below to jump straight into critical workflows.
+            <section className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 p-6 shadow-sm">
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                    <div className="space-y-2">
+                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-green-500">Welcome back</p>
+                        <h3 className="text-3xl font-semibold text-green-700 md:text-4xl">Hello, {firstName}</h3>
+                        <p className="max-w-2xl text-sm text-muted-foreground">
+                            Keep the clinic running smoothly with instant visibility into schedules, stock levels, and patient coordination. Use the quick tools below to support the care team.
                         </p>
                     </div>
-                    <div className="space-y-4 rounded-3xl border border-green-100 bg-green-50/60 p-6 shadow-sm">
-                        <h4 className="text-lg font-semibold text-green-700">Quick actions</h4>
-                        <div className="space-y-4">
-                            {QUICK_LINKS.map((quickLink) => (
-                                <Link
-                                    key={quickLink.title}
-                                    href={quickLink.href}
-                                    className="flex flex-col gap-1 rounded-2xl border border-green-100 bg-white/80 px-4 py-3 text-sm font-medium text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:bg-green-100/70"
-                                >
-                                    <span>{quickLink.title}</span>
-                                    <span className="text-xs font-normal text-muted-foreground">
-                                        {quickLink.description}
-                                    </span>
-                                </Link>
-                            ))}
+                    <div className="flex w-full flex-col gap-3 rounded-2xl border border-green-100 bg-white/80 p-4 text-sm text-muted-foreground shadow-sm md:w-80">
+                        <div className="flex items-center gap-3">
+                            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-green-600/10 text-green-700">
+                                <ClipboardList className="h-4 w-4" />
+                            </span>
+                            <div>
+                                <p className="text-xs uppercase tracking-wide text-green-500">Today&apos;s focus</p>
+                                <p className="font-semibold text-green-700">Verify supply counts before closeout.</p>
+                            </div>
                         </div>
+                        <Separator className="border-green-100" />
+                        <Button asChild variant="outline" className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70">
+                            <Link href="/nurse/inventory">Review inventory log</Link>
+                        </Button>
                     </div>
                 </div>
             </section>
 
-            <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-                {CAPABILITIES.map((capability) => {
-                    const Icon = capability.icon;
-                    return (
-                        <Card
-                            key={capability.title}
-                            className="h-full rounded-3xl border border-green-100/70 bg-white/80 shadow-sm transition hover:-translate-y-[2px] hover:shadow-md"
-                        >
-                            <CardHeader className="space-y-2">
-                                <div className="flex items-center gap-3 text-green-600">
-                                    <span className="rounded-2xl bg-green-100/80 p-2">
+            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+                {quickActions.map(({ title, description, href, icon: Icon, cta }) => (
+                    <Card
+                        key={title}
+                        className="h-full rounded-3xl border-green-100/70 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+                    >
+                        <CardHeader className="flex flex-row items-start justify-between gap-3">
+                            <div className="space-y-1">
+                                <CardTitle className="flex items-center gap-3 text-lg text-green-700">
+                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-green-600/10 text-green-700">
                                         <Icon className="h-5 w-5" />
                                     </span>
-                                    <CardTitle className="text-lg font-semibold text-green-700">
-                                        {capability.title}
-                                    </CardTitle>
-                                </div>
-                            </CardHeader>
-                            <CardContent>
-                                <ul className="space-y-2 text-sm text-muted-foreground">
-                                    {capability.items.map((item) => (
-                                        <li key={item} className="flex items-start gap-2">
-                                            <span className="mt-1 h-1.5 w-1.5 rounded-full bg-green-400" />
-                                            <span>{item}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </CardContent>
-                        </Card>
-                    );
-                })}
+                                    {title}
+                                </CardTitle>
+                                <p className="text-sm font-normal text-muted-foreground">{description}</p>
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <Button asChild variant="ghost" className="rounded-xl bg-green-600/10 px-3 text-sm font-semibold text-green-700 hover:bg-green-600/20">
+                                <Link href={href}>{cta}</Link>
+                            </Button>
+                        </CardContent>
+                    </Card>
+                ))}
+                <Card className="h-full rounded-3xl border-green-100/70 bg-gradient-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-3 text-lg">
+                            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
+                                <BarChart3 className="h-5 w-5" />
+                            </span>
+                            Operations insights
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
+                        <p>
+                            Align on clinic traffic peaks early to balance resources and shorten wait times for students and staff.
+                        </p>
+                        <p>
+                            Keep communication logs updated so physicians can review triage actions and respond to follow-up needs quickly.
+                        </p>
+                    </CardContent>
+                </Card>
+            </section>
+
+            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-green-700">How to keep clinic flow steady</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm text-muted-foreground">
+                        <p>
+                            Review pending appointments each morning and pre-stage the necessary charts and equipment so care teams can begin on time.
+                        </p>
+                        <p>
+                            Document every dispensing and inventory update as it happens. Accurate logs keep compliance effortless during audits.
+                        </p>
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                            <Button asChild variant="outline" className="w-full rounded-xl border-green-200 text-green-700 hover:bg-green-100/70">
+                                <Link href="/nurse/dispense">Open dispensing log</Link>
+                            </Button>
+                            <Button asChild variant="ghost" className="w-full rounded-xl bg-green-600/10 text-green-700 hover:bg-green-600/20">
+                                <Link href="/nurse/clinic">View clinic schedule</Link>
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-green-700">Shift reminders</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2 text-sm text-muted-foreground">
+                        <ul className="space-y-2">
+                            {shiftReminders.map((tip) => (
+                                <li key={tip} className="flex items-start gap-2 rounded-2xl bg-green-600/5 p-3">
+                                    <span className="mt-1 flex h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
+                                    <span>{tip}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </CardContent>
+                </Card>
             </section>
         </NurseLayout>
     );

--- a/src/components/doctor/doctor-layout.tsx
+++ b/src/components/doctor/doctor-layout.tsx
@@ -91,16 +91,16 @@ export function DoctorLayout({
                         href={item.href}
                         className={cn(
                             "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
-                            "hover:bg-emerald-100/70 hover:text-emerald-700",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-emerald-50",
-                            isActive && "bg-white text-emerald-700 shadow-sm"
+                            "hover:bg-green-100/70 hover:text-green-700",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-green-50",
+                            isActive && "bg-white text-green-700 shadow-sm"
                         )}
                         onClick={() => setMobileOpen(false)}
                     >
                         <Icon
                             className={cn(
                                 "h-4 w-4",
-                                isActive ? "text-emerald-700" : "text-gray-600"
+                                isActive ? "text-green-700" : "text-gray-600"
                             )}
                         />
                         {item.label}
@@ -111,9 +111,9 @@ export function DoctorLayout({
     );
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-emerald-100">
+        <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-100">
             <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 pb-8 pt-6 md:flex-row md:gap-8 md:px-6 lg:px-8">
-                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-emerald-100/80 bg-white/85 p-6 shadow-sm backdrop-blur lg:flex">
+                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-green-100/80 bg-white/80 p-6 shadow-sm backdrop-blur lg:flex">
                     <div className="flex items-center gap-3 pb-6">
                         <Image
                             src="/clinic-illustration.svg"
@@ -123,27 +123,27 @@ export function DoctorLayout({
                             className="h-11 w-11 object-contain drop-shadow"
                         />
                         <div>
-                            <p className="text-xs uppercase tracking-wide text-emerald-500">Clinical Operations</p>
-                            <h1 className="text-xl font-semibold text-emerald-700">HNU Clinic</h1>
+                            <p className="text-xs uppercase tracking-wide text-green-500">Health & Wellness</p>
+                            <h1 className="text-xl font-semibold text-green-700">HNU Clinic</h1>
                         </div>
                     </div>
-                    <div className="mb-6 flex items-center gap-3 rounded-2xl border border-emerald-100 bg-emerald-50/80 p-4">
-                        <Avatar className="h-12 w-12 border border-emerald-100">
+                    <div className="mb-6 flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
+                        <Avatar className="h-12 w-12 border border-green-100">
                             <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                            <AvatarFallback className="bg-emerald-200 text-emerald-800">
+                            <AvatarFallback className="bg-green-200 text-green-800">
                                 {avatarFallback}
                             </AvatarFallback>
                         </Avatar>
                         <div>
-                            <p className="text-xs text-emerald-500">Signed in as</p>
-                            <p className="text-sm font-semibold text-emerald-700">{fullName}</p>
+                            <p className="text-xs text-green-500">Signed in as</p>
+                            <p className="text-sm font-semibold text-green-700">{fullName}</p>
                         </div>
                     </div>
                     {navLinks}
                     <Separator className="my-6" />
                     <Button
                         variant="default"
-                        className="mt-auto w-full gap-2 rounded-xl bg-emerald-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-emerald-700"
+                        className="mt-auto w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-green-700"
                         onClick={handleLogout}
                         disabled={isLoggingOut}
                     >
@@ -159,12 +159,12 @@ export function DoctorLayout({
                 </aside>
 
                 <div className="flex flex-1 flex-col">
-                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-emerald-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/60 md:px-6">
+                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-green-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/60 md:px-6">
                         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                             <div className="space-y-3">
                                 <Link
                                     href="/doctor"
-                                    className="flex items-center gap-3 rounded-2xl border border-emerald-100 bg-white/90 px-3 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:-translate-y-[1px] hover:bg-emerald-100/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                    className="flex items-center gap-3 rounded-2xl border border-green-100 bg-white/90 px-3 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:bg-green-100/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
                                 >
                                     <Image
                                         src="/clinic-illustration.svg"
@@ -175,10 +175,10 @@ export function DoctorLayout({
                                     />
                                     <span>HNU Clinic</span>
                                 </Link>
-                                <p className="text-xs font-semibold uppercase tracking-wider text-emerald-500">
+                                <p className="text-xs font-semibold uppercase tracking-wider text-green-500">
                                     Doctor Panel
                                 </p>
-                                <h2 className="text-2xl font-semibold text-emerald-700 md:text-3xl">{title}</h2>
+                                <h2 className="text-2xl font-semibold text-green-700 md:text-3xl">{title}</h2>
                                 {description ? (
                                     <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
                                 ) : null}
@@ -190,36 +190,36 @@ export function DoctorLayout({
                                         <Button
                                             variant="outline"
                                             size="icon"
-                                            className="rounded-xl border-emerald-200 text-emerald-700 hover:bg-emerald-100/80 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
                                             aria-label="Open doctor navigation"
                                         >
                                             <Menu className="h-5 w-5" />
                                         </Button>
                                     </SheetTrigger>
-                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-emerald-100 bg-gradient-to-b from-white to-emerald-50/60 p-0">
-                                        <SheetHeader className="border-b border-emerald-100 bg-white/80 p-6">
-                                            <SheetTitle className="flex items-center gap-3 text-lg text-emerald-700">
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0">
+                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6">
+                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700">
                                                 <Menu className="h-5 w-5" />
                                                 Doctor Navigation
                                             </SheetTitle>
                                         </SheetHeader>
                                         <div className="space-y-6 px-6 py-6">
-                                            <div className="flex items-center gap-3 rounded-2xl border border-emerald-100 bg-emerald-50/80 p-4">
-                                                <Avatar className="h-11 w-11 border border-emerald-100">
+                                            <div className="flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
+                                                <Avatar className="h-11 w-11 border border-green-100">
                                                     <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                                                    <AvatarFallback className="bg-emerald-200 text-emerald-800">
+                                                    <AvatarFallback className="bg-green-200 text-green-800">
                                                         {avatarFallback}
                                                     </AvatarFallback>
                                                 </Avatar>
                                                 <div>
-                                                    <p className="text-xs text-emerald-500">Signed in as</p>
-                                                    <p className="text-sm font-semibold text-emerald-700">{fullName}</p>
+                                                    <p className="text-xs text-green-500">Signed in as</p>
+                                                    <p className="text-sm font-semibold text-green-700">{fullName}</p>
                                                 </div>
                                             </div>
                                             {navLinks}
                                             <Button
                                                 variant="default"
-                                                className="w-full gap-2 rounded-xl bg-emerald-600 font-semibold text-white shadow-sm hover:bg-emerald-700"
+                                                className="w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm hover:bg-green-700"
                                                 onClick={handleLogout}
                                                 disabled={isLoggingOut}
                                             >
@@ -241,7 +241,7 @@ export function DoctorLayout({
 
                     <main className="flex-1 space-y-6">{children}</main>
 
-                    <footer className="mt-10 rounded-3xl border border-emerald-100/70 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
+                    <footer className="mt-10 rounded-3xl border border-green-100/70 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
                         {footerNote ?? <>© {new Date().getFullYear()} HNU Clinic – Doctor Panel</>}
                     </footer>
                 </div>


### PR DESCRIPTION
## Summary
- move the doctor layout into a dedicated components/doctor directory and refresh its styling to match the patient panel palette
- retheme the doctor dashboard cards, hero banner, and calls to action so they follow the patient panel design language
- rebuild the nurse dashboard into patient-style sections with matching quick actions, gradients, and reminders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f14ff5f7608333819fde4be0ee3611