### PR TITLE
Add loader indicators for doctor workflows and adjust approval email styling

### DIFF
--- a/src/app/api/doctor/appointments/[id]/route.ts
+++ b/src/app/api/doctor/appointments/[id]/route.ts
@@ -14,6 +14,11 @@ import {
 } from "@/lib/time";
 import { sendEmail } from "@/lib/email";
 
+const EMAIL_BACKGROUND_COLOR = "#f0fdf4";
+const EMAIL_BORDER_COLOR = "#bbf7d0";
+const EMAIL_TEXT_COLOR = "#065f46";
+const EMAIL_ACCENT_COLOR = "#047857";
+
 function escapeHtml(input: string) {
     return input
         .replace(/&/g, "&amp;")
@@ -80,7 +85,7 @@ function buildStatusEmail({
     switch (status) {
         case AppointmentStatus.Approved:
             heading = "Appointment Approved";
-            intro = `Good news, <strong>${safeName}</strong>! Your appointment has been approved.`;
+            intro = `Good news, <strong>${safeName}</strong>! <span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Your appointment has been approved.</span>`;
             subject = "Your appointment has been approved";
             break;
         case AppointmentStatus.Cancelled:
@@ -108,16 +113,16 @@ function buildStatusEmail({
         .map(
             (row) => `
                 <tr>
-                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">${row.label}</td>
-                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${row.value}</td>
+                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">${row.label}</td>
+                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${row.value}</td>
                 </tr>
             `
         )
         .join("");
 
     const html = `
-        <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f0fdf4; padding: 24px; border-radius: 16px; border: 1px solid #bbf7d0; color: #065f46;">
-            <h2 style="margin-top: 0; color: #047857;">${heading}</h2>
+        <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: ${EMAIL_BACKGROUND_COLOR}; padding: 24px; border-radius: 16px; border: 1px solid ${EMAIL_BORDER_COLOR}; color: ${EMAIL_TEXT_COLOR};">
+            <h2 style="margin-top: 0; color: ${EMAIL_ACCENT_COLOR};">${heading}</h2>
             <p>${intro}</p>
             <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
                 <tbody>
@@ -332,23 +337,23 @@ export async function PATCH(
                 const oldSchedule = formatManilaDateTime(appointment.appointment_timestart);
                 const newSchedule = formatManilaDateTime(updated.appointment_timestart);
                 const html = `
-                    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f0fdf4; padding: 24px; border-radius: 16px; border: 1px solid #bbf7d0; color: #065f46;">
-                        <h2 style="margin-top: 0; color: #047857;">Appointment Update</h2>
+                    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: ${EMAIL_BACKGROUND_COLOR}; padding: 24px; border-radius: 16px; border: 1px solid ${EMAIL_BORDER_COLOR}; color: ${EMAIL_TEXT_COLOR};">
+                        <h2 style="margin-top: 0; color: ${EMAIL_ACCENT_COLOR};">Appointment Update</h2>
                         <p>Hello <strong>${escapeHtml(patientName)}</strong>,</p>
                         <p>Your appointment at <strong>${escapeHtml(updated.clinic.clinic_name)}</strong> has been moved by your doctor.</p>
                         <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
                             <tbody>
                                 <tr>
-                                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">Previous Schedule</td>
-                                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${escapeHtml(oldSchedule)}</td>
+                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">Previous Schedule</td>
+                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(oldSchedule)}</td>
                                 </tr>
                                 <tr>
-                                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">New Schedule</td>
-                                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${escapeHtml(newSchedule)}</td>
+                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">New Schedule</td>
+                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(newSchedule)}</td>
                                 </tr>
                                 <tr>
-                                    <td style="padding: 8px; border: 1px solid #bbf7d0; font-weight: 600;">Doctor's Note</td>
-                                    <td style="padding: 8px; border: 1px solid #bbf7d0;">${escapeHtml(trimmedReason)}</td>
+                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">Doctor's Note</td>
+                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(trimmedReason)}</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -145,6 +145,7 @@ export default function DoctorAppointmentsPage() {
     const [newTimeStart, setNewTimeStart] = useState("");
     const [newTimeEnd, setNewTimeEnd] = useState("");
     const [dialogOpen, setDialogOpen] = useState(false);
+    const [actionSubmitting, setActionSubmitting] = useState(false);
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState<string>("active");
 
@@ -286,6 +287,7 @@ export default function DoctorAppointmentsPage() {
         setNewDate("");
         setNewTimeStart("");
         setNewTimeEnd("");
+        setActionSubmitting(false);
     };
 
     async function handleActionSubmit() {
@@ -303,6 +305,7 @@ export default function DoctorAppointmentsPage() {
         }
 
         try {
+            setActionSubmitting(true);
             const res = await fetch(`/api/doctor/appointments/${selectedAppt.id}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
@@ -328,12 +331,17 @@ export default function DoctorAppointmentsPage() {
         } catch (error) {
             console.error(error);
             toast.error("Action failed");
+        } finally {
+            setActionSubmitting(false);
         }
     }
 
     const handleDialogOpenChange = (open: boolean) => {
         if (!open) {
+            if (actionSubmitting) return;
             resetDialogState();
+        } else {
+            setDialogOpen(true);
         }
     };
 
@@ -622,6 +630,7 @@ export default function DoctorAppointmentsPage() {
                                     value={newDate}
                                     onChange={(event) => setNewDate(event.target.value)}
                                     className="rounded-xl border-green-200"
+                                    disabled={actionSubmitting}
                                 />
                             </div>
                             <div className="space-y-2">
@@ -631,6 +640,7 @@ export default function DoctorAppointmentsPage() {
                                     value={newTimeStart}
                                     onChange={(event) => setNewTimeStart(event.target.value)}
                                     className="rounded-xl border-green-200"
+                                    disabled={actionSubmitting}
                                 />
                             </div>
                             <div className="space-y-2">
@@ -640,6 +650,7 @@ export default function DoctorAppointmentsPage() {
                                     value={newTimeEnd}
                                     onChange={(event) => setNewTimeEnd(event.target.value)}
                                     className="rounded-xl border-green-200"
+                                    disabled={actionSubmitting}
                                 />
                             </div>
                         </div>
@@ -651,17 +662,32 @@ export default function DoctorAppointmentsPage() {
                             value={reason}
                             onChange={(event) => setReason(event.target.value)}
                             className="rounded-xl border-green-200"
+                            disabled={actionSubmitting}
                         />
                     </div>
                     <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
-                        <Button type="button" variant="outline" className="rounded-xl" onClick={resetDialogState}>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="rounded-xl"
+                            onClick={resetDialogState}
+                            disabled={actionSubmitting}
+                        >
                             Close
                         </Button>
                         <Button
                             className="rounded-xl bg-green-600 text-white hover:bg-green-700"
                             onClick={handleActionSubmit}
+                            disabled={actionSubmitting}
                         >
-                            Save changes
+                            {actionSubmitting ? (
+                                <>
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    {actionType === "cancel" ? "Cancelling..." : "Saving..."}
+                                </>
+                            ) : (
+                                "Save changes"
+                            )}
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -49,6 +49,7 @@ type Availability = {
 
 export default function DoctorConsultationPage() {
     const [loading, setLoading] = useState(false);
+    const [savingDutyHours, setSavingDutyHours] = useState(false);
     const [slots, setSlots] = useState<Availability[]>([]);
     const [clinics, setClinics] = useState<Clinic[]>([]);
     const [formData, setFormData] = useState({
@@ -126,6 +127,7 @@ export default function DoctorConsultationPage() {
         const method = isEditing ? "PUT" : "POST";
 
         try {
+            setSavingDutyHours(true);
             setLoading(true);
             const res = await fetch("/api/doctor/consultation", {
                 method,
@@ -162,6 +164,7 @@ export default function DoctorConsultationPage() {
             toast.error("Failed to save duty hours");
         } finally {
             setLoading(false);
+            setSavingDutyHours(false);
         }
     }
 
@@ -285,8 +288,14 @@ export default function DoctorConsultationPage() {
                                                 disabled={loading}
                                                 className="rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
                                             >
-                                                {loading && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
-                                                {editingSlot ? "Save Changes" : "Generate"}
+                                                {savingDutyHours && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
+                                                {savingDutyHours
+                                                    ? editingSlot
+                                                        ? "Saving..."
+                                                        : "Generating..."
+                                                    : editingSlot
+                                                        ? "Save Changes"
+                                                        : "Generate"}
                                             </Button>
                                         </DialogFooter>
                                     </form>


### PR DESCRIPTION
## Summary
- add a dedicated duty-hour submission spinner so the generate button shows progress without affecting initial loads
- disable move/cancel actions while submitting and show loader feedback in the doctor appointment dialog
- align the "Your appointment has been approved" email styling with the green accent used by other notifications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f62a9b1ac083339c402b5595386ff4