### PR TITLE
Add contact validation to account management forms

### DIFF
--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -28,6 +28,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { validateAndNormalizeContacts } from "@/lib/validation";
 
 const departmentEnumMap: Record<string, string> = {
     EDUCATION: "College of Education",
@@ -275,10 +276,30 @@ export default function ScholarAccountPage() {
                 return;
             }
 
+            const contactValidation = validateAndNormalizeContacts({
+                email: profile.email,
+                contactNumber: profile.contactno,
+                emergencyNumber: profile.emergencyco_num,
+            });
+
+            if (!contactValidation.success) {
+                toast.error(contactValidation.error);
+                return;
+            }
+
+            const updatedProfile = {
+                ...profile,
+                email: contactValidation.email,
+                contactno: contactValidation.contactNumber,
+                emergencyco_num: contactValidation.emergencyNumber,
+            };
+
+            setProfile(updatedProfile);
+
             try {
                 setUpdating(true);
 
-                const payload = formatRequestPayload(profile);
+                const payload = formatRequestPayload(updatedProfile);
                 const res = await fetch("/api/scholar/account/me", {
                     method: "PUT",
                     headers: { "Content-Type": "application/json" },
@@ -334,9 +355,30 @@ export default function ScholarAccountPage() {
     const confirmDateOfBirth = useCallback(async () => {
         if (!profile || !tempDOB) return;
 
+        const contactValidation = validateAndNormalizeContacts({
+            email: profile.email,
+            contactNumber: profile.contactno,
+            emergencyNumber: profile.emergencyco_num,
+        });
+
+        if (!contactValidation.success) {
+            toast.error(contactValidation.error);
+            return;
+        }
+
+        const updatedProfile = {
+            ...profile,
+            email: contactValidation.email,
+            contactno: contactValidation.contactNumber,
+            emergencyco_num: contactValidation.emergencyNumber,
+            date_of_birth: tempDOB,
+        };
+
+        setProfile(updatedProfile);
+
         try {
             setDobSaving(true);
-            const payload = formatRequestPayload({ ...profile, date_of_birth: tempDOB });
+            const payload = formatRequestPayload(updatedProfile);
             const res = await fetch("/api/scholar/account/me", {
                 method: "PUT",
                 headers: { "Content-Type": "application/json" },

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,20 +1,22 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-export const PHONE_NUMBER_REGEX = /^09[0-9]{9}$/;
+export const PHONE_NUMBER_REGEX = /^09\d{9}$/;
 
 export function sanitizePhoneNumber(value: string): string {
     if (!value) return "";
 
-    let cleaned = value.replace(/\D/g, "");
-
-    if (/^9\d{9}$/.test(cleaned)) {
-        cleaned = `0${cleaned}`;
+    if (/[^0-9]/.test(value)) {
+        return "INVALID";
     }
 
-    if (cleaned.length > 11) {
-        cleaned = cleaned.slice(0, 11);
+    if (/^9\d{9}$/.test(value)) {
+        value = `0${value}`;
     }
 
-    return cleaned;
+    if (value.length > 11) {
+        value = value.slice(0, 11);
+    }
+
+    return value;
 }
 
 type ContactValidationInput = {
@@ -45,18 +47,18 @@ export function validateAndNormalizeContacts(input: ContactValidationInput): Con
     }
 
     const contactNumber = input.contactNumber ? sanitizePhoneNumber(input.contactNumber) : "";
-    if (contactNumber && !PHONE_NUMBER_REGEX.test(contactNumber)) {
+    if (contactNumber === "INVALID" || (contactNumber && !PHONE_NUMBER_REGEX.test(contactNumber))) {
         return {
             success: false,
-            error: "Contact number must follow the 09XXXXXXXXX format (11 digits only).",
+            error: "Contact number must contain only digits and follow the 09XXXXXXXXX format.",
         };
     }
 
     const emergencyNumber = input.emergencyNumber ? sanitizePhoneNumber(input.emergencyNumber) : "";
-    if (emergencyNumber && !PHONE_NUMBER_REGEX.test(emergencyNumber)) {
+    if (emergencyNumber === "INVALID" || (emergencyNumber && !PHONE_NUMBER_REGEX.test(emergencyNumber))) {
         return {
             success: false,
-            error: "Emergency contact number must follow the 09XXXXXXXXX format (11 digits only).",
+            error: "Emergency contact number must contain only digits and follow the 09XXXXXXXXX format.",
         };
     }
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,5 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-export const PHONE_NUMBER_REGEX = /^09\d{9}$/;
+export const PHONE_NUMBER_REGEX = /^09[0-9]{9}$/;
 
 export function sanitizePhoneNumber(value: string): string {
     if (!value) return "";

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,72 @@
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const PHONE_NUMBER_REGEX = /^(?:\+639|09)\d{9}$/;
+
+export function sanitizePhoneNumber(value: string): string {
+    if (!value) {
+        return "";
+    }
+
+    const cleaned = value.replace(/[^+\d]/g, "");
+
+    if (!cleaned) {
+        return "";
+    }
+
+    if (cleaned.startsWith("+")) {
+        return `+${cleaned.slice(1).replace(/\+/g, "")}`;
+    }
+
+    return cleaned.replace(/\+/g, "");
+}
+
+type ContactValidationInput = {
+    email?: string | null;
+    contactNumber?: string | null;
+    emergencyNumber?: string | null;
+};
+
+type ContactValidationSuccess = {
+    success: true;
+    email: string;
+    contactNumber: string;
+    emergencyNumber: string;
+};
+
+type ContactValidationError = {
+    success: false;
+    error: string;
+};
+
+export type ContactValidationResult = ContactValidationSuccess | ContactValidationError;
+
+export function validateAndNormalizeContacts(input: ContactValidationInput): ContactValidationResult {
+    const email = (input.email ?? "").trim();
+
+    if (email && !EMAIL_REGEX.test(email)) {
+        return { success: false, error: "Please enter a valid email address." };
+    }
+
+    const contactNumber = input.contactNumber ? sanitizePhoneNumber(input.contactNumber) : "";
+    if (contactNumber && !PHONE_NUMBER_REGEX.test(contactNumber)) {
+        return {
+            success: false,
+            error: "Contact number must follow the 09XXXXXXXXX or +639XXXXXXXXX format.",
+        };
+    }
+
+    const emergencyNumber = input.emergencyNumber ? sanitizePhoneNumber(input.emergencyNumber) : "";
+    if (emergencyNumber && !PHONE_NUMBER_REGEX.test(emergencyNumber)) {
+        return {
+            success: false,
+            error: "Emergency contact number must follow the 09XXXXXXXXX or +639XXXXXXXXX format.",
+        };
+    }
+
+    return {
+        success: true,
+        email,
+        contactNumber,
+        emergencyNumber,
+    };
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,23 +1,20 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-export const PHONE_NUMBER_REGEX = /^(?:\+639|09)\d{9}$/;
+export const PHONE_NUMBER_REGEX = /^09\d{9}$/;
 
 export function sanitizePhoneNumber(value: string): string {
-    if (!value) {
-        return "";
+    if (!value) return "";
+
+    let cleaned = value.replace(/\D/g, "");
+
+    if (/^9\d{9}$/.test(cleaned)) {
+        cleaned = `0${cleaned}`;
     }
 
-    const cleaned = value.replace(/[^+\d]/g, "");
-
-    if (!cleaned) {
-        return "";
+    if (cleaned.length > 11) {
+        cleaned = cleaned.slice(0, 11);
     }
 
-    if (cleaned.startsWith("+")) {
-        return `+${cleaned.slice(1).replace(/\+/g, "")}`;
-    }
-
-    return cleaned.replace(/\+/g, "");
+    return cleaned;
 }
 
 type ContactValidationInput = {
@@ -51,7 +48,7 @@ export function validateAndNormalizeContacts(input: ContactValidationInput): Con
     if (contactNumber && !PHONE_NUMBER_REGEX.test(contactNumber)) {
         return {
             success: false,
-            error: "Contact number must follow the 09XXXXXXXXX or +639XXXXXXXXX format.",
+            error: "Contact number must follow the 09XXXXXXXXX format (11 digits only).",
         };
     }
 
@@ -59,7 +56,7 @@ export function validateAndNormalizeContacts(input: ContactValidationInput): Con
     if (emergencyNumber && !PHONE_NUMBER_REGEX.test(emergencyNumber)) {
         return {
             success: false,
-            error: "Emergency contact number must follow the 09XXXXXXXXX or +639XXXXXXXXX format.",
+            error: "Emergency contact number must follow the 09XXXXXXXXX format (11 digits only).",
         };
     }
 


### PR DESCRIPTION
## Summary
- add a shared contact validation helper for email and phone fields
- enforce contact detail validation across doctor, nurse, patient, and scholar account pages, including DOB confirmation flows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f491ee06308333bd764b0e64259ac2