### PR TITLE
Add doctor certificate generation workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -240,26 +240,26 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.910.0.tgz",
-      "integrity": "sha512-YKCXrzbEhplwsvjAnMKUB9lAfawFHMz7tPLL3dCnKQYeZOQqsYiUUPjkiB2Vq8uV+ALZqJ2FCph07pW7XZHqjg==",
+      "version": "3.913.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.913.0.tgz",
+      "integrity": "sha512-xurdihi/HH3em6XgvI+AlolCjqu74CxyOAEEWAJBk1Xp+yqNUaYR5d1m26iI7UuTy8gAZ+48UNvQBVhUXe5ZwA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.910.0",
-        "@aws-sdk/credential-provider-node": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
+        "@aws-sdk/credential-provider-node": "3.913.0",
         "@aws-sdk/middleware-host-header": "3.910.0",
         "@aws-sdk/middleware-logger": "3.910.0",
         "@aws-sdk/middleware-recursion-detection": "3.910.0",
-        "@aws-sdk/middleware-user-agent": "3.910.0",
+        "@aws-sdk/middleware-user-agent": "3.911.0",
         "@aws-sdk/region-config-resolver": "3.910.0",
-        "@aws-sdk/signature-v4-multi-region": "3.910.0",
+        "@aws-sdk/signature-v4-multi-region": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@aws-sdk/util-endpoints": "3.910.0",
         "@aws-sdk/util-user-agent-browser": "3.910.0",
-        "@aws-sdk/util-user-agent-node": "3.910.0",
+        "@aws-sdk/util-user-agent-node": "3.911.0",
         "@smithy/config-resolver": "^4.3.2",
         "@smithy/core": "^3.16.1",
         "@smithy/fetch-http-handler": "^5.3.3",
@@ -292,24 +292,24 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.910.0.tgz",
-      "integrity": "sha512-oEWXhe2RHiSPKxhrq1qp7M4fxOsxMIJc4d75z8tTLLm5ujlmTZYU3kd0l2uBBaZSlbkrMiefntT6XrGint1ibw==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.911.0.tgz",
+      "integrity": "sha512-N9QAeMvN3D1ZyKXkQp4aUgC4wUMuA5E1HuVCkajc0bq1pnH4PIke36YlrDGGREqPlyLFrXCkws2gbL5p23vtlg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/middleware-host-header": "3.910.0",
         "@aws-sdk/middleware-logger": "3.910.0",
         "@aws-sdk/middleware-recursion-detection": "3.910.0",
-        "@aws-sdk/middleware-user-agent": "3.910.0",
+        "@aws-sdk/middleware-user-agent": "3.911.0",
         "@aws-sdk/region-config-resolver": "3.910.0",
         "@aws-sdk/types": "3.910.0",
         "@aws-sdk/util-endpoints": "3.910.0",
         "@aws-sdk/util-user-agent-browser": "3.910.0",
-        "@aws-sdk/util-user-agent-node": "3.910.0",
+        "@aws-sdk/util-user-agent-node": "3.911.0",
         "@smithy/config-resolver": "^4.3.2",
         "@smithy/core": "^3.16.1",
         "@smithy/fetch-http-handler": "^5.3.3",
@@ -342,14 +342,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.910.0.tgz",
-      "integrity": "sha512-b/FVNyPxZMmBp+xDwANDgR6o5Ehh/RTY9U/labH56jJpte196Psru/FmQULX3S6kvIiafQA9JefWUq81SfWVLg==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.911.0.tgz",
+      "integrity": "sha512-k4QG9A+UCq/qlDJFmjozo6R0eXXfe++/KnCDMmajehIE9kh+b/5DqlGvAmbl9w4e92LOtrY6/DN3mIX1xs4sXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.910.0",
-        "@aws-sdk/xml-builder": "3.910.0",
+        "@aws-sdk/xml-builder": "3.911.0",
         "@smithy/core": "^3.16.1",
         "@smithy/node-config-provider": "^4.3.2",
         "@smithy/property-provider": "^4.2.2",
@@ -367,13 +367,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.910.0.tgz",
-      "integrity": "sha512-Os8I5XtTLBBVyHJLxrEB06gSAZeFMH2jVoKhAaFybjOTiV7wnjBgjvWjRfStnnXs7p9d+vc/gd6wIZHjony5YQ==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.911.0.tgz",
+      "integrity": "sha512-6FWRwWn3LUZzLhqBXB+TPMW2ijCWUqGICSw8bVakEdODrvbiv1RT/MVUayzFwz/ek6e6NKZn6DbSWzx07N9Hjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/property-provider": "^4.2.2",
         "@smithy/types": "^4.7.1",
@@ -384,13 +384,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.910.0.tgz",
-      "integrity": "sha512-3KiGsTlqMnvthv90K88Uv3SvaUbmcTShBIVWYNaHdbrhrjVRR08dm2Y6XjQILazLf1NPFkxUou1YwCWK4nae1Q==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.911.0.tgz",
+      "integrity": "sha512-xUlwKmIUW2fWP/eM3nF5u4CyLtOtyohlhGJ5jdsJokr3MrQ7w0tDITO43C9IhCn+28D5UbaiWnKw5ntkw7aVfA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/fetch-http-handler": "^5.3.3",
         "@smithy/node-http-handler": "^4.4.1",
@@ -406,19 +406,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.910.0.tgz",
-      "integrity": "sha512-/8x9LKKaLGarvF1++bFEFdIvd9/djBb+HTULbJAf4JVg3tUlpHtGe7uquuZaQkQGeW4XPbcpB9RMWx5YlZkw3w==",
+      "version": "3.913.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.913.0.tgz",
+      "integrity": "sha512-iR4c4NQ1OSRKQi0SxzpwD+wP1fCy+QNKtEyCajuVlD0pvmoIHdrm5THK9e+2/7/SsQDRhOXHJfLGxHapD74WJw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
-        "@aws-sdk/credential-provider-env": "3.910.0",
-        "@aws-sdk/credential-provider-http": "3.910.0",
-        "@aws-sdk/credential-provider-process": "3.910.0",
-        "@aws-sdk/credential-provider-sso": "3.910.0",
-        "@aws-sdk/credential-provider-web-identity": "3.910.0",
-        "@aws-sdk/nested-clients": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
+        "@aws-sdk/credential-provider-env": "3.911.0",
+        "@aws-sdk/credential-provider-http": "3.911.0",
+        "@aws-sdk/credential-provider-process": "3.911.0",
+        "@aws-sdk/credential-provider-sso": "3.911.0",
+        "@aws-sdk/credential-provider-web-identity": "3.911.0",
+        "@aws-sdk/nested-clients": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/credential-provider-imds": "^4.2.2",
         "@smithy/property-provider": "^4.2.2",
@@ -431,18 +431,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.910.0.tgz",
-      "integrity": "sha512-Zz5tF/U4q9ir3rfVnPLlxbhMTHjPaPv78TarspFYn9mNN7cPVXBaXVVnMNu6ypZzBdTB8M44UYo827Qcw3kouA==",
+      "version": "3.913.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.913.0.tgz",
+      "integrity": "sha512-HQPLkKDxS83Q/nZKqg9bq4igWzYQeOMqhpx5LYs4u1GwsKeCsYrrfz12Iu4IHNWPp9EnGLcmdfbfYuqZGrsaSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.910.0",
-        "@aws-sdk/credential-provider-http": "3.910.0",
-        "@aws-sdk/credential-provider-ini": "3.910.0",
-        "@aws-sdk/credential-provider-process": "3.910.0",
-        "@aws-sdk/credential-provider-sso": "3.910.0",
-        "@aws-sdk/credential-provider-web-identity": "3.910.0",
+        "@aws-sdk/credential-provider-env": "3.911.0",
+        "@aws-sdk/credential-provider-http": "3.911.0",
+        "@aws-sdk/credential-provider-ini": "3.913.0",
+        "@aws-sdk/credential-provider-process": "3.911.0",
+        "@aws-sdk/credential-provider-sso": "3.911.0",
+        "@aws-sdk/credential-provider-web-identity": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/credential-provider-imds": "^4.2.2",
         "@smithy/property-provider": "^4.2.2",
@@ -455,13 +455,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.910.0.tgz",
-      "integrity": "sha512-l1lZfHIl/z0SxXibt7wMQ2HmRIyIZjlOrT6a554xlO//y671uxPPwScVw7QW4fPIvwfmKbl8dYCwGI//AgQ0bA==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.911.0.tgz",
+      "integrity": "sha512-mKshhV5jRQffZjbK9x7bs+uC2IsYKfpzYaBamFsEov3xtARCpOiKaIlM8gYKFEbHT2M+1R3rYYlhhl9ndVWS2g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/property-provider": "^4.2.2",
         "@smithy/shared-ini-file-loader": "^4.3.2",
