### PR TITLE
Align appointment scheduling with Manila timezone

### DIFF
--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -7,6 +7,7 @@ import {
     buildManilaDate,
     endOfManilaDay,
     formatManilaISODate,
+    getManilaWeekday,
     manilaNow,
     startOfManilaDay,
 } from "@/lib/time";
@@ -112,7 +113,9 @@ export async function POST(req: Request) {
             current.setUTCDate(current.getUTCDate() + i);
 
             const manilaDate = formatManilaISODate(current);
-            const weekday = new Date(`${manilaDate}T00:00:00+08:00`).getUTCDay();
+            const weekday = getManilaWeekday(manilaDate);
+
+            if (Number.isNaN(weekday)) continue;
 
             if (!allowedDays.has(weekday)) continue;
 

--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -45,7 +45,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { formatManilaDateTime } from "@/lib/time";
+import { formatManilaDateTime, formatManilaISODate, manilaNow } from "@/lib/time";
 
 const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
 
@@ -92,8 +92,7 @@ function normalizeStatus(value: string): AppointmentStatus | null {
 }
 
 function isToday(date: string) {
-    const today = new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
-    return date === today;
+    return date === formatManilaISODate(manilaNow());
 }
 
 function formatDateOnly(value: string) {

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -314,11 +314,7 @@ export default function DoctorConsultationPage() {
                                         <TableBody>
                                             {slots.map((slot) => (
                                                 <TableRow key={slot.availability_id} className="hover:bg-green-50 transition">
-                                                    <TableCell>
-                                                        {new Date(slot.available_date).toLocaleDateString("en-CA", {
-                                                            timeZone: "Asia/Manila",
-                                                        })}
-                                                    </TableCell>
+                                                    <TableCell>{toManilaDateString(slot.available_date)}</TableCell>
                                                     <TableCell>{format12Hour(slot.available_timestart)}</TableCell>
                                                     <TableCell>{format12Hour(slot.available_timeend)}</TableCell>
                                                     <TableCell>{slot.clinic.clinic_name}</TableCell>

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -705,7 +705,7 @@ export default function PatientAppointmentsPage() {
                                     <dd className="mt-1 text-sm font-medium text-green-800">
                                         {date && selectedSlot ? (
                                             <span>
-                                                {new Date(date).toLocaleDateString()} · {formatTimeRange(selectedSlot.start, selectedSlot.end)}
+                                                {formatDateOnly(date)} · {formatTimeRange(selectedSlot.start, selectedSlot.end)}
                                             </span>
                                         ) : (
                                             "Choose a date and time"

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -29,7 +29,13 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { formatManilaDateTime, formatManilaISODate, formatTimeRange, manilaNow } from "@/lib/time";
+import {
+    formatManilaDateTime,
+    formatManilaISODate,
+    formatTimeRange,
+    manilaNow,
+    toManilaDateString,
+} from "@/lib/time";
 import { getServiceOptionsForSpecialization, resolveServiceType } from "@/lib/service-options";
 
 const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
@@ -111,9 +117,9 @@ const STATUS_BADGE_CLASSES: Record<AppointmentStatus, string> = {
 const ACTIVE_STATUSES: AppointmentStatus[] = ["Pending", "Approved", "Moved"];
 
 function isToday(value: string) {
-    const today = new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
-    const date = new Date(value).toLocaleDateString("en-CA", { timeZone: "Asia/Manila" });
-    return today === date;
+    const today = formatManilaISODate(manilaNow());
+    const date = toManilaDateString(value);
+    return Boolean(date) && date === today;
 }
 
 function formatDateOnly(value: string) {

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,6 +1,6 @@
 // src/lib/time.ts
 
-const PH_TIME_ZONE = "Asia/Manila";
+export const PH_TIME_ZONE = "Asia/Manila";
 const PH_UTC_OFFSET = "+08:00";
 
 // Regex patterns for detecting ISO/TZ/time/date shapes
@@ -76,6 +76,24 @@ export function startOfManilaDay(date: string): Date {
 
 export function endOfManilaDay(date: string): Date {
     return new Date(`${date}T23:59:59${PH_UTC_OFFSET}`);
+}
+
+/**
+ * ✅ Manila weekday helper — always resolve using local (UTC+8) noon
+ */
+export function getManilaWeekday(value: TimeInput): number {
+    const date = parsePhilippineDate(value);
+    if (!date) return Number.NaN;
+
+    const isoDate = formatManilaISODate(date);
+    const safeMidday = new Date(`${isoDate}T12:00:00${PH_UTC_OFFSET}`);
+    return safeMidday.getUTCDay();
+}
+
+export function isManilaWeekend(value: TimeInput): boolean {
+    const weekday = getManilaWeekday(value);
+    if (Number.isNaN(weekday)) return false;
+    return weekday === 0 || weekday === 6;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add reusable Manila timezone helpers so the Singapore-hosted database aligns with Philippine dates
- update consultation slot generation and doctor UI to use the Manila weekday helper and Manila-aware formatting
- normalize appointment pages to render booking dates and today checks with the shared Manila utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f4a911913c83339a8373f772e55961