### PR TITLE
Refine nurse quarterly report exports

### DIFF
--- a/src/app/nurse/reports/page.tsx
+++ b/src/app/nurse/reports/page.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import {
-    AlertCircle,
-    BarChart2,
-    CalendarRange,
-    DownloadCloud,
-    Loader2,
-    PieChart,
-    FileDown,
-} from "lucide-react";
+import { AlertCircle, BarChart2, CalendarRange, Loader2, PieChart, FileDown } from "lucide-react";
 import { Bar, BarChart, CartesianGrid, Legend, XAxis, YAxis } from "recharts";
 
 import { NurseLayout } from "@/components/nurse/nurse-layout";
@@ -278,43 +270,6 @@ export default function NurseReportsPage() {
                             <FileDown className="mr-2 h-4 w-4" />
                         )}
                         Generate PDF
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
-                        onClick={() => {
-                            if (!data) return;
-                            const reportDate = new Date();
-                            const blob = new Blob(
-                                [
-                                    JSON.stringify(
-                                        {
-                                            generatedAt: reportDate.toISOString(),
-                                            filters: {
-                                                year,
-                                                quarter,
-                                            },
-                                            data,
-                                        },
-                                        null,
-                                        2
-                                    ),
-                                ],
-                                { type: "application/json" }
-                            );
-                            const url = URL.createObjectURL(blob);
-                            const link = document.createElement("a");
-                            link.href = url;
-                            link.download = `nurse-quarterly-report-${year}-q${quarter}.json`;
-                            document.body.appendChild(link);
-                            link.click();
-                            document.body.removeChild(link);
-                            URL.revokeObjectURL(url);
-                        }}
-                        disabled={!data}
-                    >
-                        <DownloadCloud className="mr-2 h-4 w-4" /> Export JSON
                     </Button>
                 </div>
             }


### PR DESCRIPTION
## Summary
- remove the JSON export action from the nurse reports page to focus on the PDF workflow
- redesign the quarterly PDF to highlight the selected quarter with improved styling and clearer patient mix details
- update PDF generation helpers to summarise only the chosen quarter while keeping download handling intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f4553303248333b150089d0f95168c