@@ -473,15 +473,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.910.0.tgz",
-      "integrity": "sha512-cwc9bmomjUqPDF58THUCmEnpAIsCFV3Y9FHlQmQbMkYUm7Wlrb5E2iFrZ4WDefAHuh25R/gtj+Yo74r3gl9kbw==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.911.0.tgz",
+      "integrity": "sha512-JAxd4uWe0Zc9tk6+N0cVxe9XtJVcOx6Ms0k933ZU9QbuRMH6xti/wnZxp/IvGIWIDzf5fhqiGyw5MSyDeI5b1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.910.0",
-        "@aws-sdk/core": "3.910.0",
-        "@aws-sdk/token-providers": "3.910.0",
+        "@aws-sdk/client-sso": "3.911.0",
+        "@aws-sdk/core": "3.911.0",
+        "@aws-sdk/token-providers": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/property-provider": "^4.2.2",
         "@smithy/shared-ini-file-loader": "^4.3.2",
@@ -493,14 +493,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.910.0.tgz",
-      "integrity": "sha512-HFQgZm1+7WisJ8tqcZkNRRmnoFO+So+L12wViVxneVJ+OclfL2vE/CoKqHTozP6+JCOKMlv6Vi61Lu6xDtKdTA==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.911.0.tgz",
+      "integrity": "sha512-urIbXWWG+cm54RwwTFQuRwPH0WPsMFSDF2/H9qO2J2fKoHRURuyblFCyYG3aVKZGvFBhOizJYexf5+5w3CJKBw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
-        "@aws-sdk/nested-clients": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
+        "@aws-sdk/nested-clients": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/property-provider": "^4.2.2",
         "@smithy/shared-ini-file-loader": "^4.3.2",
@@ -560,13 +560,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.910.0.tgz",
-      "integrity": "sha512-m13TmWHjIonWkIFi4O1GSsZKPzIf2sO9rUEj9fr1VwTA7Lblp6UaOcfiQHfhWXgxqYaSouvEvCtoqA3SttdPlw==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.911.0.tgz",
+      "integrity": "sha512-P0mIIW/QkAGNvFu15Jqa5NSmHeQvZkkQY8nbQpCT3tGObZe4wRsq5u1mOS+CJp4DIBbRZuHeX7ohbX5kPMi4dg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@aws-sdk/util-arn-parser": "3.893.0",
         "@smithy/core": "^3.16.1",
@@ -586,13 +586,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.910.0.tgz",
-      "integrity": "sha512-djpnECwDLI/4sck1wxK/cZJmZX5pAhRvjONyJqr0AaOfJyuIAG0PHLe7xwCrv2rCAvIBR9ofnNFzPIGTJPDUwg==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.911.0.tgz",
+      "integrity": "sha512-rY3LvGvgY/UI0nmt5f4DRzjEh8135A2TeHcva1bgOmVfOI4vkkGfA20sNRqerOkSO6hPbkxJapO50UJHFzmmyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@aws-sdk/util-endpoints": "3.910.0",
         "@smithy/core": "^3.16.1",
@@ -605,24 +605,24 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.910.0.tgz",
-      "integrity": "sha512-Jr/smgVrLZECQgMyP4nbGqgJwzFFbkjOVrU8wh/gbVIZy1+Gu6R7Shai7KHDkEjwkGcHpN1MCCO67jTAOoSlMw==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.911.0.tgz",
+      "integrity": "sha512-lp/sXbdX/S0EYaMYPVKga0omjIUbNNdFi9IJITgKZkLC6CzspihIoHd5GIdl4esMJevtTQQfkVncXTFkf/a4YA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
         "@aws-sdk/middleware-host-header": "3.910.0",
         "@aws-sdk/middleware-logger": "3.910.0",
         "@aws-sdk/middleware-recursion-detection": "3.910.0",
-        "@aws-sdk/middleware-user-agent": "3.910.0",
+        "@aws-sdk/middleware-user-agent": "3.911.0",
         "@aws-sdk/region-config-resolver": "3.910.0",
         "@aws-sdk/types": "3.910.0",
         "@aws-sdk/util-endpoints": "3.910.0",
         "@aws-sdk/util-user-agent-browser": "3.910.0",
-        "@aws-sdk/util-user-agent-node": "3.910.0",
+        "@aws-sdk/util-user-agent-node": "3.911.0",
         "@smithy/config-resolver": "^4.3.2",
         "@smithy/core": "^3.16.1",
         "@smithy/fetch-http-handler": "^5.3.3",
@@ -673,13 +673,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.910.0.tgz",
-      "integrity": "sha512-SM62pR9ozCNzbKuV315QSgR1Tkyy+0sKMzgGAufvOupuWBUaJgEuzCwfLEBhPiEODaQCdJ3UZGn0wYXxn8gXsA==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.911.0.tgz",
+      "integrity": "sha512-SJ4dUcY9+HPDIMCHiskT8F7JrRVZF2Y1NUN0Yiy6VUHSULgq2MDlIzSQpNICnmXhk1F1E1B2jJG9XtPYrvtqUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.910.0",
+        "@aws-sdk/middleware-sdk-s3": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/protocol-http": "^5.3.2",
         "@smithy/signature-v4": "^5.3.2",
@@ -691,14 +691,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.910.0.tgz",
-      "integrity": "sha512-dQr3pFpzemKyrB7SEJ2ipPtWrZiL5vaimg2PkXpwyzGrigYRc8F2R9DMUckU5zi32ozvQqq4PI3bOrw6xUfcbQ==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.911.0.tgz",
+      "integrity": "sha512-O1c5F1pbEImgEe3Vr8j1gpWu69UXWj3nN3vvLGh77hcrG5dZ8I27tSP5RN4Labm8Dnji/6ia+vqSYpN8w6KN5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.910.0",
-        "@aws-sdk/nested-clients": "3.910.0",
+        "@aws-sdk/core": "3.911.0",
+        "@aws-sdk/nested-clients": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/property-provider": "^4.2.2",
         "@smithy/shared-ini-file-loader": "^4.3.2",
@@ -780,13 +780,13 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.910.0.tgz",
-      "integrity": "sha512-qNV+rywWQDOOWmGpNlWLCU6zkJurocTBB2uLSdQ8b6Xg6U/i1VTJsoUQ5fbhSQpp/SuBGiIglyB1gSc0th7hPw==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.911.0.tgz",
+      "integrity": "sha512-3l+f6ooLF6Z6Lz0zGi7vSKSUYn/EePPizv88eZQpEAFunBHv+CSVNPtxhxHfkm7X9tTsV4QGZRIqo3taMLolmA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.910.0",
+        "@aws-sdk/middleware-user-agent": "3.911.0",
         "@aws-sdk/types": "3.910.0",
         "@smithy/node-config-provider": "^4.3.2",
         "@smithy/types": "^4.7.1",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.910.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.910.0.tgz",
-      "integrity": "sha512-UK0NzRknzUITYlkDibDSgkWvhhC11OLhhhGajl6pYCACup+6QE4SsLvmAGMkyNtGVCJ6Q+BM6PwDCBZyBgwl9A==",
+      "version": "3.911.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.911.0.tgz",
+      "integrity": "sha512-/yh3oe26bZfCVGrIMRM9Z4hvvGJD+qx5tOLlydOkuBkm72aXON7D9+MucjJXTAcI8tF2Yq+JHa0478eHQOhnLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -920,13 +920,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1549,19 +1549,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3291,13 +3278,13 @@
       "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.2.tgz",
