### PR TITLE
Refactor appointment and patient directories across roles

### DIFF
--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -1,40 +1,57 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
+    AlertCircle,
     CalendarDays,
-    ClipboardCheck,
+    CheckCircle2,
+    Clock3,
     Loader2,
-    Check,
-    XCircle,
-    Move,
     MoreHorizontal,
-    Trash2,
+    Move,
+    RefreshCcw,
+    Search,
+    Stethoscope,
+    XCircle,
 } from "lucide-react";
-import DoctorLayout from "@/components/doctor/doctor-layout";
-import { Button } from "@/components/ui/button";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+
 import { AppointmentPanel } from "@/components/appointments/appointment-panel";
+import DoctorLayout from "@/components/doctor/doctor-layout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    DialogDescription,
-    DialogFooter,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { formatManilaDateTime } from "@/lib/time";
 
-interface Appointment {
+const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
+
+type AppointmentStatus = (typeof STATUS_ORDER)[number];
+
+type Appointment = {
     id: string;
     patientName: string;
     date: string;
@@ -42,6 +59,81 @@ interface Appointment {
     status: string;
     clinic?: string;
     hasConsultation: boolean;
+};
+
+const STATUS_LABELS: Record<AppointmentStatus, string> = {
+    Pending: "Awaiting review",
+    Approved: "Confirmed",
+    Moved: "Rescheduled",
+    Completed: "Completed",
+    Cancelled: "Cancelled",
+};
+
+const STATUS_BADGE_CLASSES: Record<AppointmentStatus, string> = {
+    Pending: "border-amber-200 bg-amber-50 text-amber-700",
+    Approved: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    Moved: "border-sky-200 bg-sky-50 text-sky-700",
+    Completed: "border-slate-200 bg-slate-100 text-slate-700",
+    Cancelled: "border-rose-200 bg-rose-50 text-rose-700",
+};
+
+const ACTIVE_STATUSES: AppointmentStatus[] = ["Pending", "Approved", "Moved"];
+
+const STATUS_VALUE_MAP: Record<string, AppointmentStatus> = {
+    pending: "Pending",
+    approved: "Approved",
+    moved: "Moved",
+    completed: "Completed",
+    cancelled: "Cancelled",
+};
+
+function normalizeStatus(value: string): AppointmentStatus | null {
+    return STATUS_VALUE_MAP[value.toLowerCase()] ?? null;
+}
+
+function isToday(date: string) {
+    const today = new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
+    return date === today;
+}
+
+function formatDateOnly(value: string) {
+    if (!value) return "—";
+    const iso = `${value}T00:00:00+08:00`;
+    return (
+        formatManilaDateTime(iso, {
+            hour: undefined,
+            minute: undefined,
+        }) ?? "—"
+    );
+}
+
+function parseStartDate(appointment: Appointment) {
+    const base = appointment.date;
+    if (!base) return new Date();
+
+    const [timePart, meridiemRaw] = appointment.time.split(" ");
+    let hour = 0;
+    let minute = 0;
+
+    if (timePart) {
+        const [hourPart, minutePart] = timePart.split(":");
+        const parsedHour = Number.parseInt(hourPart ?? "0", 10);
+        const parsedMinute = Number.parseInt(minutePart ?? "0", 10);
+        hour = Number.isNaN(parsedHour) ? 0 : parsedHour;
+        minute = Number.isNaN(parsedMinute) ? 0 : parsedMinute;
+    }
+
+    const meridiem = meridiemRaw?.toLowerCase() ?? "";
+    if (meridiem === "pm" && hour < 12) {
+        hour += 12;
+    } else if (meridiem === "am" && hour === 12) {
+        hour = 0;
+    }
+
+    const iso = `${base}T${hour.toString().padStart(2, "0")}:${minute
+        .toString()
+        .padStart(2, "0")}:00+08:00`;
+    return new Date(iso);
 }
 
 export default function DoctorAppointmentsPage() {
@@ -54,31 +146,98 @@ export default function DoctorAppointmentsPage() {
     const [newTimeStart, setNewTimeStart] = useState("");
     const [newTimeEnd, setNewTimeEnd] = useState("");
     const [dialogOpen, setDialogOpen] = useState(false);
+    const [search, setSearch] = useState("");
+    const [statusFilter, setStatusFilter] = useState<string>("active");
 
-    async function loadAppointments() {
+    const loadAppointments = useCallback(async () => {
         try {
             setLoading(true);
-            const res = await fetch("/api/doctor/appointments");
+            const res = await fetch("/api/doctor/appointments", { cache: "no-store" });
             if (!res.ok) throw new Error("Failed to fetch appointments");
-            const data = await res.json();
-            setAppointments(data);
+            const data = (await res.json()) as Appointment[];
+            setAppointments(Array.isArray(data) ? data : []);
         } catch (error) {
             console.error(error);
             toast.error("Failed to load appointments");
         } finally {
             setLoading(false);
         }
-    }
-
-    // Fetch appointments
-    useEffect(() => {
-        loadAppointments();
     }, []);
 
-    const handleClearAppointments = () => {
-        setAppointments([]);
-        toast.info("Appointments cleared from view");
-    };
+    useEffect(() => {
+        loadAppointments();
+    }, [loadAppointments]);
+
+    const searchTerm = search.trim().toLowerCase();
+
+    const filteredAppointments = useMemo(() => {
+        return appointments.filter((appointment) => {
+            const status = normalizeStatus(appointment.status);
+            if (statusFilter && statusFilter !== "all") {
+                if (statusFilter === "active" && (!status || !ACTIVE_STATUSES.includes(status))) {
+                    return false;
+                }
+                if (statusFilter !== "active") {
+                    const matchStatus = STATUS_VALUE_MAP[statusFilter];
+                    if (!matchStatus || status !== matchStatus) {
+                        return false;
+                    }
+                }
+            }
+
+            if (!searchTerm) return true;
+
+            const haystack = [
+                appointment.patientName,
+                appointment.clinic ?? "",
+                appointment.date,
+                appointment.time,
+                appointment.status,
+            ]
+                .join(" ")
+                .toLowerCase();
+
+            return haystack.includes(searchTerm);
+        });
+    }, [appointments, searchTerm, statusFilter]);
+
+    const statusCounts = useMemo(() => {
+        const counts: Record<AppointmentStatus, number> = {
+            Pending: 0,
+            Approved: 0,
+            Moved: 0,
+            Completed: 0,
+            Cancelled: 0,
+        };
+        for (const appointment of appointments) {
+            const status = normalizeStatus(appointment.status);
+            if (status) {
+                counts[status] += 1;
+            }
+        }
+        return counts;
+    }, [appointments]);
+
+    const activeAppointments = useMemo(
+        () => appointments.filter((appointment) => {
+            const status = normalizeStatus(appointment.status);
+            return status ? ACTIVE_STATUSES.includes(status) : false;
+        }),
+        [appointments]
+    );
+
+    const todayAppointments = useMemo(
+        () => appointments.filter((appointment) => isToday(appointment.date)),
+        [appointments]
+    );
+
+    const nextAppointment = useMemo(() => {
+        const upcoming = activeAppointments
+            .map((appointment) => ({ appointment, start: parseStartDate(appointment) }))
+            .filter(({ start }) => start.getTime() >= Date.now())
+            .sort((a, b) => a.start.getTime() - b.start.getTime());
+        return upcoming[0]?.appointment ?? null;
+    }, [activeAppointments]);
 
     async function handleApprove(id: string) {
         try {
@@ -93,11 +252,10 @@ export default function DoctorAppointmentsPage() {
                 return;
             }
             toast.success("Appointment approved");
-            setAppointments((prev) =>
-                prev.map((appt) => (appt.id === id ? data : appt))
-            );
-        } catch {
-            toast.error("Failed to approve");
+            setAppointments((prev) => prev.map((appt) => (appt.id === id ? data : appt)));
+        } catch (error) {
+            console.error(error);
+            toast.error("Failed to approve appointment");
         }
     }
 
@@ -108,21 +266,28 @@ export default function DoctorAppointmentsPage() {
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ action: "complete" }),
             });
-
             const data = await res.json();
             if (!res.ok) {
                 toast.error(data?.error ?? "Failed to complete appointment");
                 return;
             }
-
             toast.success("Appointment marked as completed");
-            setAppointments((prev) =>
-                prev.map((appt) => (appt.id === id ? data : appt))
-            );
-        } catch {
+            setAppointments((prev) => prev.map((appt) => (appt.id === id ? data : appt)));
+        } catch (error) {
+            console.error(error);
             toast.error("Failed to complete appointment");
         }
     }
+
+    const resetDialogState = () => {
+        setDialogOpen(false);
+        setActionType(null);
+        setSelectedAppt(null);
+        setReason("");
+        setNewDate("");
+        setNewTimeStart("");
+        setNewTimeEnd("");
+    };
 
     async function handleActionSubmit() {
         if (!selectedAppt || !actionType) return;
@@ -153,27 +318,25 @@ export default function DoctorAppointmentsPage() {
             if (!res.ok) throw new Error("Action failed");
 
             if (actionType === "cancel") {
-                setAppointments((prev) =>
-                    prev.filter((appt) => appt.id !== selectedAppt.id)
-                );
+                setAppointments((prev) => prev.filter((appt) => appt.id !== selectedAppt.id));
                 toast.success("Appointment cancelled");
             } else if (actionType === "move") {
                 const updated = await res.json();
-                setAppointments((prev) =>
-                    prev.map((appt) => (appt.id === selectedAppt.id ? updated : appt))
-                );
+                setAppointments((prev) => prev.map((appt) => (appt.id === selectedAppt.id ? updated : appt)));
                 toast.success("Appointment moved");
             }
-            setDialogOpen(false);
-            setReason("");
-            setNewDate("");
-            setNewTimeStart("");
-            setNewTimeEnd("");
-        } catch (err) {
-            console.error(err);
+            resetDialogState();
+        } catch (error) {
+            console.error(error);
             toast.error("Action failed");
         }
     }
+
+    const handleDialogOpenChange = (open: boolean) => {
+        if (!open) {
+            resetDialogState();
+        }
+    };
 
     return (
         <DoctorLayout
@@ -185,226 +348,325 @@ export default function DoctorAppointmentsPage() {
                     className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
                     onClick={loadAppointments}
                 >
-                    Refresh list
+                    <RefreshCcw className="mr-2 h-4 w-4" /> Refresh list
                 </Button>
             }
         >
-            <div className="space-y-6">
-                {/* Appointments Section */}
-                <section className="space-y-6">
-                    <div className="grid gap-4 md:grid-cols-2">
-                        <Card className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 shadow-sm">
-                            <CardHeader className="space-y-1">
+            <div className="flex flex-col gap-6">
+                <section className="grid gap-4 md:grid-cols-3">
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
                                 <CardTitle className="text-base font-semibold text-green-700">
-                                    Schedule snapshot
+                                    Active queue
                                 </CardTitle>
                                 <p className="text-sm text-muted-foreground">
-                                    {loading
-                                        ? "Fetching the latest appointments..."
-                                        : `You have ${appointments.length} appointment${appointments.length === 1 ? "" : "s"} in your queue.`}
+                                    Pending, approved, and moved appointments
                                 </p>
-                            </CardHeader>
-                        </Card>
-                        <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
-                            <CardHeader className="space-y-1">
+                            </div>
+                            <Clock3 className="h-9 w-9 text-green-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">{activeAppointments.length}</p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
                                 <CardTitle className="text-base font-semibold text-green-700">
-                                    Action reminder
+                                    Today&apos;s visits
                                 </CardTitle>
                                 <p className="text-sm text-muted-foreground">
-                                    Approve or move requests within the day to keep students and employees informed ahead of their visit.
+                                    Appointments scheduled for today
                                 </p>
-                            </CardHeader>
-                        </Card>
-                    </div>
-                    <AppointmentPanel
-                        icon={ClipboardCheck}
-                        title="Appointment queue"
-                        description="Review upcoming visits, confirm slots, or make quick adjustments for your patients."
-                        actions={
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="gap-2 self-start rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
-                                onClick={handleClearAppointments}
-                                disabled={appointments.length === 0}
-                            >
-                                <Trash2 className="h-4 w-4" /> Clear appointments
-                            </Button>
-                        }
-                    >
-                        {loading ? (
-                            <div className="flex items-center justify-center gap-2 py-10 text-muted-foreground">
-                                <Loader2 className="h-5 w-5 animate-spin" /> Loading appointments...
                             </div>
-                        ) : appointments.length === 0 ? (
-                            <p className="py-6 text-center">No appointments found.</p>
-                        ) : (
-                            <div className="space-y-3 text-sm text-muted-foreground">
-                                {appointments.map((appointment) => (
-                                    <Card
-                                        key={appointment.id}
-                                        className="rounded-2xl border border-green-100/70 bg-white/90 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md"
-                                    >
-                                        <CardContent className="flex flex-col gap-4 py-4">
-                                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                                                <div>
-                                                    <h3 className="text-base font-semibold text-green-700">
-                                                        {appointment.patientName}
-                                                    </h3>
-                                                    <p className="text-xs uppercase tracking-wide text-green-500">
-                                                        {appointment.clinic ?? "Clinic assignment"}
-                                                    </p>
-                                                </div>
-                                                <Badge
-                                                    variant={appointment.status === "Pending" ? "outline" : "default"}
-                                                    className="rounded-full border-green-200 bg-green-50/70 px-3 py-1 text-xs font-semibold text-green-700"
-                                                >
-                                                    {appointment.status}
-                                                </Badge>
-                                            </div>
-
-                                            <div className="grid gap-2 text-sm sm:grid-cols-2">
-                                                <div className="flex items-center gap-2 text-muted-foreground">
-                                                    <CalendarDays className="h-4 w-4 text-green-600" />
-                                                    <span>{appointment.date}</span>
-                                                </div>
-                                                <div className="flex items-center gap-2 text-muted-foreground">
-                                                    <ClipboardCheck className="h-4 w-4 text-green-600" />
-                                                    <span>{appointment.time}</span>
-                                                </div>
-                                            </div>
-
-                                            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                                                <Badge variant="outline" className="rounded-full border-green-200 bg-green-50/70 text-green-700">
-                                                    {appointment.hasConsultation ? "With consultation" : "Awaiting consultation"}
-                                                </Badge>
-                                            </div>
-
-                                            <div className="flex flex-wrap gap-2">
-                                                <Button
-                                                    size="sm"
-                                                    variant="secondary"
-                                                    className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
-                                                    onClick={() => handleApprove(appointment.id)}
-                                                >
-                                                    <Check className="mr-2 h-4 w-4" /> Approve
-                                                </Button>
-                                                <Button
-                                                    size="sm"
-                                                    variant="outline"
-                                                    className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
-                                                    onClick={() => handleComplete(appointment.id)}
-                                                >
-                                                    <ClipboardCheck className="mr-2 h-4 w-4" /> Complete
-                                                </Button>
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger asChild>
-                                                        <Button size="sm" variant="ghost" className="rounded-xl text-green-700 hover:bg-green-100/70">
-                                                            <MoreHorizontal className="h-4 w-4" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent align="end" className="rounded-xl border-green-100">
-                                                        <DropdownMenuItem
-                                                            onClick={() => {
-                                                                setActionType("move");
-                                                                setSelectedAppt(appointment);
-                                                                setDialogOpen(true);
-                                                                setReason("");
-                                                                setNewDate("");
-                                                                setNewTimeStart("");
-                                                                setNewTimeEnd("");
-                                                            }}
-                                                        >
-                                                            <Move className="mr-2 h-4 w-4" /> Move appointment
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem
-                                                            onClick={() => {
-                                                                setActionType("cancel");
-                                                                setSelectedAppt(appointment);
-                                                                setDialogOpen(true);
-                                                                setReason("");
-                                                            }}
-                                                        >
-                                                            <XCircle className="mr-2 h-4 w-4" /> Cancel appointment
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
-                                            </div>
-                                        </CardContent>
-                                    </Card>
-                                ))}
+                            <CalendarDays className="h-9 w-9 text-green-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">{todayAppointments.length}</p>
+                            {nextAppointment ? (
+                                <p className="mt-2 text-xs text-muted-foreground">
+                                    Next: {nextAppointment.patientName} at {nextAppointment.time}
+                                </p>
+                            ) : null}
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div>
+                                <CardTitle className="text-base font-semibold text-green-700">
+                                    Pending approvals
+                                </CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Requests awaiting confirmation
+                                </p>
                             </div>
-                        )}
-                    </AppointmentPanel>
+                            <AlertCircle className="h-9 w-9 text-amber-500" />
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-3xl font-semibold text-green-700">{statusCounts.Pending}</p>
+                        </CardContent>
+                    </Card>
                 </section>
 
-                {/* Dialog */}
-                <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-                    <DialogContent className="rounded-xl">
-                        <DialogHeader>
-                            <DialogTitle className="capitalize">{actionType} Appointment</DialogTitle>
-                            <DialogDescription>
-                                {actionType === "cancel"
-                                    ? "Please provide a reason for cancellation."
-                                    : "Provide new date, time, and reason for moving appointment."}
-                            </DialogDescription>
-                        </DialogHeader>
-
-                        {actionType && (
-                            <div className="space-y-4 mt-3">
-                                {actionType === "move" && (
-                                    <>
-                                        <div>
-                                            <Label>Date</Label>
-                                            <Input
-                                                type="date"
-                                                value={newDate}
-                                                onChange={(e) => setNewDate(e.target.value)}
-                                            />
-                                        </div>
-                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                            <div>
-                                                <Label>Start Time</Label>
-                                                <Input
-                                                    type="time"
-                                                    value={newTimeStart}
-                                                    onChange={(e) => setNewTimeStart(e.target.value)}
-                                                />
-                                            </div>
-                                            <div>
-                                                <Label>End Time</Label>
-                                                <Input
-                                                    type="time"
-                                                    value={newTimeEnd}
-                                                    onChange={(e) => setNewTimeEnd(e.target.value)}
-                                                />
-                                            </div>
-                                        </div>
-                                    </>
-                                )}
-                                <div>
-                                    <Label>Reason</Label>
+                <AppointmentPanel
+                    icon={CalendarDays}
+                    title="Appointment board"
+                    description="Filter bookings, verify walk-ins, and notify the care team when schedules shift."
+                    actions={
+                        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                            <div className="flex items-center gap-2">
+                                <span className="h-2 w-2 rounded-full bg-emerald-500" /> Consultation synced
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <span className="h-2 w-2 rounded-full bg-slate-300" /> Awaiting notes
+                            </div>
+                        </div>
+                    }
+                    contentClassName="pt-4"
+                >
+                    <div className="flex flex-col gap-4">
+                        <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_200px]">
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Search queue</Label>
+                                <div className="relative">
+                                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                                     <Input
-                                        placeholder="Enter reason"
-                                        value={reason}
-                                        onChange={(e) => setReason(e.target.value)}
+                                        placeholder="Search by name, clinic, or status"
+                                        value={search}
+                                        onChange={(event) => setSearch(event.target.value)}
+                                        className="rounded-xl border-green-200 pl-9"
                                     />
                                 </div>
                             </div>
-                        )}
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Status filter</Label>
+                                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                                    <SelectTrigger className="rounded-xl border-green-200">
+                                        <SelectValue placeholder="All statuses" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="all">All statuses</SelectItem>
+                                        <SelectItem value="active">Active queue</SelectItem>
+                                        {STATUS_ORDER.map((status) => (
+                                            <SelectItem key={status} value={status.toLowerCase()}>
+                                                {STATUS_LABELS[status]}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
 
-                        <DialogFooter className="mt-4">
-                            <Button
-                                className="rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
-                                onClick={handleActionSubmit}
-                            >
-                                Submit
-                            </Button>
-                        </DialogFooter>
-                    </DialogContent>
-                </Dialog>
+                        <div className="overflow-x-auto">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
+                                        <TableHead className="min-w-[160px]">Patient</TableHead>
+                                        <TableHead className="min-w-[160px]">Clinic</TableHead>
+                                        <TableHead className="min-w-[120px]">Date</TableHead>
+                                        <TableHead className="min-w-[120px]">Time</TableHead>
+                                        <TableHead className="min-w-[120px]">Status</TableHead>
+                                        <TableHead className="min-w-[160px]">Consultation</TableHead>
+                                        <TableHead className="w-[110px] text-right">Actions</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {loading ? (
+                                        <TableRow>
+                                            <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                                                <div className="flex items-center justify-center gap-2 text-sm">
+                                                    <Loader2 className="h-4 w-4 animate-spin" /> Loading appointments...
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    ) : filteredAppointments.length === 0 ? (
+                                        <TableRow>
+                                            <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                                                No appointments match your filters.
+                                            </TableCell>
+                                        </TableRow>
+                                    ) : (
+                                        filteredAppointments.map((appointment) => {
+                                            const status = normalizeStatus(appointment.status);
+                                            const statusLabel = status ? STATUS_LABELS[status] : appointment.status;
+                                            const statusClasses = status
+                                                ? STATUS_BADGE_CLASSES[status]
+                                                : "border-slate-200 bg-slate-100 text-slate-700";
 
+                                            const canApprove = status === "Pending";
+                                            const canComplete = status === "Approved" || status === "Moved";
+                                            const canManage = status ? status !== "Completed" && status !== "Cancelled" : true;
+
+                                            return (
+                                                <TableRow key={appointment.id} className="text-sm">
+                                                    <TableCell className="font-medium text-green-700">
+                                                        <div className="flex flex-col">
+                                                            <span>{appointment.patientName}</span>
+                                                            <span className="text-xs text-muted-foreground">
+                                                                {appointment.clinic ?? "Clinic assignment"}
+                                                            </span>
+                                                        </div>
+                                                    </TableCell>
+                                                    <TableCell>{appointment.clinic ?? "—"}</TableCell>
+                                                    <TableCell>{formatDateOnly(appointment.date)}</TableCell>
+                                                    <TableCell>{appointment.time || "—"}</TableCell>
+                                                    <TableCell>
+                                                        <Badge className={"rounded-full px-2 py-1 text-xs " + statusClasses}>
+                                                            {statusLabel}
+                                                        </Badge>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Badge
+                                                            variant="outline"
+                                                            className={`rounded-full px-2 py-1 text-xs ${
+                                                                appointment.hasConsultation
+                                                                    ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                                                                    : "border-slate-200 bg-slate-100 text-slate-600"
+                                                            }`}
+                                                        >
+                                                            {appointment.hasConsultation ? "Consultation ready" : "Awaiting notes"}
+                                                        </Badge>
+                                                    </TableCell>
+                                                    <TableCell className="text-right">
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger asChild>
+                                                                <Button
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    className="rounded-xl text-green-700 hover:bg-green-100"
+                                                                >
+                                                                    <MoreHorizontal className="h-4 w-4" />
+                                                                </Button>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent align="end" className="w-48 rounded-xl border-green-100">
+                                                                <DropdownMenuItem
+                                                                    onClick={() => handleApprove(appointment.id)}
+                                                                    disabled={!canApprove}
+                                                                >
+                                                                    <CheckCircle2 className="mr-2 h-4 w-4" /> Approve
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                    onClick={() => handleComplete(appointment.id)}
+                                                                    disabled={!canComplete}
+                                                                >
+                                                                    <Stethoscope className="mr-2 h-4 w-4" /> Complete
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                    onClick={() => {
+                                                                        if (!canManage) return;
+                                                                        setActionType("move");
+                                                                        setSelectedAppt(appointment);
+                                                                        setDialogOpen(true);
+                                                                        setReason("");
+                                                                        setNewDate(appointment.date);
+                                                                        setNewTimeStart("");
+                                                                        setNewTimeEnd("");
+                                                                    }}
+                                                                    disabled={!canManage}
+                                                                >
+                                                                    <Move className="mr-2 h-4 w-4" /> Move appointment
+                                                                </DropdownMenuItem>
+                                                                <DropdownMenuItem
+                                                                    onClick={() => {
+                                                                        if (!canManage) return;
+                                                                        setActionType("cancel");
+                                                                        setSelectedAppt(appointment);
+                                                                        setDialogOpen(true);
+                                                                        setReason("");
+                                                                    }}
+                                                                    disabled={!canManage}
+                                                                >
+                                                                    <XCircle className="mr-2 h-4 w-4" /> Cancel appointment
+                                                                </DropdownMenuItem>
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    </TableCell>
+                                                </TableRow>
+                                            );
+                                        })
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    </div>
+                </AppointmentPanel>
             </div>
+
+            <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
+                <DialogContent className="rounded-3xl sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle className="text-xl text-green-700">
+                            {actionType === "move" ? "Move appointment" : "Cancel appointment"}
+                        </DialogTitle>
+                        <DialogDescription className="text-sm text-muted-foreground">
+                            {actionType === "move"
+                                ? "Select a new schedule and provide context for the care team."
+                                : "Let the patient know why the visit will not push through."}
+                        </DialogDescription>
+                    </DialogHeader>
+                    {selectedAppt ? (
+                        <div className="rounded-2xl bg-green-50/70 p-4 text-sm text-green-700">
+                            <p className="font-semibold">{selectedAppt.patientName}</p>
+                            <p className="text-xs text-muted-foreground">
+                                {selectedAppt.clinic ?? "Clinic assignment"} • {formatDateOnly(selectedAppt.date)} • {" "}
+                                {selectedAppt.time || "—"}
+                            </p>
+                        </div>
+                    ) : null}
+                    {actionType === "move" ? (
+                        <div className="grid gap-3 sm:grid-cols-2">
+                            <div className="space-y-2 sm:col-span-2">
+                                <Label className="text-sm font-medium text-green-700">New date</Label>
+                                <Input
+                                    type="date"
+                                    value={newDate}
+                                    onChange={(event) => setNewDate(event.target.value)}
+                                    className="rounded-xl border-green-200"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">Start time</Label>
+                                <Input
+                                    type="time"
+                                    value={newTimeStart}
+                                    onChange={(event) => setNewTimeStart(event.target.value)}
+                                    className="rounded-xl border-green-200"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-medium text-green-700">End time</Label>
+                                <Input
+                                    type="time"
+                                    value={newTimeEnd}
+                                    onChange={(event) => setNewTimeEnd(event.target.value)}
+                                    className="rounded-xl border-green-200"
+                                />
+                            </div>
+                        </div>
+                    ) : null}
+                    <div className="space-y-2">
+                        <Label className="text-sm font-medium text-green-700">Reason</Label>
+                        <Input
+                            placeholder={actionType === "move" ? "Share context for the new schedule" : "Explain the cancellation"}
+                            value={reason}
+                            onChange={(event) => setReason(event.target.value)}
+                            className="rounded-xl border-green-200"
+                        />
+                    </div>
+                    <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                        <Button type="button" variant="outline" className="rounded-xl" onClick={resetDialogState}>
+                            Close
+                        </Button>
+                        <Button
+                            className="rounded-xl bg-green-600 text-white hover:bg-green-700"
+                            onClick={handleActionSubmit}
+                        >
+                            Save changes
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </DoctorLayout>
     );
 }

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -2,11 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import {
-    Loader2,
-    Search,
-    Stethoscope,
-} from "lucide-react";
+import { AlertCircle, BadgeCheck, Loader2, RefreshCcw, Search, Stethoscope, Users2 } from "lucide-react";
 
 import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
@@ -29,14 +25,7 @@ import {
     TableHeader,
     TableRow,
 } from "@/components/ui/table";
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { formatManilaDateTime } from "@/lib/time";
@@ -197,14 +186,23 @@ function formatStaffName(staff?: { fullName: string | null; username: string } |
     return staff.fullName || staff.username || "—";
 }
 
+const PATIENT_STATUS_CLASSES: Record<string, string> = {
+    active: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    inactive: "border-slate-200 bg-slate-100 text-slate-700",
+};
+
 export default function DoctorPatientsPage() {
     const [records, setRecords] = useState<PatientRecord[]>([]);
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("All");
     const [typeFilter, setTypeFilter] = useState("All");
+    const [appointmentFilter, setAppointmentFilter] = useState("All");
     const [loadingRecords, setLoadingRecords] = useState(false);
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
+    const [detailOpen, setDetailOpen] = useState(false);
+    const [selectedRecord, setSelectedRecord] = useState<PatientRecord | null>(null);
+    const [activeTab, setActiveTab] = useState<"details" | "update" | "notes">("details");
 
     const loadRecords = useCallback(async () => {
         try {
@@ -229,6 +227,14 @@ export default function DoctorPatientsPage() {
         loadRecords();
     }, [loadRecords]);
 
+    useEffect(() => {
+        if (!selectedRecord) return;
+        const latest = records.find((record) => record.id === selectedRecord.id);
+        if (latest && latest !== selectedRecord) {
+            setSelectedRecord(latest);
+        }
+    }, [records, selectedRecord]);
+
     const filteredRecords = useMemo(() => {
         return records.filter((record) => {
             const query = search.toLowerCase();
@@ -246,19 +252,103 @@ export default function DoctorPatientsPage() {
 
             const matchesStatus = statusFilter === "All" || record.status === statusFilter;
             const matchesType = typeFilter === "All" || record.patientType === typeFilter;
+            const matchesAppointment =
+                appointmentFilter === "All" ||
+                (appointmentFilter === "With" && record.latestAppointment) ||
+                (appointmentFilter === "Without" && !record.latestAppointment);
 
-            return matchesSearch && matchesStatus && matchesType;
+            return matchesSearch && matchesStatus && matchesType && matchesAppointment;
         });
-    }, [records, search, statusFilter, typeFilter]);
+    }, [appointmentFilter, records, search, statusFilter, typeFilter]);
 
-    const studentCount = useMemo(
-        () => records.filter((record) => record.patientType === "Student").length,
+    const totalPatients = records.length;
+    const withAppointments = useMemo(
+        () => records.filter((record) => Boolean(record.latestAppointment)).length,
         [records]
     );
-    const employeeCount = useMemo(
-        () => records.filter((record) => record.patientType === "Employee").length,
-        [records]
-    );
+    const withoutAppointments = totalPatients - withAppointments;
+
+    function openDetails(record: PatientRecord, tab: "details" | "update" | "notes" = "details") {
+        setSelectedRecord(record);
+        setActiveTab(tab);
+        setDetailOpen(true);
+    }
+
+    function closeDetails() {
+        setDetailOpen(false);
+        setSelectedRecord(null);
+        setActiveTab("details");
+    }
+
+    async function handleUpdateInfo(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!selectedRecord) return;
+
+        setUpdatingPatientId(selectedRecord.id);
+        const form = event.currentTarget;
+        const payload = {
+            type: selectedRecord.patientType,
+            medical_cond: (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value,
+            allergies: (form.elements.namedItem("allergies") as HTMLInputElement)?.value,
+        };
+
+        try {
+            const res = await fetch(`/api/doctor/patients/${selectedRecord.id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+
+            if (res.ok) {
+                toast.success("Patient information updated");
+                await loadRecords();
+            } else {
+                const error = await res.json().catch(() => null);
+                toast.error(error?.error ?? "Failed to update patient info");
+            }
+        } catch (error) {
+            console.error(error);
+            toast.error("Failed to update patient info");
+        } finally {
+            setUpdatingPatientId(null);
+        }
+    }
+
+    async function handleSaveNotes(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!selectedRecord?.latestAppointment?.id) {
+            toast.error("No appointment available for notes");
+            return;
+        }
+
+        setSavingNotesPatientId(selectedRecord.id);
+        const form = event.currentTarget;
+        const body = {
+            appointment_id: selectedRecord.latestAppointment.id,
+            reason_of_visit: (form.elements.namedItem("reason_of_visit") as HTMLInputElement)?.value,
+            findings: (form.elements.namedItem("findings") as HTMLInputElement)?.value,
+            diagnosis: (form.elements.namedItem("diagnosis") as HTMLInputElement)?.value,
+        };
+
+        try {
+            const res = await fetch(`/api/doctor/patient-consultations`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            });
+
+            if (res.ok) {
+                toast.success("Consultation notes saved");
+                form.reset();
+                await loadRecords();
+            } else {
+                const error = await res.json().catch(() => null);
+                toast.error(error?.error ?? "Failed to save consultation notes");
+            }
+        } finally {
+            setSavingNotesPatientId(null);
+        }
+    }
 
     return (
         <DoctorLayout
@@ -270,95 +360,114 @@ export default function DoctorPatientsPage() {
                     className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
                     onClick={loadRecords}
                 >
-                    Refresh records
+                    <RefreshCcw className="mr-2 h-4 w-4" /> Refresh records
                 </Button>
             }
         >
             <div className="space-y-6">
                 <section className="mx-auto w-full max-w-6xl space-y-8 px-4 sm:px-6">
-                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                        <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
-                            <CardHeader className="pb-2">
-                                <CardTitle className="text-sm font-medium text-muted-foreground">
-                                    Total patients
-                                </CardTitle>
+                    <div className="grid gap-4 md:grid-cols-3">
+                        <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                            <CardHeader className="flex flex-row items-center justify-between">
+                                <div>
+                                    <CardTitle className="text-base font-semibold text-green-700">Total profiles</CardTitle>
+                                    <p className="text-sm text-muted-foreground">Student and employee records synced</p>
+                                </div>
+                                <Users2 className="h-9 w-9 text-green-500" />
                             </CardHeader>
                             <CardContent>
-                                <p className="text-2xl font-semibold text-green-700">{records.length}</p>
+                                <p className="text-3xl font-semibold text-green-700">{totalPatients}</p>
                             </CardContent>
                         </Card>
-                        <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
-                            <CardHeader className="pb-2">
-                                <CardTitle className="text-sm font-medium text-muted-foreground">
-                                    Students
-                                </CardTitle>
+                        <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                            <CardHeader className="flex flex-row items-center justify-between">
+                                <div>
+                                    <CardTitle className="text-base font-semibold text-green-700">With appointments</CardTitle>
+                                    <p className="text-sm text-muted-foreground">Latest visit attached to the chart</p>
+                                </div>
+                                <BadgeCheck className="h-9 w-9 text-green-500" />
                             </CardHeader>
                             <CardContent>
-                                <p className="text-2xl font-semibold text-green-700">{studentCount}</p>
+                                <p className="text-3xl font-semibold text-green-700">{withAppointments}</p>
                             </CardContent>
                         </Card>
-                        <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
-                            <CardHeader className="pb-2">
-                                <CardTitle className="text-sm font-medium text-muted-foreground">
-                                    Employees
-                                </CardTitle>
+                        <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                            <CardHeader className="flex flex-row items-center justify-between">
+                                <div>
+                                    <CardTitle className="text-base font-semibold text-green-700">No appointment yet</CardTitle>
+                                    <p className="text-sm text-muted-foreground">Profiles ready for intake coordination</p>
+                                </div>
+                                <AlertCircle className="h-9 w-9 text-amber-500" />
                             </CardHeader>
                             <CardContent>
-                                <p className="text-2xl font-semibold text-green-700">{employeeCount}</p>
+                                <p className="text-3xl font-semibold text-green-700">{withoutAppointments}</p>
                             </CardContent>
                         </Card>
                     </div>
 
-                    <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
-                        <CardHeader className="border-b border-green-100/70">
-                            <CardTitle className="text-lg font-semibold text-green-700 sm:text-xl">
-                                Patient directory
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-4 pt-4">
-                            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                                <div className="relative w-full lg:max-w-sm">
-                                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                                    <Input
-                                        placeholder="Search patients..."
-                                        value={search}
-                                        onChange={(event) => setSearch(event.target.value)}
-                                        className="pl-8"
-                                    />
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                            <div className="space-y-1">
+                                <CardTitle className="text-xl text-green-700">Patient directory</CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Filter student and employee details before handing off to nurses or doctors.
+                                </p>
+                            </div>
+                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                                <div className="space-y-2">
+                                    <Label className="text-sm font-medium text-green-700">Patient type</Label>
+                                    <Select value={typeFilter} onValueChange={setTypeFilter}>
+                                        <SelectTrigger className="rounded-xl border-green-200">
+                                            <SelectValue placeholder="All types" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="All">All</SelectItem>
+                                            <SelectItem value="Student">Students</SelectItem>
+                                            <SelectItem value="Employee">Employees</SelectItem>
+                                        </SelectContent>
+                                    </Select>
                                 </div>
-                                <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-                                    <div className="space-y-1 w-full sm:w-40">
-                                        <Label htmlFor="status-filter" className="text-sm font-medium text-green-700">
-                                            Status
-                                        </Label>
-                                        <Select value={statusFilter} onValueChange={setStatusFilter}>
-                                            <SelectTrigger id="status-filter">
-                                                <SelectValue placeholder="Filter status" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="All">All Status</SelectItem>
-                                                <SelectItem value="Active">Active</SelectItem>
-                                                <SelectItem value="Inactive">Inactive</SelectItem>
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                    <div className="space-y-1 w-full sm:w-40">
-                                        <Label htmlFor="type-filter" className="text-sm font-medium text-green-700">
-                                            Patient Type
-                                        </Label>
-                                        <Select value={typeFilter} onValueChange={setTypeFilter}>
-                                            <SelectTrigger id="type-filter">
-                                                <SelectValue placeholder="Filter type" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="All">All Patients</SelectItem>
-                                                <SelectItem value="Student">Student</SelectItem>
-                                                <SelectItem value="Employee">Employee</SelectItem>
-                                            </SelectContent>
-                                        </Select>
+                                <div className="space-y-2">
+                                    <Label className="text-sm font-medium text-green-700">Account status</Label>
+                                    <Select value={statusFilter} onValueChange={setStatusFilter}>
+                                        <SelectTrigger className="rounded-xl border-green-200">
+                                            <SelectValue placeholder="Status" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="All">All</SelectItem>
+                                            <SelectItem value="Active">Active</SelectItem>
+                                            <SelectItem value="Inactive">Inactive</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <Label className="text-sm font-medium text-green-700">Appointment link</Label>
+                                    <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
+                                        <SelectTrigger className="rounded-xl border-green-200">
+                                            <SelectValue placeholder="Appointments" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="All">All</SelectItem>
+                                            <SelectItem value="With">With appointment</SelectItem>
+                                            <SelectItem value="Without">No appointment</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <Label className="text-sm font-medium text-green-700">Search records</Label>
+                                    <div className="relative">
+                                        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                        <Input
+                                            placeholder="Search by name or ID"
+                                            value={search}
+                                            onChange={(event) => setSearch(event.target.value)}
+                                            className="rounded-xl border-green-200 pl-9"
+                                        />
                                     </div>
                                 </div>
                             </div>
+                        </CardHeader>
+                        <CardContent className="space-y-4 pt-4">
 
                             {loadingRecords ? (
                                 <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
@@ -369,326 +478,333 @@ export default function DoctorPatientsPage() {
                             ) : (
                                 <div className="overflow-x-auto">
                                     <Table className="min-w-[900px] text-sm">
-                                        <TableHeader className="bg-green-100/70 text-green-700">
-                                            <TableRow>
-                                                <TableHead>Patient ID</TableHead>
-                                                <TableHead>Full Name</TableHead>
-                                                <TableHead>Type</TableHead>
-                                                <TableHead>Gender</TableHead>
-                                                <TableHead>DOB</TableHead>
-                                                <TableHead>Status</TableHead>
-                                                <TableHead className="min-w-[160px]">Department / Program</TableHead>
-                                                <TableHead>Latest Appointment</TableHead>
-                                                <TableHead className="text-center">Actions</TableHead>
+                                        <TableHeader>
+                                            <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
+                                                <TableHead className="min-w-[200px]">Patient</TableHead>
+                                                <TableHead className="min-w-[140px]">ID</TableHead>
+                                                <TableHead className="min-w-[120px]">Type</TableHead>
+                                                <TableHead className="min-w-[160px]">Program / Department</TableHead>
+                                                <TableHead className="min-w-[120px]">Status</TableHead>
+                                                <TableHead className="min-w-[200px]">Latest appointment</TableHead>
                                             </TableRow>
                                         </TableHeader>
                                         <TableBody>
-                                            {filteredRecords.map((record) => (
-                                                <TableRow key={record.id} className="hover:bg-green-50">
-                                                    <TableCell>{record.patientId}</TableCell>
-                                                    <TableCell>{record.fullName}</TableCell>
-                                                    <TableCell>{record.patientType}</TableCell>
-                                                    <TableCell>{record.gender || "—"}</TableCell>
-                                                    <TableCell>{formatDateOnly(record.date_of_birth)}</TableCell>
-                                                    <TableCell>
-                                                        <Badge
-                                                            variant={record.status === "Active" ? "default" : "secondary"}
-                                                            className={
-                                                                record.status === "Active"
-                                                                    ? "bg-green-100 text-green-700"
-                                                                    : "bg-neutral-200 text-neutral-600"
+                                            {filteredRecords.map((record) => {
+                                                const statusKey = record.status.toLowerCase();
+                                                return (
+                                                    <TableRow
+                                                        key={record.id}
+                                                        className="cursor-pointer text-sm transition hover:bg-green-50/60 focus-visible:bg-green-50/60"
+                                                        onClick={() => openDetails(record)}
+                                                        onKeyDown={(event) => {
+                                                            if (event.key === "Enter" || event.key === " ") {
+                                                                event.preventDefault();
+                                                                openDetails(record);
                                                             }
-                                                        >
-                                                            {record.status}
-                                                        </Badge>
-                                                    </TableCell>
-                                                    <TableCell className="whitespace-pre-wrap text-muted-foreground">
-                                                        {record.patientType === "Student" ? (
-                                                            <>
-                                                                <span className="block font-medium text-foreground">
-                                                                    {formatDeptTypes(record.department)}
+                                                        }}
+                                                        tabIndex={0}
+                                                        role="button"
+                                                    >
+                                                        <TableCell className="font-medium text-green-700">
+                                                            <div className="flex flex-col">
+                                                                <span>{record.fullName}</span>
+                                                                <span className="text-xs text-muted-foreground">
+                                                                    {record.contactno ? record.contactno : "No contact number"}
                                                                 </span>
-                                                                <span className="block">
-                                                                    {formatDeptTypes(record.program)}
-                                                                </span>
-                                                            </>
-                                                        ) : (
-                                                            "—"
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell className="whitespace-pre-wrap">
-                                                        {record.latestAppointment?.timestart ? (
-                                                            <>
-                                                                <span className="block">
-                                                                    {formatAppointmentWindow(record.latestAppointment)}
-                                                                </span>
-                                                                <span className="block text-xs text-muted-foreground">
-                                                                    Doctor: {formatStaffName(record.latestAppointment.doctor)}
-                                                                </span>
-                                                                <span className="block text-xs text-muted-foreground">
-                                                                    Nurse: {formatStaffName(record.latestAppointment.consultation?.nurse)}
-                                                                </span>
-                                                            </>
-                                                        ) : (
-                                                            "—"
-                                                        )}
-                                                    </TableCell>
-                                                    <TableCell className="text-center whitespace-nowrap min-w-[90px] sm:min-w-[110px]">
-                                                        <Dialog>
-                                                            <DialogTrigger asChild>
-                                                                <Button size="sm" className="bg-green-600 hover:bg-green-700 text-white px-3 text-xs sm:text-sm">
-                                                                    Manage
-                                                                </Button>
-                                                            </DialogTrigger>
-                                                            <DialogContent className="max-w-2xl sm:max-w-2xl w-[95vw] sm:w-auto rounded-lg p-4 sm:p-6 max-h-[85vh] sm:max-h-none overflow-y-auto">
-                                                                <DialogHeader>
-                                                                    <DialogTitle>{record.fullName}</DialogTitle>
-                                                                    <DialogDescription>
-                                                                        {record.patientType} patient record overview
-                                                                    </DialogDescription>
-                                                                </DialogHeader>
-                                                                <Tabs defaultValue="details" className="space-y-4">
-                                                                    <div className="flex justify-center">
-                                                                        <TabsList className="flex flex-wrap gap-2">
-                                                                            <TabsTrigger value="details">Details</TabsTrigger>
-                                                                            <TabsTrigger value="update">Update Info</TabsTrigger>
-                                                                            <TabsTrigger value="notes">Consultation Notes</TabsTrigger>
-                                                                        </TabsList>
-                                                                    </div>
-                                                                    <TabsContent value="details" className="space-y-4">
-                                                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                                                                            <p><strong>Patient ID:</strong> {record.patientId}</p>
-                                                                            <p><strong>Status:</strong> {record.status}</p>
-                                                                            <p><strong>Gender:</strong> {record.gender || "—"}</p>
-                                                                            <p><strong>DOB:</strong> {formatDateOnly(record.date_of_birth)}</p>
-                                                                            <p><strong>Contact:</strong> {record.contactno || "—"}</p>
-                                                                            <p><strong>Address:</strong> {record.address || "—"}</p>
-                                                                            <p><strong>Blood Type:</strong> {formatBloodType(record.bloodtype)}</p>
-                                                                            <p><strong>Allergies:</strong> {record.allergies || "—"}</p>
-                                                                            <p><strong>Medical Conditions:</strong> {record.medical_cond || "—"}</p>
-                                                                            <p>
-                                                                                <strong>Emergency:</strong>{" "}
-                                                                                {record.emergency?.name || "—"} ({record.emergency?.relation || "—"}) – {record.emergency?.num || "—"}
-                                                                            </p>
-                                                                            {record.patientType === "Student" && (
-                                                                                <>
-                                                                                    <p><strong>Department:</strong> {formatDeptTypes(record.department)}</p>
-                                                                                    <p><strong>Program:</strong> {formatDeptTypes(record.program)}</p>
-                                                                                    <p> <strong>Year Level:</strong> {formatYearTypes(record.year_level)}</p>
-                                                                                </>
-                                                                            )}
-                                                                        </div>
-
-                                                                        <Separator />
-
-                                                                        <div className="space-y-3 text-sm">
-                                                                            <h4 className="font-semibold text-green-600 flex items-center gap-2">
-                                                                                <Stethoscope className="h-4 w-4" /> Latest Appointment
-                                                                            </h4>
-                                                                            {record.latestAppointment?.timestart ? (
-                                                                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                                                                                    <p>
-                                                                                        <strong>Schedule:</strong> {formatAppointmentWindow(record.latestAppointment)}
-                                                                                    </p>
-                                                                                    <p>
-                                                                                        <strong>Doctor:</strong> {formatStaffName(record.latestAppointment.doctor)}
-                                                                                    </p>
-                                                                                    <p>
-                                                                                        <strong>Nurse:</strong> {formatStaffName(record.latestAppointment.consultation?.nurse)}
-                                                                                    </p>
-                                                                                    <p>
-                                                                                        <strong>Appointment ID:</strong> {record.latestAppointment.id}
-                                                                                    </p>
-                                                                                </div>
-                                                                            ) : (
-                                                                                <p className="text-muted-foreground">No recent appointment on file.</p>
-                                                                            )}
-
-                                                                            {record.latestAppointment?.consultation && (
-                                                                                <div className="rounded-md border bg-muted/40 p-3 space-y-1">
-                                                                                    <p className="text-sm font-semibold text-green-600">Consultation Notes</p>
-                                                                                    <p><strong>Reason:</strong> {record.latestAppointment.consultation.reason_of_visit || "—"}</p>
-                                                                                    <p><strong>Findings:</strong> {record.latestAppointment.consultation.findings || "—"}</p>
-                                                                                    <p><strong>Diagnosis:</strong> {record.latestAppointment.consultation.diagnosis || "—"}</p>
-                                                                                    <p className="text-xs text-muted-foreground">
-                                                                                        Updated by {formatStaffName(record.latestAppointment.consultation.doctor)} on {formatManilaDateTime(record.latestAppointment.consultation.updatedAt) || "—"}
-                                                                                    </p>
-                                                                                </div>
-                                                                            )}
-                                                                        </div>
-                                                                    </TabsContent>
-
-                                                                    <TabsContent value="update" className="space-y-4">
-                                                                        <form
-                                                                            onSubmit={async (event) => {
-                                                                                event.preventDefault();
-                                                                                setUpdatingPatientId(record.id);
-                                                                                const form = event.currentTarget as HTMLFormElement;
-                                                                                const payload = {
-                                                                                    type: record.patientType,
-                                                                                    medical_cond: (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value,
-                                                                                    allergies: (form.elements.namedItem("allergies") as HTMLInputElement)?.value,
-                                                                                };
-
-                                                                                try {
-                                                                                    const res = await fetch(`/api/doctor/patients/${record.id}`, {
-                                                                                        method: "PATCH",
-                                                                                        headers: { "Content-Type": "application/json" },
-                                                                                        body: JSON.stringify(payload),
-                                                                                    });
-
-                                                                                    if (res.ok) {
-                                                                                        toast.success("Patient information updated");
-                                                                                        await loadRecords();
-                                                                                    } else {
-                                                                                        const error = await res.json().catch(() => null);
-                                                                                        toast.error(error?.error ?? "Failed to update patient info");
-                                                                                    }
-                                                                                } catch (error) {
-                                                                                    console.error(error);
-                                                                                    toast.error("Failed to update patient info");
-                                                                                } finally {
-                                                                                    setUpdatingPatientId(null);
-                                                                                }
-                                                                            }}
-                                                                            className="space-y-3"
-                                                                        >
-                                                                            <div>
-                                                                                <Label className="block mb-1 font-medium" htmlFor="medical_cond">Medical Conditions</Label>
-                                                                                <Input
-                                                                                    id="medical_cond"
-                                                                                    name="medical_cond"
-                                                                                    defaultValue={record.medical_cond || ""}
-                                                                                />
-                                                                            </div>
-                                                                            <div>
-                                                                                <Label className="block mb-1 font-medium" htmlFor="allergies">Allergies</Label>
-                                                                                <Input
-                                                                                    id="allergies"
-                                                                                    name="allergies"
-                                                                                    defaultValue={record.allergies || ""}
-                                                                                    placeholder="e.g. Penicillin, Peanuts"
-                                                                                />
-                                                                            </div>
-                                                                            <Button
-                                                                                type="submit"
-                                                                                disabled={updatingPatientId === record.id}
-                                                                                className="bg-green-600 hover:bg-green-700 text-white"
-                                                                            >
-                                                                                {updatingPatientId === record.id ? (
-                                                                                    <>
-                                                                                        <Loader2 className="w-4 h-4 animate-spin" />
-                                                                                        Saving...
-                                                                                    </>
-                                                                                ) : (
-                                                                                    "Save Info"
-                                                                                )}
-                                                                            </Button>
-                                                                        </form>
-                                                                    </TabsContent>
-
-                                                                    <TabsContent value="notes" className="space-y-4">
-                                                                        <form
-                                                                            onSubmit={async (event) => {
-                                                                                event.preventDefault();
-                                                                                if (!record.latestAppointment?.id) {
-                                                                                    toast.error("No appointment available for notes");
-                                                                                    return;
-                                                                                }
-
-                                                                                setSavingNotesPatientId(record.id);
-                                                                                const form = event.currentTarget as HTMLFormElement;
-                                                                                const body = {
-                                                                                    appointment_id: record.latestAppointment.id,
-                                                                                    reason_of_visit: (form.elements.namedItem("reason_of_visit") as HTMLInputElement)?.value,
-                                                                                    findings: (form.elements.namedItem("findings") as HTMLInputElement)?.value,
-                                                                                    diagnosis: (form.elements.namedItem("diagnosis") as HTMLInputElement)?.value,
-                                                                                };
-
-                                                                                try {
-                                                                                    const res = await fetch(`/api/doctor/patient-consultations`, {
-                                                                                        method: "POST",
-                                                                                        headers: { "Content-Type": "application/json" },
-                                                                                        body: JSON.stringify(body),
-                                                                                    });
-
-                                                                                    if (res.ok) {
-                                                                                        toast.success("Consultation notes saved");
-                                                                                        form.reset();
-                                                                                        await loadRecords();
-                                                                                    } else {
-                                                                                        const error = await res.json().catch(() => null);
-                                                                                        toast.error(error?.error ?? "Failed to save consultation notes");
-                                                                                    }
-                                                                                } finally {
-                                                                                    setSavingNotesPatientId(null);
-                                                                                }
-                                                                            }}
-                                                                            className="space-y-3"
-                                                                        >
-                                                                            {!record.latestAppointment?.id && (
-                                                                                <p className="text-sm text-yellow-600 bg-yellow-50 border border-yellow-200 rounded-md p-3">
-                                                                                    This patient has no active appointment. Approve or schedule one to record consultation notes.
-
-                                                                                </p>
-                                                                            )}
-                                                                            <div>
-                                                                                <Label className="block mb-1 font-medium" htmlFor="reason_of_visit">Reason of Visit</Label>
-                                                                                <Input
-                                                                                    id="reason_of_visit"
-                                                                                    name="reason_of_visit"
-                                                                                    defaultValue={record.latestAppointment?.consultation?.reason_of_visit || ""}
-                                                                                />
-                                                                            </div>
-                                                                            <div>
-                                                                                <Label className="block mb-1 font-medium" htmlFor="findings">Findings</Label>
-                                                                                <Input
-                                                                                    id="findings"
-                                                                                    name="findings"
-                                                                                    defaultValue={record.latestAppointment?.consultation?.findings || ""}
-                                                                                />
-                                                                            </div>
-                                                                            <div>
-                                                                                <Label className="block mb-1 font-medium" htmlFor="diagnosis">Diagnosis</Label>
-                                                                                <Input
-                                                                                    id="diagnosis"
-                                                                                    name="diagnosis"
-                                                                                    defaultValue={record.latestAppointment?.consultation?.diagnosis || ""}
-                                                                                />
-                                                                            </div>
-                                                                            <Button
-                                                                                type="submit"
-                                                                                disabled={savingNotesPatientId === record.id || !record.latestAppointment?.id}
-                                                                                className="bg-green-600 hover:bg-green-700 text-white"
-                                                                            >
-                                                                                {savingNotesPatientId === record.id ? (
-                                                                                    <>
-                                                                                        <Loader2 className="w-4 h-4 animate-spin" />
-                                                                                        Saving...
-                                                                                    </>
-                                                                                ) : !record.latestAppointment?.id ? (
-                                                                                    "No appointment"
-                                                                                ) : (
-                                                                                    "Save Notes"
-                                                                                )}
-                                                                            </Button>
-                                                                        </form>
-                                                                    </TabsContent>
-                                                                </Tabs>
-                                                            </DialogContent>
-                                                        </Dialog>
-                                                    </TableCell>
-                                                </TableRow>
-                                            ))}
+                                                            </div>
+                                                        </TableCell>
+                                                        <TableCell>{record.patientId}</TableCell>
+                                                        <TableCell>
+                                                            <Badge className="rounded-full border-green-200 bg-green-50 text-green-700">
+                                                                {record.patientType}
+                                                            </Badge>
+                                                        </TableCell>
+                                                        <TableCell className="whitespace-pre-wrap text-muted-foreground">
+                                                            {record.patientType === "Student" ? (
+                                                                <>
+                                                                    <span className="block font-medium text-foreground">
+                                                                        {formatDeptTypes(record.department)}
+                                                                    </span>
+                                                                    <span className="block">{formatDeptTypes(record.program)}</span>
+                                                                </>
+                                                            ) : (
+                                                                formatDeptTypes(record.department) || "—"
+                                                            )}
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <Badge
+                                                                className={`rounded-full px-2 py-1 text-xs ${
+                                                                    PATIENT_STATUS_CLASSES[statusKey] ??
+                                                                    "border-slate-200 bg-slate-100 text-slate-700"
+                                                                }`}
+                                                            >
+                                                                {record.status}
+                                                            </Badge>
+                                                        </TableCell>
+                                                        <TableCell className="whitespace-pre-wrap">
+                                                            {record.latestAppointment?.timestart ? (
+                                                                <div className="flex flex-col">
+                                                                    <span>{formatAppointmentWindow(record.latestAppointment)}</span>
+                                                                    <span className="text-xs text-muted-foreground">
+                                                                        Doctor: {formatStaffName(record.latestAppointment.doctor)}
+                                                                    </span>
+                                                                    <span className="text-xs text-muted-foreground">
+                                                                        Nurse: {formatStaffName(record.latestAppointment.consultation?.nurse)}
+                                                                    </span>
+                                                                </div>
+                                                            ) : (
+                                                                <span className="text-muted-foreground">—</span>
+                                                            )}
+                                                        </TableCell>
+                                                    </TableRow>
+                                                );
+                                            })}
                                         </TableBody>
                                     </Table>
                                 </div>
                             )}
-                        </CardContent>
-                    </Card>
-                </section>
+                </CardContent>
+            </Card>
+        </section>
 
-            </div>
+            <Dialog
+                open={detailOpen}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        closeDetails();
+                    }
+                }}
+            >
+                <DialogContent className="rounded-3xl sm:max-w-3xl">
+                    {selectedRecord ? (
+                        <div className="space-y-6">
+                            <DialogHeader>
+                                <DialogTitle className="text-xl text-green-700">Patient snapshot</DialogTitle>
+                                <DialogDescription className="text-sm text-muted-foreground">
+                                    Contact details and clinical notes shared with the care team.
+                                </DialogDescription>
+                            </DialogHeader>
+
+                            <div className="rounded-2xl bg-green-50/70 p-4 text-green-700">
+                                <p className="text-lg font-semibold">{selectedRecord.fullName}</p>
+                                <div className="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Patient ID</p>
+                                        <p className="font-medium text-green-700">{selectedRecord.patientId}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Type</p>
+                                        <p className="font-medium text-green-700">{selectedRecord.patientType}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Date of birth</p>
+                                        <p className="font-medium text-green-700">{formatDateOnly(selectedRecord.date_of_birth)}</p>
+                                    </div>
+                                    <div>
+                                        <p className="text-xs uppercase tracking-wide text-green-500">Gender</p>
+                                        <p className="font-medium text-green-700">{selectedRecord.gender ?? "—"}</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <Tabs
+                                value={activeTab}
+                                onValueChange={(value) => setActiveTab(value as "details" | "update" | "notes")}
+                                className="space-y-4"
+                            >
+                                <div className="flex justify-center">
+                                    <TabsList className="flex flex-wrap gap-2">
+                                        <TabsTrigger value="details">Details</TabsTrigger>
+                                        <TabsTrigger value="update">Update Info</TabsTrigger>
+                                        <TabsTrigger value="notes">Consultation Notes</TabsTrigger>
+                                    </TabsList>
+                                </div>
+
+                                <TabsContent value="details" className="space-y-4">
+                                    <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                                        <p>
+                                            <strong>Contact:</strong> {selectedRecord.contactno || "—"}
+                                        </p>
+                                        <p>
+                                            <strong>Address:</strong> {selectedRecord.address || "—"}
+                                        </p>
+                                        <p>
+                                            <strong>Blood Type:</strong> {formatBloodType(selectedRecord.bloodtype)}
+                                        </p>
+                                        <p>
+                                            <strong>Allergies:</strong> {selectedRecord.allergies || "—"}
+                                        </p>
+                                        <p>
+                                            <strong>Medical Conditions:</strong> {selectedRecord.medical_cond || "—"}
+                                        </p>
+                                        <p>
+                                            <strong>Emergency:</strong> {selectedRecord.emergency?.name || "—"} (
+                                            {selectedRecord.emergency?.relation || "—"}) – {selectedRecord.emergency?.num || "—"}
+                                        </p>
+                                        {selectedRecord.patientType === "Student" ? (
+                                            <>
+                                                <p>
+                                                    <strong>Department:</strong> {formatDeptTypes(selectedRecord.department)}
+                                                </p>
+                                                <p>
+                                                    <strong>Program:</strong> {formatDeptTypes(selectedRecord.program)}
+                                                </p>
+                                                <p>
+                                                    <strong>Year Level:</strong> {formatYearTypes(selectedRecord.year_level)}
+                                                </p>
+                                            </>
+                                        ) : null}
+                                    </div>
+
+                                    <Separator />
+
+                                    <div className="space-y-3 text-sm">
+                                        <h4 className="flex items-center gap-2 font-semibold text-green-600">
+                                            <Stethoscope className="h-4 w-4" /> Latest appointment
+                                        </h4>
+                                        {selectedRecord.latestAppointment?.timestart ? (
+                                            <div className="grid gap-2 sm:grid-cols-2">
+                                                <p>
+                                                    <strong>Schedule:</strong> {formatAppointmentWindow(selectedRecord.latestAppointment)}
+                                                </p>
+                                                <p>
+                                                    <strong>Doctor:</strong> {formatStaffName(selectedRecord.latestAppointment.doctor)}
+                                                </p>
+                                                <p>
+                                                    <strong>Nurse:</strong> {formatStaffName(selectedRecord.latestAppointment.consultation?.nurse)}
+                                                </p>
+                                                <p>
+                                                    <strong>Appointment ID:</strong> {selectedRecord.latestAppointment.id}
+                                                </p>
+                                            </div>
+                                        ) : (
+                                            <p className="text-muted-foreground">No recent appointment on file.</p>
+                                        )}
+
+                                        {selectedRecord.latestAppointment?.consultation ? (
+                                            <div className="space-y-1 rounded-md border bg-muted/40 p-3">
+                                                <p className="text-sm font-semibold text-green-600">Consultation Notes</p>
+                                                <p>
+                                                    <strong>Reason:</strong> {selectedRecord.latestAppointment.consultation.reason_of_visit || "—"}
+                                                </p>
+                                                <p>
+                                                    <strong>Findings:</strong> {selectedRecord.latestAppointment.consultation.findings || "—"}
+                                                </p>
+                                                <p>
+                                                    <strong>Diagnosis:</strong> {selectedRecord.latestAppointment.consultation.diagnosis || "—"}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    Updated by {formatStaffName(selectedRecord.latestAppointment.consultation.doctor)} on
+                                                    {" "}
+                                                    {formatManilaDateTime(selectedRecord.latestAppointment.consultation.updatedAt) || "—"}
+                                                </p>
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                </TabsContent>
+
+                                <TabsContent value="update" className="space-y-4">
+                                    <form onSubmit={handleUpdateInfo} className="space-y-3">
+                                        <div>
+                                            <Label className="mb-1 block font-medium" htmlFor="medical_cond">
+                                                Medical Conditions
+                                            </Label>
+                                            <Input
+                                                id="medical_cond"
+                                                name="medical_cond"
+                                                defaultValue={selectedRecord.medical_cond || ""}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label className="mb-1 block font-medium" htmlFor="allergies">
+                                                Allergies
+                                            </Label>
+                                            <Input
+                                                id="allergies"
+                                                name="allergies"
+                                                defaultValue={selectedRecord.allergies || ""}
+                                                placeholder="e.g. Penicillin, Peanuts"
+                                            />
+                                        </div>
+                                        <Button
+                                            type="submit"
+                                            disabled={updatingPatientId === selectedRecord.id}
+                                            className="bg-green-600 text-white hover:bg-green-700"
+                                        >
+                                            {updatingPatientId === selectedRecord.id ? (
+                                                <>
+                                                    <Loader2 className="h-4 w-4 animate-spin" /> Saving...
+                                                </>
+                                            ) : (
+                                                "Save info"
+                                            )}
+                                        </Button>
+                                    </form>
+                                </TabsContent>
+
+                                <TabsContent value="notes" className="space-y-4">
+                                    <form onSubmit={handleSaveNotes} className="space-y-3">
+                                        {!selectedRecord.latestAppointment?.id ? (
+                                            <p className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-700">
+                                                This patient has no active appointment. Approve or schedule one to record consultation notes.
+                                            </p>
+                                        ) : null}
+                                        <div>
+                                            <Label className="mb-1 block font-medium" htmlFor="reason_of_visit">
+                                                Reason of Visit
+                                            </Label>
+                                            <Input
+                                                id="reason_of_visit"
+                                                name="reason_of_visit"
+                                                defaultValue={selectedRecord.latestAppointment?.consultation?.reason_of_visit || ""}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label className="mb-1 block font-medium" htmlFor="findings">
+                                                Findings
+                                            </Label>
+                                            <Input
+                                                id="findings"
+                                                name="findings"
+                                                defaultValue={selectedRecord.latestAppointment?.consultation?.findings || ""}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label className="mb-1 block font-medium" htmlFor="diagnosis">
+                                                Diagnosis
+                                            </Label>
+                                            <Input
+                                                id="diagnosis"
+                                                name="diagnosis"
+                                                defaultValue={selectedRecord.latestAppointment?.consultation?.diagnosis || ""}
+                                            />
+                                        </div>
+                                        <Button
+                                            type="submit"
+                                            disabled={
+                                                savingNotesPatientId === selectedRecord.id ||
+                                                !selectedRecord.latestAppointment?.id
+                                            }
+                                            className="bg-green-600 text-white hover:bg-green-700"
+                                        >
+                                            {savingNotesPatientId === selectedRecord.id ? (
+                                                <>
+                                                    <Loader2 className="h-4 w-4 animate-spin" /> Saving...
+                                                </>
+                                            ) : !selectedRecord.latestAppointment?.id ? (
+                                                "No appointment"
+                                            ) : (
+                                                "Save notes"
+                                            )}
+                                        </Button>
+                                    </form>
+                                </TabsContent>
+                            </Tabs>
+                        </div>
+                    ) : null}
+                </DialogContent>
+            </Dialog>
+        </div>
         </DoctorLayout>
     );
 }

--- a/src/app/scholar/patients/page.tsx
+++ b/src/app/scholar/patients/page.tsx
@@ -372,13 +372,12 @@ export default function ScholarPatientsPage() {
                                     <TableHead className="min-w-[160px]">Program / Department</TableHead>
                                     <TableHead className="min-w-[120px]">Status</TableHead>
                                     <TableHead className="min-w-[200px]">Latest appointment</TableHead>
-                                    <TableHead className="w-[110px] text-right">Actions</TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
                                 {loading ? (
                                     <TableRow>
-                                        <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                                        <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
                                             <div className="flex items-center justify-center gap-2 text-sm">
                                                 <Loader2 className="h-4 w-4 animate-spin" /> Loading patient records...
                                             </div>
@@ -386,7 +385,7 @@ export default function ScholarPatientsPage() {
                                     </TableRow>
                                 ) : filteredRecords.length === 0 ? (
                                     <TableRow>
-                                        <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                                        <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
                                             No patient records match your filters.
                                         </TableCell>
                                     </TableRow>
@@ -394,7 +393,19 @@ export default function ScholarPatientsPage() {
                                     filteredRecords.map((record) => {
                                         const statusKey = record.status.toLowerCase();
                                         return (
-                                            <TableRow key={`${record.patientType}-${record.id}`} className="text-sm">
+                                            <TableRow
+                                                key={`${record.patientType}-${record.id}`}
+                                                className="cursor-pointer text-sm transition hover:bg-green-50/60 focus-visible:bg-green-50/60"
+                                                tabIndex={0}
+                                                role="button"
+                                                onClick={() => openDetails(record)}
+                                                onKeyDown={(event) => {
+                                                    if (event.key === "Enter" || event.key === " ") {
+                                                        event.preventDefault();
+                                                        openDetails(record);
+                                                    }
+                                                }}
+                                            >
                                                 <TableCell className="font-medium text-green-700">
                                                     <div className="flex flex-col">
                                                         <span>{record.fullName}</span>
@@ -435,16 +446,6 @@ export default function ScholarPatientsPage() {
                                                     ) : (
                                                         <span className="text-muted-foreground">—</span>
                                                     )}
-                                                </TableCell>
-                                                <TableCell className="text-right">
-                                                    <Button
-                                                        variant="ghost"
-                                                        size="sm"
-                                                        className="rounded-xl text-green-700 hover:bg-green-100"
-                                                        onClick={() => openDetails(record)}
-                                                    >
-                                                        View
-                                                    </Button>
                                                 </TableCell>
                                             </TableRow>
                                         );


### PR DESCRIPTION
## Summary
- Align the scholar appointment board with the shared summary cards, filters, and streamlined table view.
- Refresh the scholar, doctor, and patient directories to use the new statistic cards, inline row navigation, and shared detail dialogs.
- Rebuild the nurse records dashboard with the same card layout, filters, and tabbed patient snapshot as the other roles.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f2483ee12c83339866003b402634e4