### PR TITLE
Add scholar appointment and patient management interfaces

### DIFF
--- a/src/app/api/scholar/appointments/route.ts
+++ b/src/app/api/scholar/appointments/route.ts
@@ -1,0 +1,260 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { AppointmentStatus, Prisma, Role } from "@prisma/client";
+
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { manilaNow } from "@/lib/time";
+
+function parseDate(value: string | null, type: "start" | "end") {
+    if (!value) return null;
+    const iso = type === "start" ? `${value}T00:00:00+08:00` : `${value}T23:59:59+08:00`;
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function buildPatientName(patient: {
+    username: string;
+    student: { fname: string | null; mname: string | null; lname: string | null } | null;
+    employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+}) {
+    const student = patient.student;
+    if (student) {
+        return [student.fname, student.mname, student.lname].filter(Boolean).join(" ") || patient.username;
+    }
+    const employee = patient.employee;
+    if (employee) {
+        return [employee.fname, employee.mname, employee.lname].filter(Boolean).join(" ") || patient.username;
+    }
+    return patient.username;
+}
+
+function buildPatientIdentifier(patient: {
+    student: { student_id: string } | null;
+    employee: { employee_id: string } | null;
+}) {
+    if (patient.student?.student_id) return patient.student.student_id;
+    if (patient.employee?.employee_id) return patient.employee.employee_id;
+    return "";
+}
+
+function buildPatientType(patient: {
+    student: { student_id: string } | null;
+    employee: { employee_id: string } | null;
+}) {
+    if (patient.student) return "Student";
+    if (patient.employee) return "Employee";
+    return "Patient";
+}
+
+function buildStaffName(staff: {
+    username: string;
+    employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+    student: { fname: string | null; mname: string | null; lname: string | null } | null;
+} | null) {
+    if (!staff) return "";
+    const employee = staff.employee;
+    if (employee) {
+        return [employee.fname, employee.mname, employee.lname].filter(Boolean).join(" ") || staff.username;
+    }
+    const student = staff.student;
+    if (student) {
+        return [student.fname, student.mname, student.lname].filter(Boolean).join(" ") || staff.username;
+    }
+    return staff.username;
+}
+
+const ACTIVE_STATUSES: AppointmentStatus[] = [
+    AppointmentStatus.Pending,
+    AppointmentStatus.Approved,
+    AppointmentStatus.Moved,
+];
+
+export async function GET(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const account = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { role: true },
+        });
+
+        if (!account || account.role !== Role.SCHOLAR) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const url = new URL(req.url);
+        const statusParam = url.searchParams.get("status");
+        const fromParam = url.searchParams.get("from");
+        const toParam = url.searchParams.get("to");
+        const takeParam = url.searchParams.get("take");
+
+        const now = manilaNow();
+        const defaultFrom = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        const defaultTo = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+        const appointmentWhere: Prisma.AppointmentWhereInput = {
+            appointment_timestart: {
+                gte: parseDate(fromParam, "start") ?? defaultFrom,
+                lte: parseDate(toParam, "end") ?? defaultTo,
+            },
+        };
+
+        if (statusParam && statusParam !== "all") {
+            if (statusParam === "active") {
+                appointmentWhere.status = { in: ACTIVE_STATUSES };
+            } else if ((Object.values(AppointmentStatus) as string[]).includes(statusParam)) {
+                appointmentWhere.status = statusParam as AppointmentStatus;
+            }
+        }
+
+        const take = takeParam ? Number.parseInt(takeParam, 10) : 200;
+
+        const appointments = await prisma.appointment.findMany({
+            where: appointmentWhere,
+            orderBy: { appointment_timestart: "asc" },
+            take: Number.isNaN(take) ? 200 : Math.min(Math.max(take, 1), 500),
+            include: {
+                clinic: { select: { clinic_id: true, clinic_name: true } },
+                doctor: {
+                    select: {
+                        user_id: true,
+                        username: true,
+                        employee: { select: { fname: true, mname: true, lname: true } },
+                        student: { select: { fname: true, mname: true, lname: true } },
+                    },
+                },
+                patient: {
+                    select: {
+                        user_id: true,
+                        username: true,
+                        student: {
+                            select: {
+                                student_id: true,
+                                fname: true,
+                                mname: true,
+                                lname: true,
+                            },
+                        },
+                        employee: {
+                            select: {
+                                employee_id: true,
+                                fname: true,
+                                mname: true,
+                                lname: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        const formatted = appointments.map((appointment) => ({
+            id: appointment.appointment_id,
+            clinic: {
+                id: appointment.clinic_id,
+                name: appointment.clinic?.clinic_name ?? "",
+            },
+            doctor: {
+                id: appointment.doctor_user_id,
+                name: buildStaffName(appointment.doctor),
+            },
+            patient: {
+                id: appointment.patient_user_id,
+                name: buildPatientName(appointment.patient),
+                identifier: buildPatientIdentifier(appointment.patient),
+                type: buildPatientType(appointment.patient),
+            },
+            start: appointment.appointment_timestart.toISOString(),
+            end: appointment.appointment_timeend.toISOString(),
+            serviceType: appointment.service_type,
+            status: appointment.status,
+            remarks: appointment.remarks ?? "",
+            createdAt: appointment.createdAt.toISOString(),
+            updatedAt: appointment.updatedAt.toISOString(),
+        }));
+
+        return NextResponse.json(formatted);
+    } catch (err) {
+        console.error("[GET /api/scholar/appointments]", err);
+        return NextResponse.json(
+            { error: "Failed to fetch appointments" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PATCH(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const account = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { role: true },
+        });
+
+        if (!account || account.role !== Role.SCHOLAR) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const payload = await req.json();
+        const appointmentId = payload?.appointment_id as string | undefined;
+        const newStatus = payload?.status as AppointmentStatus | undefined;
+        const remarks = typeof payload?.remarks === "string" ? payload.remarks : undefined;
+
+        if (!appointmentId) {
+            return NextResponse.json({ error: "Appointment ID is required" }, { status: 400 });
+        }
+
+        if (newStatus && !(Object.values(AppointmentStatus) as AppointmentStatus[]).includes(newStatus)) {
+            return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+        }
+
+        const existing = await prisma.appointment.findUnique({
+            where: { appointment_id: appointmentId },
+            select: { appointment_id: true },
+        });
+
+        if (!existing) {
+            return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
+        }
+
+        const data: Prisma.AppointmentUpdateInput = {};
+        if (newStatus) data.status = newStatus;
+        if (typeof remarks === "string") data.remarks = remarks;
+
+        if (Object.keys(data).length === 0) {
+            return NextResponse.json({ error: "No updates provided" }, { status: 400 });
+        }
+
+        const updated = await prisma.appointment.update({
+            where: { appointment_id: appointmentId },
+            data,
+            select: {
+                appointment_id: true,
+                status: true,
+                remarks: true,
+                updatedAt: true,
+            },
+        });
+
+        return NextResponse.json({
+            appointment_id: updated.appointment_id,
+            status: updated.status,
+            remarks: updated.remarks ?? "",
+            updatedAt: updated.updatedAt.toISOString(),
+        });
+    } catch (err) {
+        console.error("[PATCH /api/scholar/appointments]", err);
+        return NextResponse.json(
+            { error: "Failed to update appointment" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/scholar/patients/route.ts
+++ b/src/app/api/scholar/patients/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { Role } from "@prisma/client";
+
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { fetchPatientRecords } from "@/lib/patient-records";
+
+function matchesSearch(value: string | null | undefined, search: string) {
+    if (!value) return false;
+    return value.toLowerCase().includes(search);
+}
+
+export async function GET(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const account = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { role: true },
+        });
+
+        if (!account || account.role !== Role.SCHOLAR) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const url = new URL(req.url);
+        const typeParam = url.searchParams.get("type")?.toLowerCase();
+        const statusParam = url.searchParams.get("status")?.toLowerCase();
+        const searchParam = url.searchParams.get("search")?.toLowerCase().trim() ?? "";
+        const withAppointment = url.searchParams.get("withAppointment");
+
+        const records = await fetchPatientRecords();
+
+        const filtered = records.filter((record) => {
+            if (typeParam && typeParam !== "all") {
+                if (typeParam === "student" && record.patientType !== "Student") return false;
+                if (typeParam === "employee" && record.patientType !== "Employee") return false;
+            }
+
+            if (statusParam && statusParam !== "all") {
+                if (record.status.toLowerCase() !== statusParam) return false;
+            }
+
+            if (withAppointment === "yes" && !record.latestAppointment) return false;
+            if (withAppointment === "no" && record.latestAppointment) return false;
+
+            if (searchParam) {
+                const haystack = [
+                    record.fullName,
+                    record.patientId,
+                    record.patientType,
+                    record.department,
+                    record.program,
+                    record.year_level,
+                    record.contactno,
+                    record.address,
+                    record.emergency?.name,
+                    record.emergency?.num,
+                    record.emergency?.relation,
+                ];
+
+                const matchFound = haystack.some((item) => matchesSearch(item ?? undefined, searchParam));
+                if (!matchFound) return false;
+            }
+
+            return true;
+        });
+
+        return NextResponse.json(filtered);
+    } catch (err) {
+        console.error("[GET /api/scholar/patients]", err);
+        return NextResponse.json(
+            { error: "Failed to fetch patient list" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+    AlertCircle,
+    CalendarDays,
+    CheckCircle2,
+    Clock3,
+    Loader2,
+    RefreshCcw,
+    Search,
+} from "lucide-react";
+
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { AppointmentPanel } from "@/components/appointments/appointment-panel";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { formatManilaDateTime } from "@/lib/time";
+
+const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
+
+type AppointmentStatus = (typeof STATUS_ORDER)[number];
+
+type ScholarAppointment = {
+    id: string;
+    clinic: {
+        id: string;
+        name: string;
+    };
+    doctor: {
+        id: string;
+        name: string;
+    };
+    patient: {
+        id: string;
+        name: string;
+        identifier: string;
+        type: string;
+    };
+    start: string;
+    end: string;
+    serviceType: string | null;
+    status: AppointmentStatus;
+    remarks: string;
+    createdAt: string;
+    updatedAt: string;
+};
+
+const STATUS_LABELS: Record<AppointmentStatus, string> = {
+    Pending: "Awaiting review",
+    Approved: "Confirmed",
+    Moved: "Rescheduled",
+    Completed: "Completed",
+    Cancelled: "Cancelled",
+};
+
+const STATUS_BADGE_CLASSES: Record<AppointmentStatus, string> = {
+    Pending: "border-amber-200 bg-amber-50 text-amber-700",
+    Approved: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    Moved: "border-sky-200 bg-sky-50 text-sky-700",
+    Completed: "border-slate-200 bg-slate-100 text-slate-700",
+    Cancelled: "border-rose-200 bg-rose-50 text-rose-700",
+};
+
+const ACTIVE_STATUSES: AppointmentStatus[] = ["Pending", "Approved", "Moved"];
+
+function isToday(value: string) {
+    const today = new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+    const date = new Date(value).toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+    return today === date;
+}
+
+function formatDateOnly(value: string) {
+    return formatManilaDateTime(value, {
+        hour: undefined,
+        minute: undefined,
+    });
+}
+
+function formatTimeOnly(value: string) {
+    return formatManilaDateTime(value, {
+        year: undefined,
+        month: undefined,
+        day: undefined,
+    });
+}
+
+function formatTimeWindow(start: string, end: string) {
+    const startText = formatTimeOnly(start);
+    const endText = formatTimeOnly(end);
+    return endText ? `${startText} – ${endText}` : startText;
+}
+
+export default function ScholarAppointmentsPage() {
+    const [appointments, setAppointments] = useState<ScholarAppointment[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [search, setSearch] = useState("");
+    const [statusFilter, setStatusFilter] = useState<string>("active");
+    const [manageOpen, setManageOpen] = useState(false);
+    const [selected, setSelected] = useState<ScholarAppointment | null>(null);
+    const [updateStatus, setUpdateStatus] = useState<AppointmentStatus | "">("");
+    const [updateRemarks, setUpdateRemarks] = useState("");
+    const [updating, setUpdating] = useState(false);
+
+    const loadAppointments = useCallback(async () => {
+        try {
+            setLoading(true);
+            const res = await fetch("/api/scholar/appointments?status=all", { cache: "no-store" });
+            const data = await res.json();
+            if (!res.ok) {
+                toast.error(data?.error ?? "Failed to load appointments");
+                return;
+            }
+            setAppointments(Array.isArray(data) ? data : []);
+        } catch (err) {
+            console.error(err);
+            toast.error("Unable to load appointments");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadAppointments();
+    }, [loadAppointments]);
+
+    const searchTerm = search.trim().toLowerCase();
+
+    const filteredAppointments = useMemo(() => {
+        return appointments.filter((appointment) => {
+            if (statusFilter && statusFilter !== "all") {
+                if (statusFilter === "active" && !ACTIVE_STATUSES.includes(appointment.status)) {
+                    return false;
+                }
+                if (
+                    statusFilter !== "active" &&
+                    appointment.status.toLowerCase() !== statusFilter.toLowerCase()
+                ) {
+                    return false;
+                }
+            }
+
+            if (!searchTerm) return true;
+
+            const haystack = [
+                appointment.patient.name,
+                appointment.patient.identifier,
+                appointment.patient.type,
+                appointment.doctor.name,
+                appointment.clinic.name,
+                appointment.serviceType ?? "",
+                appointment.status,
+                appointment.remarks,
+            ]
+                .join(" ")
+                .toLowerCase();
+
+            return haystack.includes(searchTerm);
+        });
+    }, [appointments, searchTerm, statusFilter]);
+
+    const statusCounts = useMemo(() => {
+        const counts: Record<AppointmentStatus, number> = {
+            Pending: 0,
+            Approved: 0,
+            Moved: 0,
+            Completed: 0,
+            Cancelled: 0,
+        };
+        for (const appointment of appointments) {
+            counts[appointment.status] += 1;
+        }
+        return counts;
+    }, [appointments]);
+
+    const activeAppointments = useMemo(
+        () => appointments.filter((appointment) => ACTIVE_STATUSES.includes(appointment.status)),
+        [appointments]
+    );
+
+    const todayAppointments = useMemo(
+        () => appointments.filter((appointment) => isToday(appointment.start)),
+        [appointments]
+    );
+
+    const nextAppointment = useMemo(() => {
+        const upcoming = activeAppointments
+            .filter((appointment) => new Date(appointment.start).getTime() >= Date.now())
+            .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+        return upcoming[0] ?? null;
+    }, [activeAppointments]);
+
+    function openManageDialog(appointment: ScholarAppointment) {
+        setSelected(appointment);
+        setUpdateStatus(appointment.status);
+        setUpdateRemarks(appointment.remarks ?? "");
+        setManageOpen(true);
+    }
+
+    function closeManageDialog() {
+        setManageOpen(false);
+        setSelected(null);
+        setUpdateStatus("");
+        setUpdateRemarks("");
+    }
+
+    const handleUpdateSubmit = useCallback(
+        async (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            if (!selected || !updateStatus) {
+                toast.error("Select a new status before saving");
+                return;
+            }
+
+            try {
+                setUpdating(true);
+                const res = await fetch("/api/scholar/appointments", {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        appointment_id: selected.id,
+                        status: updateStatus,
+                        remarks: updateRemarks,
+                    }),
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    toast.error(data?.error ?? "Failed to update appointment");
+                    return;
+                }
+                toast.success("Appointment updated");
+                closeManageDialog();
+                loadAppointments();
+            } catch (err) {
+                console.error(err);
+                toast.error("Unable to update appointment");
+            } finally {
+                setUpdating(false);
+            }
+        },
+        [loadAppointments, selected, updateRemarks, updateStatus]
+    );
+
+    return (
+        <ScholarLayout
+            title="Appointment coordination"
+            description="Track campus clinic bookings, monitor status changes, and keep students informed about their schedules."
+            actions={
+                <Button variant="outline" onClick={loadAppointments} className="rounded-xl">
+                    <RefreshCcw className="mr-2 h-4 w-4" /> Refresh
+                </Button>
+            }
+        >
+            <div className="flex flex-col gap-6">
+                <section className="grid gap-4 md:grid-cols-3">
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">
+                                    Active queue
+                                </CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Pending, approved, and moved appointments
+                                </p>
+                            </div>
+                            <Clock3 className="h-9 w-9 text-green-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">
+                                {activeAppointments.length}
+                            </p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">
+                                    Today&apos;s visits
+                                </CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Appointments scheduled for today
+                                </p>
+                            </div>
+                            <CalendarDays className="h-9 w-9 text-green-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">
+                                {todayAppointments.length}
+                            </p>
+                            {nextAppointment ? (
+                                <p className="mt-2 text-xs text-muted-foreground">
+                                    Next: {nextAppointment.patient.name} at {formatTimeOnly(nextAppointment.start)}
+                                </p>
+                            ) : null}
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">
+                                    Pending approvals
+                                </CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Requests awaiting confirmation
+                                </p>
+                            </div>
+                            <AlertCircle className="h-9 w-9 text-amber-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">
+                                {statusCounts.Pending}
+                            </p>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <AppointmentPanel
+                    icon={CalendarDays}
+                    title="Appointment board"
+                    description="Filter bookings, verify walk-ins, and notify the medical team when schedules shift."
+                    actions={
+                        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                            <div className="flex items-center gap-2">
+                                <span className="h-2 w-2 rounded-full bg-emerald-500" /> Confirmed
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="h-2 w-2 rounded-full bg-amber-500" /> Pending
+                            </div>
+                        </div>
+                    }
+                    contentClassName="pt-4"
+                >
+                    <div className="flex flex-col gap-4">
+                        <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_200px]">
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Search queue</Label>
+                                <div className="relative">
+                                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                    <Input
+                                        placeholder="Search by name, ID, clinic, or note"
+                                        value={search}
+                                        onChange={(event) => setSearch(event.target.value)}
+                                        className="rounded-xl border-green-200 pl-9"
+                                    />
+                                </div>
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Status filter</Label>
+                                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                                    <SelectTrigger className="rounded-xl border-green-200">
+                                        <SelectValue placeholder="All statuses" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all">All statuses</SelectItem>
+                                        <SelectItem value="active">Active queue</SelectItem>
+                                        {STATUS_ORDER.map((status) => (
+                                            <SelectItem key={status} value={status.toLowerCase()}>
+                                                {STATUS_LABELS[status]}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+
+                        <div className="overflow-x-auto">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
+                                        <TableHead className="min-w-[160px]">Patient</TableHead>
+                                        <TableHead className="min-w-[160px]">Clinic</TableHead>
+                                        <TableHead className="min-w-[140px]">Doctor</TableHead>
+                                        <TableHead className="min-w-[110px]">Date</TableHead>
+                                        <TableHead className="min-w-[140px]">Time</TableHead>
+                                        <TableHead className="min-w-[120px]">Status</TableHead>
+                                        <TableHead className="min-w-[120px]">Service</TableHead>
+                                        <TableHead className="w-[100px] text-right">Actions</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {loading ? (
+                                        <TableRow>
+                                            <TableCell colSpan={8} className="h-32 text-center text-muted-foreground">
+                                                <div className="flex items-center justify-center gap-2 text-sm">
+                                                    <Loader2 className="h-4 w-4 animate-spin" /> Loading appointments...
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    ) : filteredAppointments.length === 0 ? (
+                                        <TableRow>
+                                            <TableCell colSpan={8} className="h-32 text-center text-muted-foreground">
+                                                No appointments match your filters.
+                                            </TableCell>
+                                        </TableRow>
+                                    ) : (
+                                        filteredAppointments.map((appointment) => (
+                                            <TableRow key={appointment.id} className="text-sm">
+                                                <TableCell className="font-medium text-green-700">
+                                                    <div className="flex flex-col">
+                                                        <span>{appointment.patient.name}</span>
+                                                        <span className="text-xs text-muted-foreground">
+                                                            {appointment.patient.type}
+                                                            {appointment.patient.identifier
+                                                                ? ` • ${appointment.patient.identifier}`
+                                                                : ""}
+                                                        </span>
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="flex flex-col">
+                                                        <span className="font-medium">{appointment.clinic.name || "—"}</span>
+                                                        <span className="text-xs text-muted-foreground">
+                                                            Created {formatManilaDateTime(appointment.createdAt)}
+                                                        </span>
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>{appointment.doctor.name || "—"}</TableCell>
+                                                <TableCell>{formatDateOnly(appointment.start)}</TableCell>
+                                                <TableCell>{formatTimeWindow(appointment.start, appointment.end)}</TableCell>
+                                                <TableCell>
+                                                    <Badge className={cn("rounded-full px-2 py-1 text-xs", STATUS_BADGE_CLASSES[appointment.status])}>
+                                                        {STATUS_LABELS[appointment.status]}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell>{appointment.serviceType ?? "—"}</TableCell>
+                                                <TableCell className="text-right">
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="rounded-xl text-green-700 hover:bg-green-100"
+                                                        onClick={() => openManageDialog(appointment)}
+                                                    >
+                                                        Manage
+                                                    </Button>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    </div>
+                </AppointmentPanel>
+            </div>
+
+            <Dialog open={manageOpen} onOpenChange={setManageOpen}>
+                <DialogContent className="rounded-3xl sm:max-w-lg">
+                    <form onSubmit={handleUpdateSubmit} className="space-y-4">
+                        <DialogHeader>
+                            <DialogTitle className="text-xl text-green-700">Manage appointment</DialogTitle>
+                            <DialogDescription className="text-sm text-muted-foreground">
+                                Update the appointment status or add front-desk notes visible to the care team.
+                            </DialogDescription>
+                        </DialogHeader>
+                        {selected ? (
+                            <div className="rounded-2xl bg-green-50/70 p-4 text-sm text-green-700">
+                                <p className="font-semibold">{selected.patient.name}</p>
+                                <p className="text-xs text-muted-foreground">
+                                    {selected.clinic.name || "Unassigned clinic"} • {formatDateOnly(selected.start)} • {" "}
+                                    {formatTimeWindow(selected.start, selected.end)}
+                                </p>
+                            </div>
+                        ) : null}
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium text-green-700">Status</Label>
+                            <Select
+                                value={updateStatus || undefined}
+                                onValueChange={(value) => setUpdateStatus(value as AppointmentStatus)}
+                            >
+                                <SelectTrigger className="rounded-xl border-green-200">
+                                    <SelectValue placeholder="Select status" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {STATUS_ORDER.map((status) => (
+                                        <SelectItem key={status} value={status}>
+                                            {STATUS_LABELS[status]}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium text-green-700">Front-desk notes</Label>
+                            <Textarea
+                                value={updateRemarks}
+                                onChange={(event) => setUpdateRemarks(event.target.value)}
+                                className="min-h-[120px] rounded-2xl border-green-200"
+                                placeholder="Leave context for the nurses or doctors (optional)"
+                            />
+                        </div>
+                        <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                            <Button type="button" variant="outline" onClick={closeManageDialog} className="rounded-xl">
+                                Cancel
+                            </Button>
+                            <Button
+                                type="submit"
+                                className="rounded-xl bg-green-600 text-white hover:bg-green-700"
+                                disabled={updating}
+                            >
+                                {updating ? (
+                                    <>
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving
+                                    </>
+                                ) : (
+                                    <>
+                                        <CheckCircle2 className="mr-2 h-4 w-4" /> Save changes
+                                    </>
+                                )}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+        </ScholarLayout>
+    );
+}

--- a/src/app/scholar/patients/page.tsx
+++ b/src/app/scholar/patients/page.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { AlertCircle, BadgeCheck, HeartPulse, Loader2, RefreshCcw, Search, Users2 } from "lucide-react";
+
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { formatManilaDateTime } from "@/lib/time";
+import { cn } from "@/lib/utils";
+
+const DEPARTMENT_LABELS: Record<string, string> = {
+    EDUCATION: "College of Education",
+    ARTS_AND_SCIENCES: "College of Arts and Sciences",
+    BUSINESS_AND_ACCOUNTANCY: "College of Business and Accountancy",
+    ENGINEERING_AND_COMPUTER_STUDIES: "College of Engineering and Computer Studies",
+    HEALTH_SCIENCES: "College of Health Sciences",
+    LAW: "College of Law",
+    BASIC_EDUCATION: "Basic Education Department",
+};
+
+const YEAR_LEVEL_LABELS: Record<string, string> = {
+    FIRST_YEAR: "1st Year",
+    SECOND_YEAR: "2nd Year",
+    THIRD_YEAR: "3rd Year",
+    FOURTH_YEAR: "4th Year",
+    FIFTH_YEAR: "5th Year",
+    KINDERGARTEN: "Kindergarten",
+    ELEMENTARY: "Elementary",
+    JUNIOR_HIGH: "Junior High School",
+    SENIOR_HIGH: "Senior High School",
+};
+
+const BLOOD_TYPE_LABELS: Record<string, string> = {
+    A_POS: "A+",
+    A_NEG: "A-",
+    B_POS: "B+",
+    B_NEG: "B-",
+    AB_POS: "AB+",
+    AB_NEG: "AB-",
+    O_POS: "O+",
+    O_NEG: "O-",
+};
+
+type StaffSummary = {
+    id: string;
+    username: string;
+    fullName: string | null;
+};
+
+type ConsultationSummary = {
+    id: string;
+    reason_of_visit: string | null;
+    findings: string | null;
+    diagnosis: string | null;
+    updatedAt: string | null;
+    doctor: StaffSummary | null;
+    nurse: StaffSummary | null;
+};
+
+type PatientRecord = {
+    id: string;
+    patientId: string;
+    fullName: string;
+    patientType: "Student" | "Employee";
+    gender: string | null;
+    date_of_birth: string | null;
+    status: string;
+    department?: string | null;
+    program?: string | null;
+    year_level?: string | null;
+    contactno?: string | null;
+    address?: string | null;
+    bloodtype?: string | null;
+    allergies?: string | null;
+    medical_cond?: string | null;
+    emergency?: {
+        name?: string | null;
+        num?: string | null;
+        relation?: string | null;
+    };
+    appointment_id: string | null;
+    latestAppointment: {
+        id: string;
+        timestart: string | null;
+        timeend: string | null;
+        doctor: StaffSummary | null;
+        consultation: ConsultationSummary | null;
+    } | null;
+};
+
+const PATIENT_STATUS_CLASSES: Record<string, string> = {
+    active: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    inactive: "border-slate-200 bg-slate-100 text-slate-700",
+};
+
+function humanize(value: string | null | undefined) {
+    if (!value) return "—";
+    if (DEPARTMENT_LABELS[value]) return DEPARTMENT_LABELS[value];
+    if (YEAR_LEVEL_LABELS[value]) return YEAR_LEVEL_LABELS[value];
+    if (BLOOD_TYPE_LABELS[value]) return BLOOD_TYPE_LABELS[value];
+    if (/^[A-Z0-9_]+$/.test(value)) {
+        return value
+            .toLowerCase()
+            .split("_")
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(" ");
+    }
+    return value;
+}
+
+function formatAppointmentWindow(appointment: PatientRecord["latestAppointment"]) {
+    if (!appointment?.timestart) return "—";
+    const start = formatManilaDateTime(appointment.timestart);
+    const end = appointment.timeend
+        ? formatManilaDateTime(appointment.timeend, {
+              year: undefined,
+              month: undefined,
+              day: undefined,
+          })
+        : null;
+    return end ? `${start} – ${end}` : start;
+}
+
+function formatStaffName(staff?: StaffSummary | null) {
+    if (!staff) return "—";
+    return staff.fullName || staff.username || "—";
+}
+
+function formatDOB(value: string | null | undefined) {
+    if (!value) return "—";
+    return formatManilaDateTime(value, {
+        hour: undefined,
+        minute: undefined,
+    });
+}
+
+export default function ScholarPatientsPage() {
+    const [records, setRecords] = useState<PatientRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [search, setSearch] = useState("");
+    const [typeFilter, setTypeFilter] = useState("all");
+    const [statusFilter, setStatusFilter] = useState("active");
+    const [appointmentFilter, setAppointmentFilter] = useState("all");
+    const [selected, setSelected] = useState<PatientRecord | null>(null);
+    const [detailOpen, setDetailOpen] = useState(false);
+
+    const loadRecords = useCallback(async () => {
+        try {
+            setLoading(true);
+            const query = new URLSearchParams();
+            query.set("type", "all");
+            query.set("status", "all");
+            const res = await fetch(`/api/scholar/patients?${query.toString()}`, { cache: "no-store" });
+            const data = await res.json();
+            if (!res.ok) {
+                toast.error(data?.error ?? "Failed to fetch patient list");
+                return;
+            }
+            setRecords(Array.isArray(data) ? data : []);
+        } catch (err) {
+            console.error(err);
+            toast.error("Unable to load patients");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadRecords();
+    }, [loadRecords]);
+
+    useEffect(() => {
+        if (!detailOpen) {
+            setSelected(null);
+        }
+    }, [detailOpen]);
+
+    const searchTerm = search.trim().toLowerCase();
+
+    const filteredRecords = useMemo(() => {
+        return records.filter((record) => {
+            if (typeFilter !== "all" && record.patientType.toLowerCase() !== typeFilter) {
+                return false;
+            }
+            if (statusFilter !== "all") {
+                if (statusFilter === "active" && record.status.toLowerCase() !== "active") return false;
+                if (statusFilter === "inactive" && record.status.toLowerCase() !== "inactive") return false;
+            }
+            if (appointmentFilter === "with" && !record.latestAppointment) return false;
+            if (appointmentFilter === "without" && record.latestAppointment) return false;
+
+            if (!searchTerm) return true;
+
+            const haystack = [
+                record.fullName,
+                record.patientId,
+                record.patientType,
+                record.department,
+                record.program,
+                record.year_level,
+                record.contactno,
+                record.address,
+                record.emergency?.name,
+                record.emergency?.num,
+                record.emergency?.relation,
+                record.status,
+            ]
+                .join(" ")
+                .toLowerCase();
+
+            return haystack.includes(searchTerm);
+        });
+    }, [appointmentFilter, records, searchTerm, statusFilter, typeFilter]);
+
+    const totalPatients = records.length;
+    const withAppointments = useMemo(
+        () => records.filter((record) => Boolean(record.latestAppointment)).length,
+        [records]
+    );
+    const withoutAppointments = totalPatients - withAppointments;
+
+    function openDetails(record: PatientRecord) {
+        setSelected(record);
+        setDetailOpen(true);
+    }
+
+    function closeDetails() {
+        setDetailOpen(false);
+        setSelected(null);
+    }
+
+    return (
+        <ScholarLayout
+            title="Patient intake overview"
+            description="Review student and employee profiles, confirm eligibility, and keep contact details ready for the care team."
+            actions={
+                <Button variant="outline" onClick={loadRecords} className="rounded-xl">
+                    <RefreshCcw className="mr-2 h-4 w-4" /> Refresh
+                </Button>
+            }
+        >
+            <div className="flex flex-col gap-6">
+                <section className="grid gap-4 md:grid-cols-3">
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">Total profiles</CardTitle>
+                                <p className="text-sm text-muted-foreground">Student and employee records synced</p>
+                            </div>
+                            <Users2 className="h-9 w-9 text-green-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">{totalPatients}</p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">With appointments</CardTitle>
+                                <p className="text-sm text-muted-foreground">Latest visit attached to the chart</p>
+                            </div>
+                            <BadgeCheck className="h-9 w-9 text-green-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">{withAppointments}</p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">No appointment yet</CardTitle>
+                                <p className="text-sm text-muted-foreground">Students ready for intake coordination</p>
+                            </div>
+                            <AlertCircle className="h-9 w-9 text-amber-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">{withoutAppointments}</p>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                        <div className="space-y-1">
+                            <CardTitle className="text-xl text-green-700">Patient directory</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                Filter student and employee details before handing off to nurses or doctors.
+                            </p>
+                        </div>
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Patient type</Label>
+                                <Select value={typeFilter} onValueChange={setTypeFilter}>
+                                    <SelectTrigger className="rounded-xl border-green-200">
+                                        <SelectValue placeholder="All types" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all">All</SelectItem>
+                                        <SelectItem value="student">Students</SelectItem>
+                                        <SelectItem value="employee">Employees</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Account status</Label>
+                                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                                    <SelectTrigger className="rounded-xl border-green-200">
+                                        <SelectValue placeholder="Status" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all">All</SelectItem>
+                                        <SelectItem value="active">Active</SelectItem>
+                                        <SelectItem value="inactive">Inactive</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Appointment link</Label>
+                                <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
+                                    <SelectTrigger className="rounded-xl border-green-200">
+                                        <SelectValue placeholder="Appointment" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all">All</SelectItem>
+                                        <SelectItem value="with">With appointment</SelectItem>
+                                        <SelectItem value="without">No appointment</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Search records</Label>
+                                <div className="relative">
+                                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                    <Input
+                                        placeholder="Search by name, ID, or program"
+                                        value={search}
+                                        onChange={(event) => setSearch(event.target.value)}
+                                        className="rounded-xl border-green-200 pl-9"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </CardHeader>
+                    <CardContent className="overflow-x-auto">
+                        <Table>
+                            <TableHeader>
+                                <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
+                                    <TableHead className="min-w-[200px]">Patient</TableHead>
+                                    <TableHead className="min-w-[140px]">ID</TableHead>
+                                    <TableHead className="min-w-[120px]">Type</TableHead>
+                                    <TableHead className="min-w-[160px]">Program / Department</TableHead>
+                                    <TableHead className="min-w-[120px]">Status</TableHead>
+                                    <TableHead className="min-w-[200px]">Latest appointment</TableHead>
+                                    <TableHead className="w-[110px] text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {loading ? (
+                                    <TableRow>
+                                        <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                                            <div className="flex items-center justify-center gap-2 text-sm">
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Loading patient records...
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ) : filteredRecords.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                                            No patient records match your filters.
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    filteredRecords.map((record) => {
+                                        const statusKey = record.status.toLowerCase();
+                                        return (
+                                            <TableRow key={`${record.patientType}-${record.id}`} className="text-sm">
+                                                <TableCell className="font-medium text-green-700">
+                                                    <div className="flex flex-col">
+                                                        <span>{record.fullName}</span>
+                                                        <span className="text-xs text-muted-foreground">
+                                                            {record.contactno ? record.contactno : "No contact number"}
+                                                        </span>
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>{record.patientId}</TableCell>
+                                                <TableCell>
+                                                    <Badge className="rounded-full border-green-200 bg-green-50 text-green-700">
+                                                        {record.patientType}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell>
+                                                    {record.patientType === "Student"
+                                                        ? humanize(record.program) || "—"
+                                                        : humanize(record.department) || "—"}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Badge
+                                                        className={cn(
+                                                            "rounded-full px-2 py-1 text-xs",
+                                                            PATIENT_STATUS_CLASSES[statusKey] ?? "border-slate-200 bg-slate-100 text-slate-700"
+                                                        )}
+                                                    >
+                                                        {record.status}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell>
+                                                    {record.latestAppointment ? (
+                                                        <div className="flex flex-col">
+                                                            <span>{formatAppointmentWindow(record.latestAppointment)}</span>
+                                                            <span className="text-xs text-muted-foreground">
+                                                                with {formatStaffName(record.latestAppointment.doctor)}
+                                                            </span>
+                                                        </div>
+                                                    ) : (
+                                                        <span className="text-muted-foreground">—</span>
+                                                    )}
+                                                </TableCell>
+                                                <TableCell className="text-right">
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="rounded-xl text-green-700 hover:bg-green-100"
+                                                        onClick={() => openDetails(record)}
+                                                    >
+                                                        View
+                                                    </Button>
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })
+                                )}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <Dialog open={detailOpen} onOpenChange={setDetailOpen}>
+                <DialogContent className="rounded-3xl sm:max-w-3xl">
+                    <DialogHeader>
+                        <DialogTitle className="text-xl text-green-700">Patient snapshot</DialogTitle>
+                        <DialogDescription className="text-sm text-muted-foreground">
+                            Contact details and medical notes shared with the clinic team.
+                        </DialogDescription>
+                    </DialogHeader>
+                    {selected ? (
+                        <div className="space-y-6 text-sm">
+                            <div className="rounded-2xl bg-green-50/70 p-4 text-green-700">
+                                <p className="text-lg font-semibold">{selected.fullName}</p>
+                                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Patient ID</p>
+                                        <p className="font-medium text-green-700">{selected.patientId}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Type</p>
+                                        <p className="font-medium text-green-700">{selected.patientType}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Date of birth</p>
+                                        <p className="font-medium text-green-700">{formatDOB(selected.date_of_birth)}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Gender</p>
+                                        <p className="font-medium text-green-700">{selected.gender ?? "—"}</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="grid gap-4 md:grid-cols-2">
+                                <div className="space-y-3 rounded-2xl border border-green-100 bg-white/70 p-4">
+                                    <h4 className="flex items-center gap-2 text-sm font-semibold text-green-700">
+                                        <Users2 className="h-4 w-4" /> Academic / department info
+                                    </h4>
+                                    <dl className="grid gap-2 text-muted-foreground">
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Program</dt>
+                                            <dd>{humanize(selected.program)}</dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Department</dt>
+                                            <dd>{humanize(selected.department)}</dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Year level</dt>
+                                            <dd>{humanize(selected.year_level)}</dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                                <div className="space-y-3 rounded-2xl border border-green-100 bg-white/70 p-4">
+                                    <h4 className="flex items-center gap-2 text-sm font-semibold text-green-700">
+                                        <HeartPulse className="h-4 w-4" /> Medical details
+                                    </h4>
+                                    <dl className="grid gap-2 text-muted-foreground">
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Blood type</dt>
+                                            <dd>{humanize(selected.bloodtype)}</dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Allergies</dt>
+                                            <dd>{selected.allergies || "—"}</dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Medical conditions</dt>
+                                            <dd>{selected.medical_cond || "—"}</dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
+
+                            <div className="grid gap-4 md:grid-cols-2">
+                            <div className="space-y-3 rounded-2xl border border-green-100 bg-white/70 p-4">
+                                <h4 className="text-sm font-semibold text-green-700">Contact information</h4>
+                                <dl className="grid gap-2 text-muted-foreground">
+                                    <div>
+                                        <dt className="text-xs uppercase tracking-wide">Phone</dt>
+                                        <dd>{selected.contactno || "—"}</dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs uppercase tracking-wide">Address</dt>
+                                        <dd>{selected.address || "—"}</dd>
+                                    </div>
+                                </dl>
+                            </div>
+                                <div className="space-y-3 rounded-2xl border border-green-100 bg-white/70 p-4">
+                                    <h4 className="text-sm font-semibold text-green-700">Emergency contact</h4>
+                                    <dl className="grid gap-2 text-muted-foreground">
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Name</dt>
+                                            <dd>{selected.emergency?.name || "—"}</dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Relation</dt>
+                                            <dd>{selected.emergency?.relation || "—"}</dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-xs uppercase tracking-wide">Contact number</dt>
+                                            <dd>{selected.emergency?.num || "—"}</dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
+
+                            <div className="space-y-3 rounded-2xl border border-green-100 bg-white/70 p-4">
+                                <h4 className="text-sm font-semibold text-green-700">Latest appointment</h4>
+                                {selected.latestAppointment ? (
+                                    <div className="grid gap-2 text-muted-foreground sm:grid-cols-2">
+                                        <div>
+                                            <p className="text-xs uppercase tracking-wide">Schedule</p>
+                                            <p>{formatAppointmentWindow(selected.latestAppointment)}</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-wide">Doctor</p>
+                                            <p>{formatStaffName(selected.latestAppointment.doctor)}</p>
+                                        </div>
+                                        <div className="sm:col-span-2">
+                                            <p className="text-xs uppercase tracking-wide">Consultation notes</p>
+                                            <p>
+                                                {selected.latestAppointment.consultation?.diagnosis ||
+                                                    selected.latestAppointment.consultation?.findings ||
+                                                    selected.latestAppointment.consultation?.reason_of_visit ||
+                                                    "No notes provided"}
+                                            </p>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <p className="text-muted-foreground">No appointment history attached yet.</p>
+                                )}
+                            </div>
+                        </div>
+                    ) : null}
+                    <DialogFooter className="mt-4">
+                        <Button variant="outline" className="rounded-xl" onClick={closeDetails}>
+                            Close
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </ScholarLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- add server endpoints so scholars can list, filter, and update campus appointments
- create a scholar appointment dashboard with queue insights, filtering, and status update dialogs
- build a scholar patient directory with search, segmentation controls, and detailed profile viewer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f2406a40b48333814702fb596eeb2a