-      "integrity": "sha512-fPbcmEI+A6QiGOuumTpKSo7z+9VYr5DLN8d5/8jDJOwmt4HAKy/UGuRstCMpKbtr+FMaHH4pvFinSAbIAYCHZQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3305,16 +3292,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.3.2.tgz",
-      "integrity": "sha512-F/G+VaulIebINyfvcoXmODgIc7JU/lxWK9/iI0Divxyvd2QWB7/ZcF7JKwMssWI6/zZzlMkq/Pt6ow2AOEebPw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.3.3.tgz",
+      "integrity": "sha512-xSql8A1Bl41O9JvGU/CtgiLBlwkvpHTSKRlvz9zOBvBCPjXghZ6ZkcVzmV2f7FLAA+80+aqKmIOmy8pEDrtCaw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3322,19 +3309,19 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.16.1.tgz",
-      "integrity": "sha512-yRx5ag3xEQ/yGvyo80FVukS7ZkeUP49Vbzg0MjfHLkuCIgg5lFtaEJfZR178KJmjWPqLU4d0P4k7SKgF9UkOaQ==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.0.tgz",
+      "integrity": "sha512-Tir3DbfoTO97fEGUZjzGeoXgcQAUBRDTmuH9A8lxuP8ATrgezrAJ6cLuRvwdKN4ZbYNlHgKlBX69Hyu3THYhtg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.2",
-        "@smithy/util-stream": "^4.5.2",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -3344,16 +3331,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.2.tgz",
-      "integrity": "sha512-hOjFTK+4mfehDnfjNkPqHUKBKR2qmlix5gy7YzruNbTdeoBE3QkfNCPvuCK2r05VUJ02QQ9bz2G41CxhSexsMw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+      "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/property-provider": "^4.2.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/url-parser": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3361,15 +3348,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.3.tgz",
-      "integrity": "sha512-cipIcM3xQ5NdIVwcRb37LaQwIxZNMEZb/ZOPmLFS9uGo9TGx2dGCyMBj9oT7ypH4TUD/kOTc/qHmwQzthrSk+g==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/querystring-builder": "^4.2.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
@@ -3378,13 +3365,13 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.2.tgz",
-      "integrity": "sha512-xuOPGrF2GUP+9og5NU02fplRVjJjMhAaY8ZconB3eLKjv/VSV9/s+sFf72MYO5Q2jcSRVk/ywZHpyGbE3FYnFQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+      "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -3394,13 +3381,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.2.tgz",
-      "integrity": "sha512-Z0844Zpoid5L1DmKX2+cn2Qu9i3XWjhzwYBRJEWrKJwjUuhEkzf37jKPj9dYFsZeKsAbS2qI0JyLsYafbXJvpA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+      "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3421,14 +3408,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.2.tgz",
-      "integrity": "sha512-aJ7LAuIXStF6EqzRVX9kAW+6/sYoJJv0QqoFrz2BhA9r/85kLYOJ6Ph47wYSGBxzSLxsYT5jqgMw/qpbv1+m+w==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+      "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3436,19 +3423,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.3.tgz",
-      "integrity": "sha512-CfxQ6X9L87/3C67Po6AGWXsx8iS4w2BO8vQEZJD6hwqg2vNRC/lMa2O5wXYCG9tKotdZ0R8KG33TS7kpUnYKiw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.4.tgz",
+      "integrity": "sha512-/RJhpYkMOaUZoJEkddamGPPIYeKICKXOu/ojhn85dKDM0n5iDIhjvYAQLP3K5FPhgB203O3GpWzoK2OehEoIUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.16.1",
-        "@smithy/middleware-serde": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/shared-ini-file-loader": "^4.3.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/url-parser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.2",
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-middleware": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3456,19 +3443,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.3.tgz",
-      "integrity": "sha512-EHnKGeFuzbmER4oSl/VJDxPLi+aiZUb3nk5KK8eNwHjMhI04jHlui2ZkaBzMfNmXOgymaS6zV//fyt6PSnI1ow==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.4.tgz",
+      "integrity": "sha512-vSgABQAkuUHRO03AhR2rWxVQ1un284lkBn+NFawzdahmzksAoOeVMnXXsuPViL4GlhRHXqFaMlc8Mj04OfQk1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/service-error-classification": "^4.2.2",
-        "@smithy/smithy-client": "^4.8.1",
-        "@smithy/types": "^4.7.1",
-        "@smithy/util-middleware": "^4.2.2",
-        "@smithy/util-retry": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
@@ -3477,14 +3464,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.2.tgz",
-      "integrity": "sha512-tDMPMBCsA1GBxanShhPvQYwdiau3NmctUp+eELMhUTDua+EUrugXlaKCnTMMoEB5mbHFebdv81uJPkVP02oihA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3492,13 +3479,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.2.tgz",
-      "integrity": "sha512-7rgzDyLOQouh1bC6gOXnCGSX2dqvbOclgClsFkj735xQM2CHV63Ams8odNZGJgcqnBsEz44V/pDGHU6ALEUD+w==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3506,15 +3493,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.2.tgz",
-      "integrity": "sha512-u38G0Audi2ORsL0QnzhopZ3yweMblQf8CZNbzUJ3wfTtZ7OiOwOzee0Nge/3dKeG/8lx0kt8K0kqDi6sYu0oKQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.2",
-        "@smithy/shared-ini-file-loader": "^4.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3522,16 +3509,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.1.tgz",
-      "integrity": "sha512-9gKJoL45MNyOCGTG082nmx0A6KrbLVQ+5QSSKyzRi0AzL0R81u3wC1+nPvKXgTaBdAKM73fFPdCBHpmtipQwdQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.2.tgz",
+      "integrity": "sha512-MHFvTjts24cjGo1byXqhXrbqm7uznFD/ESFx8npHMWTFQVdBZjrT1hKottmp69LBTRm/JQzP/sn1vPt0/r6AYQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/querystring-builder": "^4.2.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3539,13 +3526,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.2.tgz",
-      "integrity": "sha512-MW7MfI+qYe/Ue5RH0uEztEKB+vBlOMM+1Dz68qzTsY8fC9kanXMFPEVdiq35JTGKWt5wZAjU1R0uXYEjK2MM1g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3553,13 +3540,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.2.tgz",
-      "integrity": "sha512-nkKOI8xEkBXUmdxsFExomOb+wkU+Xgn0Fq2LMC7YIX5r4YPUg7PLayV/s/u3AtbyjWYlrvN7nAiDTLlqSdUjHw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3567,13 +3554,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.2.tgz",
-      "integrity": "sha512-YgXvq89o+R/8zIoeuXYv8Ysrbwgjx+iVYu9QbseqZjMDAhIg/FRt7jis0KASYFtd/Cnsnz4/nYTJXkJDWe8wHg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -3582,13 +3569,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.2.tgz",
-      "integrity": "sha512-DczOD2yJy3NXcv1JvhjFC7bIb/tay6nnIRD/qrzBaju5lrkVBOwCT3Ps37tra20wy8PicZpworStK7ZcI9pCRQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3596,26 +3583,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.2.tgz",
-      "integrity": "sha512-1X17cMLwe/vb4RpZbQVpJ1xQQ7fhQKggMdt3qjdV3+6QNllzvUXyS3WFnyaFWLyaGqfYHKkNONbO1fBCMQyZtQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+      "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1"
+        "@smithy/types": "^4.8.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.2.tgz",
-      "integrity": "sha512-AWnLgSmOTdDXM8aZCN4Im0X07M3GGffeL9vGfea4mdKZD0cPT9yLF9SsRbEa00tHLI+KfubDrmjpaKT2pM4GdQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3623,17 +3610,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.2.tgz",
-      "integrity": "sha512-BRnQGGyaRSSL0KtjjFF9YoSSg8qzSqHMub4H2iKkd+LZNzZ1b7H5amslZBzi+AnvuwPMyeiNv0oqay/VmIuoRA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+      "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.3",
         "@smithy/util-uri-escape": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -3643,18 +3630,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.8.1.tgz",
