### PR TITLE
Delete cancelled appointments for doctors and patients

### DIFF
--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -337,9 +337,8 @@ export async function DELETE(req: Request) {
             );
         }
 
-        await prisma.appointment.update({
+        await prisma.appointment.delete({
             where: { appointment_id },
-            data: { status: AppointmentStatus.Cancelled },
         });
 
         return NextResponse.json({ message: "Appointment cancelled" });


### PR DESCRIPTION
## Summary
- remove doctor appointment cancellation updates in favor of deleting the appointment record after notifying the patient
- delete patient appointments from the database when the patient cancels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f194238e30833381fa905094d9ba75