-      "integrity": "sha512-N5wK57pVThzLVK5NgmHxocTy5auqGDGQ+JsL5RjCTriPt8JLYgXT0Awa915zCpzc9hXHDOKqDX5g9BFdwkSfUA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.0.tgz",
+      "integrity": "sha512-qz7RTd15GGdwJ3ZCeBKLDQuUQ88m+skh2hJwcpPm1VqLeKzgZvXf6SrNbxvx7uOqvvkjCMXqx3YB5PDJyk00ww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.16.1",
-        "@smithy/middleware-endpoint": "^4.3.3",
-        "@smithy/middleware-stack": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/util-stream": "^4.5.2",
+        "@smithy/core": "^3.17.0",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3662,9 +3649,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.7.1.tgz",
-      "integrity": "sha512-WwP7vzoDyzvIFLzF5UhLQ6AsEx/PvSObzlNtJNW3lLy+BaSvTqCU628QKVvcJI/dydlAS1mSHQP7anKcxDcOxA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3675,14 +3662,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.2.tgz",
-      "integrity": "sha512-s2EYKukaswzjiHJCss6asB1F4zjRc0E/MFyceAKzb3+wqKA2Z/+Gfhb5FP8xVVRHBAvBkregaQAydifgbnUlCw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/querystring-parser": "^4.2.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3758,15 +3745,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.2.tgz",
-      "integrity": "sha512-6JvKHZ5GORYkEZ2+yJKEHp6dQQKng+P/Mu3g3CDy0fRLQgXEO8be+FLrBGGb4kB9lCW6wcQDkN7kRiGkkVAXgg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.3.tgz",
+      "integrity": "sha512-vqHoybAuZXbFXZqgzquiUXtdY+UT/aU33sxa4GBPkiYklmR20LlCn+d3Wc3yA5ZM13gQ92SZe/D8xh6hkjx+IQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.2",
-        "@smithy/smithy-client": "^4.8.1",
-        "@smithy/types": "^4.7.1",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3774,18 +3761,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.3.tgz",
-      "integrity": "sha512-bkTGuMmKvghfCh9NayADrQcjngoF8P+XTgID5r3rm+8LphFiuM6ERqpBS95YyVaLjDetnKus9zK/bGlkQOOtNQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.4.tgz",
+      "integrity": "sha512-X5/xrPHedifo7hJUUWKlpxVb2oDOiqPUXlvsZv1EZSjILoutLiJyWva3coBpn00e/gPSpH8Rn2eIbgdwHQdW7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.3.2",
-        "@smithy/credential-provider-imds": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/property-provider": "^4.2.2",
-        "@smithy/smithy-client": "^4.8.1",
-        "@smithy/types": "^4.7.1",
+        "@smithy/config-resolver": "^4.3.3",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3793,14 +3780,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.2.tgz",
-      "integrity": "sha512-ZQi6fFTMBkfwwSPAlcGzArmNILz33QH99CL8jDfVWrzwVVcZc56Mge10jGk0zdRgWPXyL1/OXKjfw4vT5VtRQg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+      "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3821,13 +3808,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.2.tgz",
-      "integrity": "sha512-wL9tZwWKy0x0qf6ffN7tX5CT03hb1e7XpjdepaKfKcPcyn5+jHAWPqivhF1Sw/T5DYi9wGcxsX8Lu07MOp2Puw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.7.1",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3835,14 +3822,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.2.tgz",
-      "integrity": "sha512-TlbnWAOoCuG2PgY0Hi3BGU1w2IXs3xDsD4E8WDfKRZUn2qx3wRA9mbYnmpWHPswTJCz2L+ebh+9OvD42sV4mNw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+      "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3850,15 +3837,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.2.tgz",
-      "integrity": "sha512-RWYVuQVKtNbr7E0IxV8XHDId714yHPTxU6dHScd6wSMWAXboErzTG7+xqcL+K3r0Xg0cZSlfuNhl1J0rzMLSSw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.3.tgz",
+      "integrity": "sha512-oZvn8a5bwwQBNYHT2eNo0EU8Kkby3jeIg1P2Lu9EQtqDxki1LIjGRJM6dJ5CZUig8QmLxWxqOKWvg3mVoOBs5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.3",
-        "@smithy/node-http-handler": "^4.4.1",
-        "@smithy/types": "^4.7.1",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",
@@ -3922,6 +3909,12 @@
         "node": ">=20.11.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -3945,54 +3938,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.14.tgz",
-      "integrity": "sha512-hpz+8vFk3Ic2xssIA3e01R6jkmsAhvkQdXlEbRTk6S10xDAtiQiM3FyvZVGsucefq764euO/b8WUW9ysLdThHw==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.15.tgz",
+      "integrity": "sha512-HF4+7QxATZWY3Jr8OlZrBSXmwT3Watj0OogeDvdUY/ByXJHQ+LBtqA2brDb3sBxYslIFx6UP94BJ4X6a4L9Bmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "enhanced-resolve": "^5.18.3",
         "jiti": "^2.6.0",
-        "lightningcss": "1.30.1",
+        "lightningcss": "1.30.2",
         "magic-string": "^0.30.19",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.14"
+        "tailwindcss": "4.1.15"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.14.tgz",
-      "integrity": "sha512-23yx+VUbBwCg2x5XWdB8+1lkPajzLmALEfMb51zZUBYaYVPDQvBSD/WYDqiVyBIo2BZFa3yw1Rpy3G2Jp+K0dw==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.15.tgz",
+      "integrity": "sha512-krhX+UOOgnsUuks2SR7hFafXmLQrKxB4YyRTERuCE59JlYL+FawgaAlSkOYmDRJdf1Q+IFNDMl9iRnBW7QBDfQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.4",
-        "tar": "^7.5.1"
-      },
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.14",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.14",
-        "@tailwindcss/oxide-darwin-x64": "4.1.14",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.14",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.14",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.14",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.14",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.14",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.14",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.14",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.14",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.14"
+        "@tailwindcss/oxide-android-arm64": "4.1.15",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.15",
+        "@tailwindcss/oxide-darwin-x64": "4.1.15",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.15",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.15",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.15",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.15",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.15",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.15",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.15",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.15",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.15"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.14.tgz",
-      "integrity": "sha512-a94ifZrGwMvbdeAxWoSuGcIl6/DOP5cdxagid7xJv6bwFp3oebp7y2ImYsnZBMTwjn5Ev5xESvS3FFYUGgPODQ==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.15.tgz",
+      "integrity": "sha512-TkUkUgAw8At4cBjCeVCRMc/guVLKOU1D+sBPrHt5uVcGhlbVKxrCaCW9OKUIBv1oWkjh4GbunD/u/Mf0ql6kEA==",
       "cpu": [
         "arm64"
       ],
@@ -4007,9 +3995,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.14.tgz",
-      "integrity": "sha512-HkFP/CqfSh09xCnrPJA7jud7hij5ahKyWomrC3oiO2U9i0UjP17o9pJbxUN0IJ471GTQQmzwhp0DEcpbp4MZTA==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.15.tgz",
+      "integrity": "sha512-xt5XEJpn2piMSfvd1UFN6jrWXyaKCwikP4Pidcf+yfHTSzSpYhG3dcMktjNkQO3JiLCp+0bG0HoWGvz97K162w==",
       "cpu": [
         "arm64"
       ],
@@ -4024,9 +4012,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.14.tgz",
-      "integrity": "sha512-eVNaWmCgdLf5iv6Qd3s7JI5SEFBFRtfm6W0mphJYXgvnDEAZ5sZzqmI06bK6xo0IErDHdTA5/t7d4eTfWbWOFw==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.15.tgz",
+      "integrity": "sha512-TnWaxP6Bx2CojZEXAV2M01Yl13nYPpp0EtGpUrY+LMciKfIXiLL2r/SiSRpagE5Fp2gX+rflp/Os1VJDAyqymg==",
       "cpu": [
         "x64"
       ],
@@ -4041,9 +4029,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.14.tgz",
-      "integrity": "sha512-QWLoRXNikEuqtNb0dhQN6wsSVVjX6dmUFzuuiL09ZeXju25dsei2uIPl71y2Ic6QbNBsB4scwBoFnlBfabHkEw==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.15.tgz",
+      "integrity": "sha512-quISQDWqiB6Cqhjc3iWptXVZHNVENsWoI77L1qgGEHNIdLDLFnw3/AfY7DidAiiCIkGX/MjIdB3bbBZR/G2aJg==",
       "cpu": [
         "x64"
       ],
@@ -4058,9 +4046,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.14.tgz",
-      "integrity": "sha512-VB4gjQni9+F0VCASU+L8zSIyjrLLsy03sjcR3bM0V2g4SNamo0FakZFKyUQ96ZVwGK4CaJsc9zd/obQy74o0Fw==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.15.tgz",
+      "integrity": "sha512-ObG76+vPlab65xzVUQbExmDU9FIeYLQ5k2LrQdR2Ud6hboR+ZobXpDoKEYXf/uOezOfIYmy2Ta3w0ejkTg9yxg==",
       "cpu": [
         "arm"
       ],
@@ -4075,9 +4063,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.14.tgz",
-      "integrity": "sha512-qaEy0dIZ6d9vyLnmeg24yzA8XuEAD9WjpM5nIM1sUgQ/Zv7cVkharPDQcmm/t/TvXoKo/0knI3me3AGfdx6w1w==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.15.tgz",
+      "integrity": "sha512-4WbBacRmk43pkb8/xts3wnOZMDKsPFyEH/oisCm2q3aLZND25ufvJKcDUpAu0cS+CBOL05dYa8D4U5OWECuH/Q==",
       "cpu": [
         "arm64"
       ],
@@ -4092,9 +4080,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.14.tgz",
-      "integrity": "sha512-ISZjT44s59O8xKsPEIesiIydMG/sCXoMBCqsphDm/WcbnuWLxxb+GcvSIIA5NjUw6F8Tex7s5/LM2yDy8RqYBQ==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.15.tgz",
+      "integrity": "sha512-AbvmEiteEj1nf42nE8skdHv73NoR+EwXVSgPY6l39X12Ex8pzOwwfi3Kc8GAmjsnsaDEbk+aj9NyL3UeyHcTLg==",
       "cpu": [
         "arm64"
       ],
@@ -4109,9 +4097,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.14.tgz",
-      "integrity": "sha512-02c6JhLPJj10L2caH4U0zF8Hji4dOeahmuMl23stk0MU1wfd1OraE7rOloidSF8W5JTHkFdVo/O7uRUJJnUAJg==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.15.tgz",
+      "integrity": "sha512-+rzMVlvVgrXtFiS+ES78yWgKqpThgV19ISKD58Ck+YO5pO5KjyxLt7AWKsWMbY0R9yBDC82w6QVGz837AKQcHg==",
       "cpu": [
         "x64"
       ],
@@ -4126,9 +4114,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.14.tgz",
-      "integrity": "sha512-TNGeLiN1XS66kQhxHG/7wMeQDOoL0S33x9BgmydbrWAb9Qw0KYdd8o1ifx4HOGDWhVmJ+Ul+JQ7lyknQFilO3Q==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.15.tgz",
+      "integrity": "sha512-fPdEy7a8eQN9qOIK3Em9D3TO1z41JScJn8yxl/76mp4sAXFDfV4YXxsiptJcOwy6bGR+70ZSwFIZhTXzQeqwQg==",
       "cpu": [
         "x64"
       ],
@@ -4143,9 +4131,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.14.tgz",
-      "integrity": "sha512-uZYAsaW/jS/IYkd6EWPJKW/NlPNSkWkBlaeVBi/WsFQNP05/bzkebUL8FH1pdsqx4f2fH/bWFcUABOM9nfiJkQ==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.15.tgz",
+      "integrity": "sha512-sJ4yd6iXXdlgIMfIBXuVGp/NvmviEoMVWMOAGxtxhzLPp9LOj5k0pMEMZdjeMCl4C6Up+RM8T3Zgk+BMQ0bGcQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -4164,7 +4152,7 @@
         "@emnapi/core": "^1.5.0",
         "@emnapi/runtime": "^1.5.0",
         "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.0.5",
+        "@napi-rs/wasm-runtime": "^1.0.7",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.4.0"
       },
@@ -4173,9 +4161,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.14.tgz",
-      "integrity": "sha512-Az0RnnkcvRqsuoLH2Z4n3JfAef0wElgzHD5Aky/e+0tBUxUhIeIqFBTMNQvmMRSP15fWwmvjBxZ3Q8RhsDnxAA==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.15.tgz",
+      "integrity": "sha512-sJGE5faXnNQ1iXeqmRin7Ds/ru2fgCiaQZQQz3ZGIDtvbkeV85rAZ0QJFMDg0FrqsffZG96H1U9AQlNBRLsHVg==",
       "cpu": [
         "arm64"
       ],
@@ -4190,9 +4178,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.14.tgz",
-      "integrity": "sha512-ttblVGHgf68kEE4om1n/n44I0yGPkCPbLsqzjvybhpwa6mKKtgFfAzy6btc3HRmuW7nHe0OOrSeNP9sQmmH9XA==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.15.tgz",
+      "integrity": "sha512-NLeHE7jUV6HcFKS504bpOohyi01zPXi2PXmjFfkzTph8xRxDdxkRsXm/xDO5uV5K3brrE1cCwbUYmFUSHR3u1w==",
       "cpu": [
         "x64"
       ],
@@ -4207,17 +4195,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.14.tgz",
-      "integrity": "sha512-BdMjIxy7HUNThK87C7BC8I1rE8BVUsfNQSI5siQ4JK3iIa3w0XyVvVL9SXLWO//CtYTcp1v7zci0fYwJOjB+Zg==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.15.tgz",
+      "integrity": "sha512-IZh8IT76KujRz6d15wZw4eoeViT4TqmzVWNNfpuNCTKiaZUwgr5vtPqO4HjuYDyx3MgGR5qgPt1HMzTeLJyA3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.14",
-        "@tailwindcss/oxide": "4.1.14",
+        "@tailwindcss/node": "4.1.15",
+        "@tailwindcss/oxide": "4.1.15",
         "postcss": "^8.4.41",
-        "tailwindcss": "4.1.14"
+        "tailwindcss": "4.1.15"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -4343,9 +4331,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.21.tgz",
-      "integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
+      "version": "20.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
+      "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5267,12 +5255,15 @@
       "license": "MIT"
     },
     "node_modules/ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha512-qEdtR2UH78yyHX/AUNfXmJTlM48XoFZKBdwi1nzkI1mJL21cmbu0cvjxjpkXJ5NENMq42H+hNs8VLJcqXLerBQ==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=4"
       }
     },
     "node_modules/ast-types-flow": {
@@ -5416,9 +5407,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.0.tgz",
-      "integrity": "sha512-c+RCqMSZbkz97Mw1LWR0gcOqwK82oyYKfLoHJ8k13ybi1+I80ffdDzUy0TdAburdrR/kI0/VuN8YgEnJqX+Nyw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.1.tgz",
+      "integrity": "sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -5595,9 +5586,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001750",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
-      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5645,16 +5636,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/chromium-bidi": {
@@ -6172,31 +6153,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/degenerator/node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/degenerator/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6579,6 +6535,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6622,50 +6584,26 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.1",
         "@eslint/core": "^0.16.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.37.0",
+        "@eslint/js": "9.38.0",
         "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -6826,7 +6764,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7028,9 +6965,9 @@
       }
     },
     "node_modules/esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha512-AWwVMNxwhN8+NIPQzAQZCm7RkLC4RbM3B1OobMuyp3i+w73X57KCKaVIxaRZb+DYCojq7rspo+fmuQfAboyhFg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7226,6 +7163,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -8475,6 +8418,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jstransform/node_modules/source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8536,9 +8491,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -8552,22 +8507,44 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
       "cpu": [
         "arm64"
       ],
@@ -8586,9 +8563,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
       "cpu": [
         "x64"
       ],
@@ -8607,9 +8584,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
       "cpu": [
         "x64"
       ],
@@ -8628,9 +8605,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
       "cpu": [
         "arm"
       ],
@@ -8649,9 +8626,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
       "cpu": [
         "arm64"
       ],
@@ -8670,9 +8647,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
       ],
@@ -8691,9 +8668,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
       "cpu": [
         "x64"
       ],
@@ -8712,9 +8689,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
       ],
@@ -8733,9 +8710,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
       "cpu": [
         "arm64"
       ],
@@ -8754,9 +8731,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
       "cpu": [
         "x64"
       ],
@@ -8899,29 +8876,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -9874,6 +9828,12 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10121,6 +10081,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha512-qEdtR2UH78yyHX/AUNfXmJTlM48XoFZKBdwi1nzkI1mJL21cmbu0cvjxjpkXJ5NENMq42H+hNs8VLJcqXLerBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/recast/node_modules/esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha512-AWwVMNxwhN8+NIPQzAQZCm7RkLC4RbM3B1OobMuyp3i+w73X57KCKaVIxaRZb+DYCojq7rspo+fmuQfAboyhFg==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/recast/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -10256,11 +10238,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resend": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.1.3.tgz",
-      "integrity": "sha512-vHRdmU3q+nS5x7cYHZpAQ5zpZE+DV+7q6axIUiRcxYsoUpjBuW50zwdrOz+8O6vUbjGFIz4r2qkt4s+2G0y4GA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.2.0.tgz",
+      "integrity": "sha512-mH8KFD/qoVdohQ+iFMqWfeVFzAnQ4ZaybD5XVqHIOxldUkvjTJEe9Ae2mhmldBNGlE/xzBNiCGkztI7owBsVsQ==",
       "license": "MIT",
+      "dependencies": {
+        "svix": "1.76.1"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -10668,15 +10659,13 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
+      "optional": true,
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -10950,6 +10939,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.18.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.11.tgz",
+      "integrity": "sha512-Gd33J2XIrXurb+eT2ktze3rJAfAp9ZNjlBdh4SVgyrKEOADwCbdUDaK7QgJno8Ue4kcajscsKqu6n8OBG3hhCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/svix/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
@@ -10974,9 +10999,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
-      "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.15.tgz",
+      "integrity": "sha512-k2WLnWkYFkdpRv+Oby3EBXIyQC8/s1HOFMBUViwtAh6Z5uAozeUSMQlIsn/c6Q2iJzqG6aJT3wdPaRNj70iYxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10992,23 +11017,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tar-fs": {
@@ -11048,16 +11056,6 @@
         "react-native-b4a": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/text-decoder": {
@@ -11367,7 +11365,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -11413,6 +11410,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {

--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -94,6 +94,7 @@ export async function GET() {
             username: user.username,
             role: user.role,
             status: user.status,
+            specialization: user.specialization ?? null,
             profile: user.employee ?? null,
         });
     } catch (err) {

--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -1,0 +1,679 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import chromium from "@sparticuz/chromium";
+import puppeteer from "puppeteer-core";
+
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import {
+    AppointmentStatus,
+    DoctorSpecialization,
+    MedcertStatus,
+    Role,
+} from "@prisma/client";
+import { formatManilaDateTime, manilaNow } from "@/lib/time";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function escapeHtml(value: string) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function titleCase(value: string | null | undefined) {
+    if (!value) return "";
+    return value
+        .toLowerCase()
+        .split(/\s+/)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+}
+
+function humanizeEnum(value: string | null | undefined) {
+    if (!value) return "";
+    return value
+        .split("_")
+        .map((segment) =>
+            segment.length <= 3 && segment === segment.toUpperCase()
+                ? segment
+                : segment.charAt(0) + segment.slice(1).toLowerCase()
+        )
+        .join(" ");
+}
+
+function computeAge(dateOfBirth?: Date | null, now: Date = new Date()) {
+    if (!dateOfBirth) return "";
+    const birth = new Date(dateOfBirth);
+    if (Number.isNaN(birth.getTime())) return "";
+
+    let age = now.getUTCFullYear() - birth.getUTCFullYear();
+    const monthDiff = now.getUTCMonth() - birth.getUTCMonth();
+    if (
+        monthDiff < 0 ||
+        (monthDiff === 0 && now.getUTCDate() < birth.getUTCDate())
+    ) {
+        age -= 1;
+    }
+
+    return age >= 0 ? String(age) : "";
+}
+
+function slugify(value: string) {
+    return value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .substring(0, 80) || "certificate";
+}
+
+function buildConditionList(rawConditions?: string | null) {
+    if (!rawConditions) {
+        return [];
+    }
+    return rawConditions
+        .split(/[,;\n]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+function formatDateLong(date: Date) {
+    return new Intl.DateTimeFormat("en-PH", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "Asia/Manila",
+    }).format(date);
+}
+
+type CertificateContext = {
+    certificateId: string;
+    certificateType: "medical" | "dental";
+    issueDate: Date;
+    validUntil: Date;
+    issueDateDisplay: string;
+    patientName: string;
+    patientType: string;
+    age: string;
+    sex: string;
+    address: string;
+    program: string;
+    department: string;
+    yearLevel: string;
+    clinicName: string;
+    consultationDate: string;
+    diagnosis: string;
+    findings: string;
+    reason: string;
+    allergies: string[];
+    medicalConditions: string[];
+    doctorName: string;
+    doctorTitle: string;
+    licenseNumber: string;
+    ptrNumber: string;
+};
+
+function renderConditionItems(label: string, items: string[]) {
+    if (!items.length) {
+        return `<div class="detail-line"><span class="detail-label">${label}:</span><span class="detail-value muted">Not recorded</span></div>`;
+    }
+
+    const rendered = items
+        .map((item) => `<span class="chip">${escapeHtml(titleCase(item))}</span>`)
+        .join(" ");
+
+    return `<div class="detail-line"><span class="detail-label">${label}:</span><span class="detail-value">${rendered}</span></div>`;
+}
+
+function renderCertificateHtml(context: CertificateContext) {
+    const heading =
+        context.certificateType === "dental"
+            ? "Dental Certificate"
+            : "Medical Certificate";
+
+    const introLine =
+        context.certificateType === "dental"
+            ? `This is to certify that <strong>${escapeHtml(
+                  context.patientName
+              )}</strong>, a student of Holy Name University, underwent a dental evaluation at the Health Services Department.`
+            : `This is to certify that <strong>${escapeHtml(
+                  context.patientName
+              )}</strong>, a student of Holy Name University, was examined at the Health Services Department.`;
+
+    const assessmentLine = context.diagnosis
+        ? `The assessment was noted as <strong>${escapeHtml(
+              context.diagnosis
+          )}</strong>.`
+        : `The assessment findings are on record with the attending clinician.`;
+
+    const recommendationLine = context.findings
+        ? escapeHtml(context.findings)
+        : "No additional remarks were recorded.";
+
+    const reasonLine = context.reason
+        ? `Reason for visit: ${escapeHtml(context.reason)}.`
+        : "Reason for visit: Not specified.";
+
+    return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${escapeHtml(heading)}</title>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: "Times New Roman", "Georgia", serif;
+        background: #ffffff;
+        color: #111827;
+      }
+
+      main {
+        width: 8.27in;
+        min-height: 11.69in;
+        margin: 0 auto;
+        padding: 0.75in 0.8in;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      header {
+        text-align: center;
+        border-bottom: 2px solid #111827;
+        padding-bottom: 18px;
+        margin-bottom: 12px;
+      }
+
+      .institution {
+        font-size: 16px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+      }
+
+      .department {
+        font-size: 14px;
+        margin: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      h1 {
+        font-size: 28px;
+        margin: 12px 0 4px;
+        letter-spacing: 0.1em;
+      }
+
+      .meta-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        margin-top: 4px;
+      }
+
+      .section-title {
+        font-size: 16px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin: 16px 0 8px;
+      }
+
+      .details {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px 18px;
+        font-size: 13px;
+      }
+
+      .detail-line {
+        display: flex;
+        gap: 6px;
+        align-items: baseline;
+      }
+
+      .detail-label {
+        font-weight: 600;
+        min-width: 110px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 11px;
+        color: #374151;
+      }
+
+      .detail-value {
+        flex: 1;
+        font-size: 13px;
+      }
+
+      .muted {
+        color: #6b7280;
+        font-style: italic;
+      }
+
+      .chip {
+        display: inline-block;
+        border: 1px solid #d1d5db;
+        border-radius: 999px;
+        padding: 2px 10px;
+        font-size: 11px;
+        margin-right: 6px;
+        margin-bottom: 4px;
+      }
+
+      .statement {
+        font-size: 14px;
+        line-height: 1.6;
+        text-align: justify;
+      }
+
+      .statement strong {
+        font-weight: 700;
+      }
+
+      .signature-block {
+        margin-top: 36px;
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .signature {
+        text-align: center;
+        font-size: 13px;
+      }
+
+      .signature .line {
+        border-bottom: 1px solid #111827;
+        margin-bottom: 6px;
+        padding-bottom: 4px;
+        font-weight: 600;
+      }
+
+      footer {
+        margin-top: auto;
+        font-size: 11px;
+        color: #6b7280;
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .certificate-id {
+        font-family: "Courier New", monospace;
+        letter-spacing: 0.08em;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="institution">Holy Name University</div>
+        <div class="department">Health Services Department</div>
+        <h1>${escapeHtml(heading)}</h1>
+        <div class="meta-row">
+          <span>Date Issued: ${escapeHtml(context.issueDateDisplay)}</span>
+          <span>Clinic: ${escapeHtml(context.clinicName)}</span>
+        </div>
+      </header>
+
+      <section>
+        <div class="section-title">Patient Information</div>
+        <div class="details">
+          <div class="detail-line"><span class="detail-label">Name:</span><span class="detail-value">${escapeHtml(
+              context.patientName
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Age:</span><span class="detail-value">${escapeHtml(
+              context.age || "Not provided"
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Sex:</span><span class="detail-value">${escapeHtml(
+              context.sex || "Not provided"
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Student status:</span><span class="detail-value">${escapeHtml(
+              context.patientType
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Program:</span><span class="detail-value">${escapeHtml(
+              context.program || "Not recorded"
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Year level:</span><span class="detail-value">${escapeHtml(
+              context.yearLevel || "Not recorded"
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Department:</span><span class="detail-value">${escapeHtml(
+              context.department || "Not recorded"
+          )}</span></div>
+          <div class="detail-line"><span class="detail-label">Address:</span><span class="detail-value">${escapeHtml(
+              context.address || "Not recorded"
+          )}</span></div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-title">Consultation Summary</div>
+        <p class="statement">${introLine}</p>
+        <p class="statement">${assessmentLine}</p>
+        <p class="statement">${reasonLine}</p>
+        <p class="statement">Doctor's remarks: ${recommendationLine}</p>
+        <p class="statement">Consultation recorded on ${escapeHtml(
+            context.consultationDate
+        )}.</p>
+      </section>
+
+      <section>
+        <div class="section-title">Health Declarations</div>
+        ${renderConditionItems("Allergies", context.allergies)}
+        ${renderConditionItems("Medical Conditions", context.medicalConditions)}
+      </section>
+
+      <div class="signature-block">
+        <div class="signature">
+          <div class="line">${escapeHtml(context.doctorName)}</div>
+          <div>${escapeHtml(context.doctorTitle)}</div>
+          <div>License No.: ${escapeHtml(context.licenseNumber || "Not provided")}</div>
+          <div>PTR No.: ${escapeHtml(context.ptrNumber || "Not provided")}</div>
+        </div>
+      </div>
+
+      <footer>
+        <span>Valid until: ${escapeHtml(formatDateLong(context.validUntil))}</span>
+        <span class="certificate-id">Certificate ID: ${escapeHtml(
+            context.certificateId
+        )}</span>
+      </footer>
+    </main>
+  </body>
+</html>`;
+}
+
+export async function GET(
+    _request: Request,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const doctor = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { role: true },
+        });
+
+        if (!doctor || doctor.role !== Role.DOCTOR) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const appointmentId = params.id;
+        const appointment = await prisma.appointment.findUnique({
+            where: { appointment_id: appointmentId },
+            include: {
+                clinic: { select: { clinic_name: true } },
+                doctor: {
+                    select: {
+                        user_id: true,
+                        username: true,
+                        specialization: true,
+                        employee: {
+                            select: {
+                                fname: true,
+                                mname: true,
+                                lname: true,
+                                employee_id: true,
+                                contactno: true,
+                            },
+                        },
+                    },
+                },
+                consultation: {
+                    select: {
+                        consultation_id: true,
+                        reason_of_visit: true,
+                        findings: true,
+                        diagnosis: true,
+                        updatedAt: true,
+                    },
+                },
+                patient: {
+                    select: {
+                        user_id: true,
+                        username: true,
+                        student: {
+                            select: {
+                                fname: true,
+                                mname: true,
+                                lname: true,
+                                date_of_birth: true,
+                                gender: true,
+                                address: true,
+                                program: true,
+                                department: true,
+                                year_level: true,
+                                allergies: true,
+                                medical_cond: true,
+                            },
+                        },
+                        employee: {
+                            select: {
+                                fname: true,
+                                mname: true,
+                                lname: true,
+                                date_of_birth: true,
+                                gender: true,
+                                address: true,
+                                department: true,
+                                allergies: true,
+                                medical_cond: true,
+                            },
+                        },
+                    },
+                },
+                patient_user_id: true,
+                status: true,
+                appointment_timestart: true,
+            },
+        });
+
+        if (!appointment) {
+            return NextResponse.json(
+                { error: "Appointment not found" },
+                { status: 404 }
+            );
+        }
+
+        if (appointment.doctor_user_id !== session.user.id) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        if (appointment.status !== AppointmentStatus.Completed) {
+            return NextResponse.json(
+                { error: "Complete the appointment before generating a certificate." },
+                { status: 400 }
+            );
+        }
+
+        if (!appointment.consultation) {
+            return NextResponse.json(
+                { error: "Consultation notes are required before issuing a certificate." },
+                { status: 400 }
+            );
+        }
+
+        const specialization = appointment.doctor.specialization;
+        if (
+            !specialization ||
+            ![DoctorSpecialization.Physician, DoctorSpecialization.Dentist].includes(
+                specialization
+            )
+        ) {
+            return NextResponse.json(
+                { error: "Doctor specialization is required to generate a certificate." },
+                { status: 400 }
+            );
+        }
+
+        const studentProfile = appointment.patient.student;
+        if (!studentProfile) {
+            return NextResponse.json(
+                { error: "Certificates are currently available for student patients only." },
+                { status: 400 }
+            );
+        }
+
+        const now = manilaNow();
+        const validity = new Date(now);
+        validity.setUTCDate(validity.getUTCDate() + 3);
+
+        const existingCert = await prisma.medCert.findFirst({
+            where: { consultation_id: appointment.consultation.consultation_id },
+        });
+
+        const medcert = existingCert
+            ? await prisma.medCert.update({
+                  where: { certificate_id: existingCert.certificate_id },
+                  data: {
+                      issue_date: now,
+                      valid_until: validity,
+                      status: MedcertStatus.Valid,
+                      issued_by_user_id: session.user.id,
+                  },
+              })
+            : await prisma.medCert.create({
+                  data: {
+                      consultation_id: appointment.consultation.consultation_id,
+                      patient_user_id: appointment.patient_user_id,
+                      issued_by_user_id: session.user.id,
+                      issue_date: now,
+                      valid_until: validity,
+                      status: MedcertStatus.Valid,
+                  },
+              });
+
+        const age = computeAge(studentProfile.date_of_birth, now);
+        const sex = studentProfile.gender ? titleCase(studentProfile.gender) : "";
+        const program = titleCase(studentProfile.program);
+        const department = humanizeEnum(studentProfile.department);
+        const yearLevel = humanizeEnum(studentProfile.year_level);
+        const allergies = buildConditionList(studentProfile.allergies);
+        const medicalConditions = buildConditionList(studentProfile.medical_cond);
+        const patientName = titleCase(
+            [studentProfile.fname, studentProfile.mname, studentProfile.lname]
+                .filter(Boolean)
+                .join(" ") || appointment.patient.username
+        );
+
+        const doctorEmployee = appointment.doctor.employee;
+        const doctorName = doctorEmployee
+            ? titleCase(
+                  [doctorEmployee.fname, doctorEmployee.mname, doctorEmployee.lname]
+                      .filter(Boolean)
+                      .join(" ") || appointment.doctor.username
+              )
+            : appointment.doctor.username.startsWith("Dr.")
+                ? appointment.doctor.username
+                : `Dr. ${appointment.doctor.username}`;
+
+        const doctorTitle =
+            specialization === DoctorSpecialization.Dentist
+                ? "Attending Dentist"
+                : "Attending Physician";
+
+        const issueDateDisplay = formatDateLong(medcert.issue_date);
+        const consultationDate =
+            formatManilaDateTime(appointment.appointment_timestart) ?? issueDateDisplay;
+
+        const context: CertificateContext = {
+            certificateId: medcert.certificate_id,
+            certificateType:
+                specialization === DoctorSpecialization.Dentist ? "dental" : "medical",
+            issueDate: medcert.issue_date,
+            validUntil: medcert.valid_until,
+            issueDateDisplay,
+            patientName,
+            patientType: "Student",
+            age,
+            sex,
+            address: studentProfile.address ?? "",
+            program,
+            department,
+            yearLevel,
+            clinicName: appointment.clinic.clinic_name,
+            consultationDate,
+            diagnosis: appointment.consultation.diagnosis ?? "",
+            findings: appointment.consultation.findings ?? "",
+            reason: appointment.consultation.reason_of_visit ?? "",
+            allergies,
+            medicalConditions,
+            doctorName,
+            doctorTitle,
+            licenseNumber: doctorEmployee?.employee_id ?? "",
+            ptrNumber: doctorEmployee?.contactno ?? "",
+        };
+
+        const html = renderCertificateHtml(context);
+
+        const executablePath = await chromium.executablePath();
+        const browser = await puppeteer.launch({
+            args: chromium.args,
+            defaultViewport: { width: 1280, height: 720 },
+            executablePath: executablePath || undefined,
+            headless: true,
+        });
+
+        try {
+            const page = await browser.newPage();
+            await page.setContent(html, { waitUntil: "networkidle0" });
+            await page.emulateMediaType("print");
+            const pdfBuffer = await page.pdf({
+                format: "A4",
+                printBackground: true,
+                margin: {
+                    top: "0.4in",
+                    bottom: "0.5in",
+                    left: "0.5in",
+                    right: "0.5in",
+                },
+            });
+
+            const pdfArrayBuffer =
+                pdfBuffer instanceof ArrayBuffer
+                    ? pdfBuffer
+                    : pdfBuffer.buffer.slice(
+                          pdfBuffer.byteOffset,
+                          pdfBuffer.byteOffset + pdfBuffer.byteLength
+                      );
+
+            const filename = `${
+                context.certificateType === "dental" ? "dental" : "medical"
+            }-certificate-${slugify(patientName)}.pdf`;
+
+            return new Response(pdfArrayBuffer as ArrayBuffer, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/pdf",
+                    "Content-Disposition": `attachment; filename="${filename}"`,
+                    "Cache-Control": "no-store",
+                },
+            });
+        } finally {
+            await browser.close();
+        }
+    } catch (error) {
+        console.error("[GET /api/doctor/appointments/:id/certificate]", error);
+        return NextResponse.json(
+            { error: "Failed to generate certificate" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -627,7 +627,6 @@ export async function GET(
 
         const html = renderCertificateHtml(context);
 
-        const executablePath = await chromium.executablePath();
         const browser = await puppeteer.launch({
             args: chromium.args,
             defaultViewport: { width: 1280, height: 720 },

--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -139,16 +139,16 @@ function renderCertificateHtml(context: CertificateContext) {
     const introLine =
         context.certificateType === "dental"
             ? `This is to certify that <strong>${escapeHtml(
-                  context.patientName
-              )}</strong>, a student of Holy Name University, underwent a dental evaluation at the Health Services Department.`
+                context.patientName
+            )}</strong>, a student of Holy Name University, underwent a dental evaluation at the Health Services Department.`
             : `This is to certify that <strong>${escapeHtml(
-                  context.patientName
-              )}</strong>, a student of Holy Name University, was examined at the Health Services Department.`;
+                context.patientName
+            )}</strong>, a student of Holy Name University, was examined at the Health Services Department.`;
 
     const assessmentLine = context.diagnosis
         ? `The assessment was noted as <strong>${escapeHtml(
-              context.diagnosis
-          )}</strong>.`
+            context.diagnosis
+        )}</strong>.`
         : `The assessment findings are on record with the attending clinician.`;
 
     const recommendationLine = context.findings
@@ -333,29 +333,29 @@ function renderCertificateHtml(context: CertificateContext) {
         <div class="section-title">Patient Information</div>
         <div class="details">
           <div class="detail-line"><span class="detail-label">Name:</span><span class="detail-value">${escapeHtml(
-              context.patientName
-          )}</span></div>
+        context.patientName
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Age:</span><span class="detail-value">${escapeHtml(
-              context.age || "Not provided"
-          )}</span></div>
+        context.age || "Not provided"
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Sex:</span><span class="detail-value">${escapeHtml(
-              context.sex || "Not provided"
-          )}</span></div>
+        context.sex || "Not provided"
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Student status:</span><span class="detail-value">${escapeHtml(
-              context.patientType
-          )}</span></div>
+        context.patientType
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Program:</span><span class="detail-value">${escapeHtml(
-              context.program || "Not recorded"
-          )}</span></div>
+        context.program || "Not recorded"
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Year level:</span><span class="detail-value">${escapeHtml(
-              context.yearLevel || "Not recorded"
-          )}</span></div>
+        context.yearLevel || "Not recorded"
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Department:</span><span class="detail-value">${escapeHtml(
-              context.department || "Not recorded"
-          )}</span></div>
+        context.department || "Not recorded"
+    )}</span></div>
           <div class="detail-line"><span class="detail-label">Address:</span><span class="detail-value">${escapeHtml(
-              context.address || "Not recorded"
-          )}</span></div>
+        context.address || "Not recorded"
+    )}</span></div>
         </div>
       </section>
 
@@ -366,8 +366,8 @@ function renderCertificateHtml(context: CertificateContext) {
         <p class="statement">${reasonLine}</p>
         <p class="statement">Doctor's remarks: ${recommendationLine}</p>
         <p class="statement">Consultation recorded on ${escapeHtml(
-            context.consultationDate
-        )}.</p>
+        context.consultationDate
+    )}.</p>
       </section>
 
       <section>
@@ -388,8 +388,8 @@ function renderCertificateHtml(context: CertificateContext) {
       <footer>
         <span>Valid until: ${escapeHtml(formatDateLong(context.validUntil))}</span>
         <span class="certificate-id">Certificate ID: ${escapeHtml(
-            context.certificateId
-        )}</span>
+        context.certificateId
+    )}</span>
       </footer>
     </main>
   </body>
@@ -418,7 +418,13 @@ export async function GET(
         const appointmentId = params.id;
         const appointment = await prisma.appointment.findUnique({
             where: { appointment_id: appointmentId },
-            include: {
+            select: {
+                appointment_id: true,
+                patient_user_id: true,
+                doctor_user_id: true, // ✅ add this line
+                appointment_timestart: true,
+                status: true,
+
                 clinic: { select: { clinic_name: true } },
                 doctor: {
                     select: {
@@ -472,16 +478,12 @@ export async function GET(
                                 date_of_birth: true,
                                 gender: true,
                                 address: true,
-                                department: true,
                                 allergies: true,
                                 medical_cond: true,
                             },
                         },
                     },
                 },
-                patient_user_id: true,
-                status: true,
-                appointment_timestart: true,
             },
         });
 
@@ -541,24 +543,24 @@ export async function GET(
 
         const medcert = existingCert
             ? await prisma.medCert.update({
-                  where: { certificate_id: existingCert.certificate_id },
-                  data: {
-                      issue_date: now,
-                      valid_until: validity,
-                      status: MedcertStatus.Valid,
-                      issued_by_user_id: session.user.id,
-                  },
-              })
+                where: { certificate_id: existingCert.certificate_id },
+                data: {
+                    issue_date: now,
+                    valid_until: validity,
+                    status: MedcertStatus.Valid,
+                    issued_by_user_id: session.user.id,
+                },
+            })
             : await prisma.medCert.create({
-                  data: {
-                      consultation_id: appointment.consultation.consultation_id,
-                      patient_user_id: appointment.patient_user_id,
-                      issued_by_user_id: session.user.id,
-                      issue_date: now,
-                      valid_until: validity,
-                      status: MedcertStatus.Valid,
-                  },
-              });
+                data: {
+                    consultation_id: appointment.consultation.consultation_id,
+                    patient_user_id: appointment.patient_user_id,
+                    issued_by_user_id: session.user.id,
+                    issue_date: now,
+                    valid_until: validity,
+                    status: MedcertStatus.Valid,
+                },
+            });
 
         const age = computeAge(studentProfile.date_of_birth, now);
         const sex = studentProfile.gender ? titleCase(studentProfile.gender) : "";
@@ -576,10 +578,10 @@ export async function GET(
         const doctorEmployee = appointment.doctor.employee;
         const doctorName = doctorEmployee
             ? titleCase(
-                  [doctorEmployee.fname, doctorEmployee.mname, doctorEmployee.lname]
-                      .filter(Boolean)
-                      .join(" ") || appointment.doctor.username
-              )
+                [doctorEmployee.fname, doctorEmployee.mname, doctorEmployee.lname]
+                    .filter(Boolean)
+                    .join(" ") || appointment.doctor.username
+            )
             : appointment.doctor.username.startsWith("Dr.")
                 ? appointment.doctor.username
                 : `Dr. ${appointment.doctor.username}`;
@@ -650,13 +652,12 @@ export async function GET(
                 pdfBuffer instanceof ArrayBuffer
                     ? pdfBuffer
                     : pdfBuffer.buffer.slice(
-                          pdfBuffer.byteOffset,
-                          pdfBuffer.byteOffset + pdfBuffer.byteLength
-                      );
+                        pdfBuffer.byteOffset,
+                        pdfBuffer.byteOffset + pdfBuffer.byteLength
+                    );
 
-            const filename = `${
-                context.certificateType === "dental" ? "dental" : "medical"
-            }-certificate-${slugify(patientName)}.pdf`;
+            const filename = `${context.certificateType === "dental" ? "dental" : "medical"
+                }-certificate-${slugify(patientName)}.pdf`;
 
             return new Response(pdfArrayBuffer as ArrayBuffer, {
                 status: 200,

--- a/src/app/api/doctor/appointments/[id]/route.ts
+++ b/src/app/api/doctor/appointments/[id]/route.ts
@@ -153,13 +153,28 @@ function shapeResponse(appointment: {
     };
     consultation: { consultation_id: string } | null;
 }) {
+    const patientType = appointment.patient.student
+        ? "Student"
+        : appointment.patient.employee
+            ? "Employee"
+            : "Unknown";
+
+    const timeOnly =
+        formatManilaDateTime(appointment.appointment_timestart, {
+            year: undefined,
+            month: undefined,
+            day: undefined,
+        }) ?? "";
+
     return {
         id: appointment.appointment_id,
         status: appointment.status,
         clinic: appointment.clinic.clinic_name,
-        patient: formatPatientName(appointment.patient),
-        time: formatManilaDateTime(appointment.appointment_timestart),
-        consultation: appointment.consultation?.consultation_id ?? null,
+        patientName: formatPatientName(appointment.patient),
+        date: formatManilaISODate(appointment.appointment_timestart),
+        time: timeOnly,
+        hasConsultation: Boolean(appointment.consultation),
+        patientType,
     };
 }
 

--- a/src/app/api/doctor/appointments/[id]/route.ts
+++ b/src/app/api/doctor/appointments/[id]/route.ts
@@ -180,10 +180,11 @@ function shapeResponse(appointment: {
 
 export async function PATCH(
     request: Request,
-    { params }: { params: { id: string } }
+    context: { params: Promise<{ id: string }> }
 ) {
+    const { id } = await context.params;
+
     try {
-        const { id } = params;
         const session = await getServerSession(authOptions);
         if (!session?.user?.id)
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/doctor/appointments/route.ts
+++ b/src/app/api/doctor/appointments/route.ts
@@ -54,6 +54,11 @@ export async function GET() {
             time: phTime(a.appointment_timestart),
             status: a.status,
             hasConsultation: Boolean(a.consultation),
+            patientType: a.patient.student
+                ? "Student"
+                : a.patient.employee
+                    ? "Employee"
+                    : "Unknown",
         }));
 
         return NextResponse.json(formatted);


### PR DESCRIPTION
## Summary
- expose doctor specialization to the client and include patient types in appointment responses
- add a certificate PDF endpoint that issues medical or dental certificates for completed student visits
- update the doctor appointments page to fetch specialization data and let doctors download the generated certificate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f656e4260c833384aaa816d99aaeac