### PR TITLE
Add dark mode toggles and styles for marketing and app layouts

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Menu,
     X,
@@ -51,9 +52,9 @@ export default function AboutPage() {
     ];
 
     return (
-        <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50">
+        <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
             {/* Header */}
-            <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100">
+            <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100 dark:bg-slate-950/80 dark:border-slate-800">
                 <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-8 py-3">
                     {/* Logo + Title */}
                     <div className="flex items-center gap-1">
@@ -69,47 +70,54 @@ export default function AboutPage() {
                                 priority
                                 className="md:w-14 md:h-14"
                             />
-                            <h1 className="text-lg md:text-2xl font-bold text-green-600 leading-none">
+                            <h1 className="text-lg md:text-2xl font-bold text-green-600 leading-none dark:text-emerald-300">
                                 HNU Clinic
                             </h1>
                         </Link>
                     </div>
 
                     {/* Desktop Nav */}
-                    <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+                    <nav className="hidden md:flex items-center gap-5 text-sm font-medium">
                         {navigation.map((item) => (
-                            <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
+                            <Link
+                                key={item.label}
+                                href={item.href}
+                                className="text-gray-700 hover:text-green-600 transition dark:text-slate-200 dark:hover:text-emerald-300"
+                            >
                                 {item.label}
                             </Link>
                         ))}
+                        <ThemeToggle className="hidden lg:inline-flex" />
                         <Link href="/login">
-                            <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
+                            <Button className="bg-green-600 hover:bg-green-700 shadow-sm dark:bg-emerald-500 dark:hover:bg-emerald-400">
+                                Login
+                            </Button>
                         </Link>
                     </nav>
 
                     {/* Mobile Menu Button */}
-                    <button
-                        className="md:hidden p-2"
-                        onClick={() => setMenuOpen(!menuOpen)}
-                    >
-                        {menuOpen ? (
-                            <X className="w-6 h-6 text-green-600" />
-                        ) : (
-                            <Menu className="w-6 h-6 text-green-600" />
-                        )}
-                    </button>
+                    <div className="flex items-center gap-2 md:hidden">
+                        <ThemeToggle size="sm" />
+                        <button className="p-2 text-green-600 dark:text-emerald-300" onClick={() => setMenuOpen(!menuOpen)}>
+                            {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+                        </button>
+                    </div>
                 </div>
 
                 {/* Mobile Dropdown Nav */}
                 {menuOpen && (
-                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95">
+                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95 dark:bg-slate-950/95">
                         {navigation.map((item) => (
-                            <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
+                            <Link
+                                key={item.label}
+                                href={item.href}
+                                className="text-gray-700 hover:text-green-600 transition dark:text-slate-200 dark:hover:text-emerald-300"
+                            >
                                 {item.label}
                             </Link>
                         ))}
                         <Link href="/login">
-                            <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
+                            <Button className="w-full bg-green-600 hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
                         </Link>
                     </div>
                 )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,6 +136,94 @@
   .font-display {
     font-family: var(--font-display), system-ui, sans-serif;
   }
+
+  .dark .text-gray-700 {
+    color: oklch(0.855 0.015 260.052);
+  }
+
+  .dark .text-gray-600 {
+    color: oklch(0.8 0.02 260.052);
+  }
+
+  .dark .text-green-600,
+  .dark .text-green-700 {
+    color: oklch(0.74 0.11 155.417);
+  }
+
+  .dark .text-green-800 {
+    color: oklch(0.7 0.11 155.417);
+  }
+
+  .dark .text-slate-600,
+  .dark .text-slate-700 {
+    color: oklch(0.82 0.02 260.052);
+  }
+
+  .dark .text-slate-500 {
+    color: oklch(0.78 0.02 260.052);
+  }
+
+  .dark .bg-white {
+    background-color: color-mix(in oklch, var(--card) 92%, transparent);
+  }
+
+  .dark .bg-white\/90 {
+    background-color: color-mix(in oklch, var(--card) 90%, transparent);
+  }
+
+  .dark .bg-white\/80 {
+    background-color: color-mix(in oklch, var(--card) 80%, transparent);
+  }
+
+  .dark .bg-white\/60 {
+    background-color: color-mix(in oklch, var(--card) 60%, transparent);
+  }
+
+  .dark .bg-white\/70 {
+    background-color: color-mix(in oklch, var(--card) 70%, transparent);
+  }
+
+  .dark .bg-green-50,
+  .dark .bg-green-100 {
+    background-color: color-mix(in oklch, var(--primary) 25%, var(--background));
+  }
+
+  .dark .bg-green-50\/60 {
+    background-color: color-mix(in oklch, var(--primary) 18%, var(--background));
+  }
+
+  .dark .bg-green-200\/40 {
+    background-color: color-mix(in oklch, var(--primary) 22%, transparent);
+  }
+
+  .dark .bg-green-300\/40 {
+    background-color: color-mix(in oklch, var(--primary) 30%, transparent);
+  }
+
+  .dark .border-green-100,
+  .dark .border-green-200 {
+    border-color: color-mix(in oklch, var(--primary) 35%, var(--background));
+  }
+
+  .dark .border-green-100\/80 {
+    border-color: color-mix(in oklch, var(--primary) 35%, var(--background));
+  }
+
+  .dark .bg-green-600 {
+    background-color: color-mix(in oklch, var(--primary) 80%, black 10%);
+  }
+
+  .dark .hover\:bg-green-700:hover {
+    background-color: color-mix(in oklch, var(--primary) 85%, black 18%);
+  }
+
+  .dark .bg-green-600:hover {
+    background-color: color-mix(in oklch, var(--primary) 85%, black 18%);
+  }
+
+  .dark .text-green-500 {
+    color: oklch(0.78 0.1 154.992);
+  }
 }
 
 html {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html
       lang="en"
       data-scroll-behavior="smooth"
+      suppressHydrationWarning
       className={`${poppins.variable} ${inter.variable}`}
     >
       <body className="antialiased min-h-screen flex flex-col font-sans">

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Users,
     Code2,
@@ -61,9 +62,9 @@ export default function LearnMorePage() {
     ];
 
     return (
-        <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50">
+        <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
             {/* Header */}
-            <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100">
+            <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100 dark:bg-slate-950/80 dark:border-slate-800">
                 <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-8 py-3">
                     {/* Logo + Title */}
                     <div className="flex items-center gap-1">
@@ -79,48 +80,58 @@ export default function LearnMorePage() {
                                 priority
                                 className="md:w-14 md:h-14"
                             />
-                            <h1 className="text-lg md:text-2xl font-bold text-green-600 leading-none">
+                            <h1 className="text-lg md:text-2xl font-bold text-green-600 leading-none dark:text-emerald-300">
                                 HNU Clinic
                             </h1>
                         </Link>
                     </div>
 
                     {/* Desktop Nav */}
-                    <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+                    <nav className="hidden md:flex items-center gap-5 text-sm font-medium">
                         {navigation.map((item) => (
-                            <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
+                            <Link
+                                key={item.label}
+                                href={item.href}
+                                className="text-gray-700 hover:text-green-600 transition dark:text-slate-200 dark:hover:text-emerald-300"
+                            >
                                 {item.label}
                             </Link>
                         ))}
+                        <ThemeToggle className="hidden lg:inline-flex" />
                         <Link href="/login">
-                            <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
+                            <Button className="bg-green-600 hover:bg-green-700 shadow-sm dark:bg-emerald-500 dark:hover:bg-emerald-400">
+                                Login
+                            </Button>
                         </Link>
                     </nav>
 
                     {/* Mobile Nav Toggle */}
-                    <button
-                        className="md:hidden p-2"
-                        onClick={() => setMenuOpen(!menuOpen)}
-                        aria-label={menuOpen ? "Close menu" : "Open menu"}
-                    >
-                        {menuOpen ? (
-                            <X className="w-6 h-6 text-green-600" />
-                        ) : (
-                            <Menu className="w-6 h-6 text-green-600" />
-                        )}
-                    </button>
+                    <div className="flex items-center gap-2 md:hidden">
+                        <ThemeToggle size="sm" />
+                        <button
+                            className="p-2 text-green-600 dark:text-emerald-300"
+                            onClick={() => setMenuOpen(!menuOpen)}
+                            aria-label={menuOpen ? "Close menu" : "Open menu"}
+                        >
+                            {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+                        </button>
+                    </div>
                 </div>
 
                 {/* Mobile Dropdown */}
                 {menuOpen && (
-                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95">
+                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95 dark:bg-slate-950/95">
                         {navigation.map((item) => (
-                            <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600">
+                            <Link
+                                key={item.label}
+                                href={item.href}
+                                className="text-gray-700 hover:text-green-600 dark:text-slate-200 dark:hover:text-emerald-300"
+                            >
                                 {item.label}
                             </Link>
                         ))}
                         <Link href="/login">
-                            <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
+                            <Button className="w-full bg-green-600 hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
                         </Link>
                     </div>
                 )}
@@ -128,26 +139,29 @@ export default function LearnMorePage() {
 
             {/* Hero Section */}
             <section className="relative overflow-hidden">
-                <div className="absolute inset-0 -z-10 bg-gradient-to-br from-green-100 via-white to-green-50" />
-                <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.12),_transparent_65%)]" />
+                <div className="absolute inset-0 -z-10 bg-gradient-to-br from-green-100 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900" />
+                <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.12),_transparent_65%)] dark:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_65%)]" />
                 <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between px-6 md:px-12 py-16 md:py-24 gap-12">
                     <div className="max-w-xl space-y-6 text-center md:text-left">
-                        <span className="inline-flex items-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                        <span className="inline-flex items-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700 dark:border-slate-800 dark:bg-slate-950/80 dark:text-emerald-200">
                             Platform Overview
                         </span>
-                        <h2 className="text-3xl md:text-5xl font-bold text-green-700 leading-tight">
+                        <h2 className="text-3xl md:text-5xl font-bold text-green-700 leading-tight dark:text-emerald-200">
                             HNU Clinic’s digital system keeps campus healthcare organized, secure, and accessible.
                         </h2>
-                        <p className="text-gray-700 text-base md:text-lg leading-relaxed">
+                        <p className="text-gray-700 text-base md:text-lg leading-relaxed dark:text-slate-200">
                             From streamlined appointment requests to comprehensive visit documentation, the platform supports every stage of the patient journey for students, faculty, and staff.
                         </p>
                         <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start">
                             <Link href="/login">
-                                <Button size="lg" className="bg-green-600 hover:bg-green-700 shadow-md">
+                                <Button size="lg" className="bg-green-600 hover:bg-green-700 shadow-md dark:bg-emerald-500 dark:hover:bg-emerald-400">
                                     Go to Portal
                                 </Button>
                             </Link>
-                            <Link href="/about" className="flex items-center justify-center gap-2 text-green-700 text-sm font-medium hover:text-green-800">
+                            <Link
+                                href="/about"
+                                className="flex items-center justify-center gap-2 text-green-700 text-sm font-medium hover:text-green-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+                            >
                                 <span>Discover our clinic team</span>
                                 <ArrowRight className="h-4 w-4" />
                             </Link>
@@ -194,7 +208,7 @@ export default function LearnMorePage() {
             </section>
 
             {/* Technologies Used */}
-            <section className="py-16 md:py-20 px-6 md:px-12 bg-white">
+            <section className="py-16 md:py-20 px-6 md:px-12 bg-white dark:bg-slate-950">
                 <div className="max-w-6xl mx-auto space-y-10">
                     <div className="text-center space-y-4">
                         <Code2 className="w-12 h-12 text-green-600 mx-auto" />

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -19,6 +19,7 @@ import {
     DialogDescription,
 } from "@/components/ui/dialog";
 import { normalizeResetContact } from "@/lib/password-reset";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export default function LoginPageClient() {
     const [loadingRole, setLoadingRole] = useState<string | null>(null);
@@ -236,7 +237,7 @@ export default function LoginPageClient() {
                 placeholder={placeholder}
                 required
                 disabled={!!loadingRole}
-                className="h-11 rounded-xl border-green-100 bg-white/90 text-slate-700 placeholder:text-slate-400 focus-visible:ring-green-500/50"
+                className="h-11 rounded-xl border-green-100 bg-white/90 text-slate-700 placeholder:text-slate-400 focus-visible:ring-green-500/50 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-100"
             />
 
             <div className="relative">
@@ -245,7 +246,7 @@ export default function LoginPageClient() {
                     type={showPassword ? "text" : "password"}
                     placeholder="Password"
                     required
-                    className="h-11 rounded-xl border-green-100 bg-white/90 pr-12 text-slate-700 placeholder:text-slate-400 focus-visible:ring-green-500/50"
+                    className="h-11 rounded-xl border-green-100 bg-white/90 pr-12 text-slate-700 placeholder:text-slate-400 focus-visible:ring-green-500/50 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-100"
                     disabled={!!loadingRole}
                 />
                 <Button
@@ -254,7 +255,7 @@ export default function LoginPageClient() {
                     size="icon"
                     onClick={() => setShowPassword(!showPassword)}
                     disabled={!!loadingRole}
-                    className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:bg-transparent"
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:bg-transparent dark:text-slate-300"
                 >
                     {showPassword ? (
                         <EyeOff className="h-5 w-5" />
@@ -267,7 +268,7 @@ export default function LoginPageClient() {
             <Button
                 type="submit"
                 disabled={loadingRole === role}
-                className="flex h-11 w-full items-center justify-center gap-2 rounded-xl bg-green-600 font-medium text-white shadow-md shadow-green-200 transition hover:bg-green-700"
+                className="flex h-11 w-full items-center justify-center gap-2 rounded-xl bg-green-600 font-medium text-white shadow-md shadow-green-200 transition hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
             >
                 {loadingRole === role ? (
                     <>
@@ -283,7 +284,7 @@ export default function LoginPageClient() {
                 <button
                     type="button"
                     onClick={() => setForgotOpen(true)}
-                    className="font-medium text-green-800 underline-offset-4 transition hover:underline"
+                    className="font-medium text-green-800 underline-offset-4 transition hover:underline dark:text-emerald-300"
                 >
                     Forgot password?
                 </button>
@@ -293,7 +294,8 @@ export default function LoginPageClient() {
 
     // ---------- RENDER ----------
     return (
-        <div className="relative min-h-screen bg-gradient-to-br from-green-100 via-white to-green-200">
+        <div className="relative min-h-screen bg-gradient-to-br from-green-100 via-white to-green-200 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
+            <ThemeToggle size="sm" className="absolute right-6 top-6 z-20" />
             <div className="absolute inset-0 overflow-hidden">
                 <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-green-300/40 blur-3xl" />
                 <div className="absolute -bottom-28 -left-16 h-72 w-72 rounded-full bg-green-300/40 blur-3xl" />
@@ -301,11 +303,11 @@ export default function LoginPageClient() {
 
             <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col justify-between gap-12 px-6 py-12 lg:flex-row lg:items-center lg:py-24">
                 <div className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-lg lg:text-left">
-                    <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1 text-sm font-medium text-green-700 shadow-sm">
-                        <span className="h-2 w-2 rounded-full bg-green-500" />
+                    <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1 text-sm font-medium text-green-700 shadow-sm dark:bg-slate-900/70 dark:text-emerald-200">
+                        <span className="h-2 w-2 rounded-full bg-green-500 dark:bg-emerald-400" />
                         Secure Access Portal
                     </span>
-                    <h1 className="mt-6 text-3xl font-bold text-green-600 sm:text-4xl md:text-5xl">
+                    <h1 className="mt-6 text-3xl font-bold text-green-600 sm:text-4xl md:text-5xl dark:text-emerald-200">
                         Welcome back to HNU Clinic
                     </h1>
                     <p className="mt-4 text-base leading-relaxed text-slate-600 sm:text-lg">
@@ -315,13 +317,13 @@ export default function LoginPageClient() {
 
                     <dl className="mt-8 grid gap-4 text-left sm:grid-cols-2">
                         <div className="rounded-xl bg-white/80 p-4 shadow-sm backdrop-blur">
-                            <dt className="text-sm font-medium text-green-700">Multi-role support</dt>
+                            <dt className="text-sm font-medium text-green-700 dark:text-emerald-200">Multi-role support</dt>
                             <dd className="mt-1 text-sm text-slate-600">
                                 Access tailored dashboards for doctors, nurses, scholars, and patients.
                             </dd>
                         </div>
                         <div className="rounded-xl bg-white/80 p-4 shadow-sm backdrop-blur">
-                            <dt className="text-sm font-medium text-green-700">Privacy first</dt>
+                            <dt className="text-sm font-medium text-green-700 dark:text-emerald-200">Privacy first</dt>
                             <dd className="mt-1 text-sm text-slate-600">
                                 Your information is protected with secure authentication measures.
                             </dd>
@@ -333,11 +335,11 @@ export default function LoginPageClient() {
                     <Card
                         className={`relative z-10 overflow-hidden border-0 bg-white/90 shadow-xl backdrop-blur-xl transition-opacity ${loadingRole ? "opacity-60" : ""}`}
                     >
-                        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-green-400 via-lime-400 to-green-500" />
+                        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-green-400 via-lime-400 to-green-500 dark:from-emerald-500 dark:via-emerald-400 dark:to-emerald-600" />
                         <CardContent className="p-8">
                             <div className="mb-6 flex items-center justify-between">
                                 <div>
-                                    <h2 className="text-xl font-semibold text-green-900">Sign in</h2>
+                                    <h2 className="text-xl font-semibold text-green-900 dark:text-emerald-200">Sign in</h2>
                                     <p className="text-sm text-slate-500">
                                         Use your assigned credentials to access the clinic portal.
                                     </p>
@@ -348,27 +350,27 @@ export default function LoginPageClient() {
                             </div>
 
                             <Tabs defaultValue="doctor" className="w-full">
-                                <TabsList className="flex flex-wrap w-full grid-cols-2 gap-2 rounded-xl bg-green-100/60 p-1 text-sm sm:grid-cols-4">
+                                <TabsList className="flex flex-wrap w-full grid-cols-2 gap-2 rounded-xl bg-green-100/60 p-1 text-sm sm:grid-cols-4 dark:bg-slate-900/70">
                                     <TabsTrigger
-                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700"
+                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700 dark:data-[state=active]:bg-slate-900/80 dark:data-[state=active]:text-emerald-200"
                                         value="doctor"
                                     >
                                         Doctor
                                     </TabsTrigger>
                                     <TabsTrigger
-                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700"
+                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700 dark:data-[state=active]:bg-slate-900/80 dark:data-[state=active]:text-emerald-200"
                                         value="nurse"
                                     >
                                         Nurse
                                     </TabsTrigger>
                                     <TabsTrigger
-                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700"
+                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700 dark:data-[state=active]:bg-slate-900/80 dark:data-[state=active]:text-emerald-200"
                                         value="scholar"
                                     >
                                         Scholar
                                     </TabsTrigger>
                                     <TabsTrigger
-                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700"
+                                        className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-green-700 dark:data-[state=active]:bg-slate-900/80 dark:data-[state=active]:text-emerald-200"
                                         value="patient"
                                     >
                                         Patient
@@ -403,9 +405,9 @@ export default function LoginPageClient() {
 
             {/* Forgot Password Modal */}
             <Dialog open={forgotOpen} onOpenChange={handleForgotToggle}>
-                <DialogContent className="max-w-sm">
+                <DialogContent className="max-w-sm dark:bg-slate-950">
                     <DialogHeader>
-                        <DialogTitle className="text-green-700">Reset Password</DialogTitle>
+                        <DialogTitle className="text-green-700 dark:text-emerald-200">Reset Password</DialogTitle>
                         <DialogDescription className="text-gray-600">
                             {tokenSent
                                 ? "Enter the 6 digit code sent to your email and set your new password."
@@ -437,7 +439,7 @@ export default function LoginPageClient() {
                                 <Button
                                     type="submit"
                                     disabled={verifying}
-                                    className="w-full bg-green-600 text-white hover:bg-green-700"
+                                    className="w-full bg-green-600 text-white hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                                 >
                                     {verifying ? (
                                         <>
@@ -467,7 +469,7 @@ export default function LoginPageClient() {
                                             setShowResetPassword(false);
                                             setShowResetConfirmPassword(false);
                                         }}
-                                        className="text-xs font-medium text-green-700 underline-offset-2 hover:underline"
+                                        className="text-xs font-medium text-green-700 underline-offset-2 hover:underline dark:text-emerald-300"
                                     >
                                         Use a different contact
                                     </button>
@@ -519,7 +521,7 @@ export default function LoginPageClient() {
                                                     setNewPassword(e.target.value);
                                                     if (passwordError) setPasswordError(null);
                                                 }}
-                                                className="pr-12"
+                                            className="pr-12"
                                                 required
                                             />
                                             <Button
@@ -527,7 +529,7 @@ export default function LoginPageClient() {
                                                 variant="ghost"
                                                 size="icon"
                                                 onClick={() => setShowResetPassword((prev) => !prev)}
-                                                className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:bg-transparent"
+                                                className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:bg-transparent dark:text-slate-300"
                                             >
                                                 {showResetPassword ? (
                                                     <EyeOff className="h-5 w-5" />
@@ -546,7 +548,7 @@ export default function LoginPageClient() {
                                                     setConfirmPassword(e.target.value);
                                                     if (passwordError) setPasswordError(null);
                                                 }}
-                                                className="pr-12"
+                                            className="pr-12"
                                                 required
                                             />
                                             <Button
@@ -556,7 +558,7 @@ export default function LoginPageClient() {
                                                 onClick={() =>
                                                     setShowResetConfirmPassword((prev) => !prev)
                                                 }
-                                                className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:bg-transparent"
+                                                className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:bg-transparent dark:text-slate-300"
                                             >
                                                 {showResetConfirmPassword ? (
                                                     <EyeOff className="h-5 w-5" />
@@ -577,7 +579,7 @@ export default function LoginPageClient() {
                                     <Button
                                         type="submit"
                                         disabled={resetting}
-                                        className="w-full bg-green-600 text-white hover:bg-green-700"
+                                        className="w-full bg-green-600 text-white hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                                     >
                                         {resetting ? (
                                             <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Menu, X, Loader2, ShieldCheck, Clock, MapPin } from "lucide-react";
 
 // Lazy load lucide icons
@@ -64,9 +65,9 @@ export default function HomePage() {
   };
 
   return (
-    <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50">
+    <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
       {/* Header */}
-      <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100">
+      <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100 dark:bg-slate-950/80 dark:border-slate-800">
         <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-8 py-3">
           {/* Logo + Title */}
           <div className="flex items-center gap-1">
@@ -82,47 +83,53 @@ export default function HomePage() {
                 priority
                 className="md:w-14 md:h-14"
               />
-              <h1 className="text-lg md:text-2xl font-bold text-green-600 leading-none">
+              <h1 className="text-lg md:text-2xl font-bold text-green-600 leading-none dark:text-emerald-300">
                 HNU Clinic
               </h1>
             </Link>
           </div>
 
           {/* Desktop Nav */}
-          <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+          <nav className="hidden md:flex items-center gap-4 text-sm font-medium">
             {navigation.map((item) => (
               <Link
                 key={item.label}
                 href={item.href}
-                className="text-gray-700 hover:text-green-600 transition"
+                className="text-gray-700 hover:text-green-600 transition dark:text-slate-200 dark:hover:text-emerald-300"
               >
                 {item.label}
               </Link>
             ))}
+            <ThemeToggle className="hidden lg:inline-flex" />
             <Link href="/login">
-              <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
+              <Button className="bg-green-600 hover:bg-green-700 shadow-sm dark:bg-emerald-500 dark:hover:bg-emerald-400">
+                Login
+              </Button>
             </Link>
           </nav>
 
           {/* Mobile Nav Toggle */}
-          <button
-            className="md:hidden p-2"
+          <div className="flex items-center gap-2 md:hidden">
+            <ThemeToggle size="sm" />
+            <button
+              className="p-2 text-green-600 dark:text-emerald-300"
             onClick={() => setMenuOpen(!menuOpen)}
           >
-            {menuOpen ? <X className="w-6 h-6 text-green-600" /> : <Menu className="w-6 h-6 text-green-600" />}
+            {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
           </button>
+          </div>
         </div>
 
         {/* Mobile Dropdown */}
         {menuOpen && (
-          <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95">
+          <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95 dark:bg-slate-950/95">
             {navigation.map((item) => (
-              <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600">
+              <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 dark:text-slate-200 dark:hover:text-emerald-300">
                 {item.label}
               </Link>
             ))}
             <Link href="/login">
-              <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
+              <Button className="w-full bg-green-600 hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
             </Link>
           </div>
         )}
@@ -130,22 +137,22 @@ export default function HomePage() {
 
       {/* Hero Section */}
       <section className="relative overflow-hidden">
-        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-green-100 via-white to-green-50" />
-        <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.12),_transparent_60%)]" />
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-green-100 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900" />
+        <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.12),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.2),_transparent_60%)]" />
         <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto px-6 md:px-12 py-16 md:py-24 gap-12">
           <div className="max-w-xl text-center md:text-left space-y-6">
-            <span className="inline-flex items-center rounded-full bg-white shadow-sm border border-green-100 px-4 py-1 text-sm font-medium text-green-700">
+            <span className="inline-flex items-center rounded-full bg-white shadow-sm border border-green-100 px-4 py-1 text-sm font-medium text-green-700 dark:bg-slate-950/80 dark:border-slate-800 dark:text-emerald-200">
               Comprehensive Care, Digitally Delivered
             </span>
-            <h2 className="text-3xl md:text-5xl font-bold text-green-600 leading-tight">
+            <h2 className="text-3xl md:text-5xl font-bold text-green-600 leading-tight dark:text-emerald-200">
               Manage health records, book visits, and stay connected to your care team.
             </h2>
-            <p className="text-gray-700 text-base md:text-lg leading-relaxed">
+            <p className="text-gray-700 text-base md:text-lg leading-relaxed dark:text-slate-200">
               The HNU Clinic platform streamlines appointments, consolidates health histories, and keeps patients informed every step of the way—securely and intuitively.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start w-full sm:w-auto">
               <Link href="/login" className="w-full sm:w-auto">
-                <Button size="lg" className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white shadow-md">
+                <Button size="lg" className="w-full sm:w-auto bg-green-600 hover:bg-green-700 text-white shadow-md dark:bg-emerald-500 dark:hover:bg-emerald-400">
                   Book an Appointment
                 </Button>
               </Link>
@@ -153,7 +160,7 @@ export default function HomePage() {
                 <Button
                   size="lg"
                   variant="outline"
-                  className="w-full sm:w-auto border-green-600 text-green-700 hover:bg-green-50"
+                  className="w-full sm:w-auto border-green-600 text-green-700 hover:bg-green-50 dark:border-emerald-400 dark:text-emerald-200 dark:hover:bg-slate-900/60"
                 >
                   Explore the Platform
                 </Button>
@@ -161,9 +168,9 @@ export default function HomePage() {
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-left sm:text-center">
               {[{ label: "24/7 Portal Access", value: "Always on" }, { label: "Integrated Health Records", value: "Unified" }, { label: "Secure Patient Data", value: "Encrypted" }].map((item) => (
-                <div key={item.label} className="rounded-xl bg-white/80 border border-green-100 px-4 py-3 shadow-sm">
-                  <p className="text-sm uppercase tracking-wide text-green-500 font-medium">{item.value}</p>
-                  <p className="text-gray-700 text-sm">{item.label}</p>
+                <div key={item.label} className="rounded-xl bg-white/80 border border-green-100 px-4 py-3 shadow-sm dark:bg-slate-900/70 dark:border-slate-800">
+                  <p className="text-sm uppercase tracking-wide text-green-500 font-medium dark:text-emerald-300">{item.value}</p>
+                  <p className="text-gray-700 text-sm dark:text-slate-200">{item.label}</p>
                 </div>
               ))}
             </div>
@@ -182,11 +189,11 @@ export default function HomePage() {
       </section>
 
       {/* Features */}
-      <section id="features" className="bg-white py-16 md:py-20 px-6 md:px-12">
+      <section id="features" className="bg-white py-16 md:py-20 px-6 md:px-12 dark:bg-slate-950">
         <div className="max-w-7xl mx-auto space-y-12">
           <div className="text-center max-w-3xl mx-auto space-y-4">
-            <h3 className="text-2xl md:text-3xl font-bold text-green-600">Built for dependable clinic operations</h3>
-            <p className="text-gray-600">
+            <h3 className="text-2xl md:text-3xl font-bold text-green-600 dark:text-emerald-200">Built for dependable clinic operations</h3>
+            <p className="text-gray-600 dark:text-slate-300">
               HNU Clinic brings essential services together so patients and providers can focus on care—not coordination.
             </p>
           </div>
@@ -223,14 +230,17 @@ export default function HomePage() {
                 icon: MapPin,
               },
             ].map(({ title, description, icon: Icon }) => (
-              <Card key={title} className="rounded-2xl border-green-100 shadow-sm hover:shadow-md transition">
+              <Card
+                key={title}
+                className="rounded-2xl border-green-100 shadow-sm hover:shadow-md transition dark:border-emerald-900/60 dark:bg-slate-900"
+              >
                 <CardHeader className="flex flex-col items-start gap-4">
-                  <span className="inline-flex items-center justify-center rounded-full bg-green-50 p-3 text-green-600 shadow-sm">
+                  <span className="inline-flex items-center justify-center rounded-full bg-green-50 p-3 text-green-600 shadow-sm dark:bg-emerald-900/40 dark:text-emerald-300">
                     <Icon className="w-6 h-6" />
                   </span>
-                  <CardTitle className="text-lg md:text-xl text-green-700">{title}</CardTitle>
+                  <CardTitle className="text-lg md:text-xl text-green-700 dark:text-emerald-200">{title}</CardTitle>
                 </CardHeader>
-                <CardContent className="pt-0 text-gray-600 text-sm md:text-base leading-relaxed">
+                <CardContent className="pt-0 text-gray-600 text-sm md:text-base leading-relaxed dark:text-slate-300">
                   {description}
                 </CardContent>
               </Card>
@@ -243,22 +253,25 @@ export default function HomePage() {
       <section id="workflow" className="py-16 md:py-20 px-6 md:px-12">
         <div className="max-w-6xl mx-auto grid gap-12 md:grid-cols-2 items-center">
           <div className="space-y-6">
-            <h3 className="text-2xl md:text-3xl font-bold text-green-600">A trusted pathway from booking to follow-up</h3>
-            <p className="text-gray-600 leading-relaxed">
+            <h3 className="text-2xl md:text-3xl font-bold text-green-600 dark:text-emerald-200">A trusted pathway from booking to follow-up</h3>
+            <p className="text-gray-600 leading-relaxed dark:text-slate-300">
               Whether it is an annual assessment or urgent visit, the HNU Clinic workflow keeps each step organized so patients receive timely attention and healthcare teams have the insight they need.
             </p>
             <div className="grid gap-4">
               {["Reserve an appointment slot in minutes", "Arrive prepared with digital intake and reminders", "Receive coordinated care and documented outcomes"].map((step, index) => (
-                <div key={step} className="flex items-start gap-4 rounded-xl bg-white/80 border border-green-100 p-4 shadow-sm">
-                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-green-600 text-white font-semibold">
+                <div
+                  key={step}
+                  className="flex items-start gap-4 rounded-xl bg-white/80 border border-green-100 p-4 shadow-sm dark:bg-slate-900/70 dark:border-slate-800"
+                >
+                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-green-600 text-white font-semibold dark:bg-emerald-500">
                     {index + 1}
                   </span>
-                  <p className="text-gray-700 text-sm md:text-base leading-relaxed">{step}</p>
+                  <p className="text-gray-700 text-sm md:text-base leading-relaxed dark:text-slate-200">{step}</p>
                 </div>
               ))}
             </div>
           </div>
-          <Card className="rounded-3xl border-none bg-gradient-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-xl">
+          <Card className="rounded-3xl border-none bg-gradient-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-xl dark:from-slate-950 dark:via-emerald-900/40 dark:to-emerald-700">
             <CardContent className="p-8 space-y-6">
               <h4 className="text-2xl font-semibold">Why patients trust the portal</h4>
               <ul className="space-y-4 text-sm md:text-base">
@@ -284,27 +297,27 @@ export default function HomePage() {
       <section id="contact" className="py-16 md:py-20 px-6 md:px-12">
         <div className="max-w-6xl mx-auto grid gap-12 md:grid-cols-[1.2fr_1fr] items-center">
           <div className="space-y-4 text-center md:text-left">
-            <h3 className="text-2xl md:text-3xl font-bold text-green-600">Let’s coordinate your next clinic visit</h3>
-            <p className="text-gray-600 leading-relaxed">
+            <h3 className="text-2xl md:text-3xl font-bold text-green-600 dark:text-emerald-200">Let’s coordinate your next clinic visit</h3>
+            <p className="text-gray-600 leading-relaxed dark:text-slate-300">
               Share your details and our team will reach out with appointment options or answers to your questions. We’re here to support your wellness on campus.
             </p>
             <div className="grid sm:grid-cols-2 gap-4">
-              <div className="rounded-xl border border-green-100 bg-white/80 p-4 text-left shadow-sm">
-                <p className="text-xs uppercase tracking-wide text-green-700">Clinic Hours</p>
-                <p className="text-sm text-gray-700">Monday – Friday, 7:30 AM – 8:00 PM</p>
-                <p className="text-sm text-gray-700">Saturday, 8:00 AM – 11:00 AM</p>
+              <div className="rounded-xl border border-green-100 bg-white/80 p-4 text-left shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+                <p className="text-xs uppercase tracking-wide text-green-700 dark:text-emerald-300">Clinic Hours</p>
+                <p className="text-sm text-gray-700 dark:text-slate-200">Monday – Friday, 7:30 AM – 8:00 PM</p>
+                <p className="text-sm text-gray-700 dark:text-slate-200">Saturday, 8:00 AM – 11:00 AM</p>
               </div>
-              <div className="rounded-xl border border-green-100 bg-white/80 p-4 text-left shadow-sm">
-                <p className="text-xs uppercase tracking-wide text-green-700">Location</p>
-                <p className="text-sm text-gray-700">Holy Name University campus clinic</p>
+              <div className="rounded-xl border border-green-100 bg-white/80 p-4 text-left shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+                <p className="text-xs uppercase tracking-wide text-green-700 dark:text-emerald-300">Location</p>
+                <p className="text-sm text-gray-700 dark:text-slate-200">Holy Name University campus clinic</p>
               </div>
             </div>
           </div>
-          <Card className="rounded-2xl shadow-lg border-green-100 bg-white/90 backdrop-blur-sm">
+          <Card className="rounded-2xl shadow-lg border-green-100 bg-white/90 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/80">
             <CardContent className="p-6 md:p-8 space-y-4">
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-gray-700" htmlFor="name">
+                  <label className="text-sm font-medium text-gray-700 dark:text-slate-200" htmlFor="name">
                     Full Name
                   </label>
                   <Input
@@ -316,7 +329,7 @@ export default function HomePage() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-gray-700" htmlFor="email">
+                  <label className="text-sm font-medium text-gray-700 dark:text-slate-200" htmlFor="email">
                     Email Address
                   </label>
                   <Input
@@ -329,7 +342,7 @@ export default function HomePage() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-gray-700" htmlFor="message">
+                  <label className="text-sm font-medium text-gray-700 dark:text-slate-200" htmlFor="message">
                     Message
                   </label>
                   <Textarea
@@ -344,7 +357,7 @@ export default function HomePage() {
                 <Button
                   type="submit"
                   disabled={loading}
-                  className="w-full p-4 md:p-5 bg-green-600 hover:bg-green-700 flex items-center justify-center text-base"
+                  className="w-full p-4 md:p-5 bg-green-600 hover:bg-green-700 flex items-center justify-center text-base dark:bg-emerald-500 dark:hover:bg-emerald-400"
                 >
                   {loading ? (
                     <>
@@ -362,20 +375,20 @@ export default function HomePage() {
       </section>
 
       {/* Footer */}
-      <footer className="bg-green-900 text-green-50">
+      <footer className="bg-green-900 text-green-50 dark:bg-slate-950 dark:text-slate-200">
         <div className="max-w-7xl mx-auto px-6 md:px-12 py-12 grid gap-8 md:grid-cols-3">
           <div className="space-y-3">
             <p className="text-lg font-semibold">HNU Clinic</p>
-            <p className="text-sm text-green-100 leading-relaxed">
+            <p className="text-sm text-green-100 leading-relaxed dark:text-slate-400">
               Delivering compassionate, technology-enabled care to the Holy Name University community.
             </p>
           </div>
           <div className="space-y-3">
             <p className="text-lg font-semibold">Quick Links</p>
-            <ul className="space-y-2 text-sm text-green-100">
+            <ul className="space-y-2 text-sm text-green-100 dark:text-slate-400">
               {navigation.map((item) => (
                 <li key={item.label}>
-                  <Link href={item.href} className="hover:text-white transition">
+                  <Link href={item.href} className="hover:text-white transition dark:hover:text-emerald-300">
                     {item.label}
                   </Link>
                 </li>
@@ -384,15 +397,15 @@ export default function HomePage() {
           </div>
           <div className="space-y-3">
             <p className="text-lg font-semibold">Stay in Touch</p>
-            <p className="text-sm text-green-100 leading-relaxed">
+            <p className="text-sm text-green-100 leading-relaxed dark:text-slate-400">
               Visit the campus clinic or send us a message and our staff will guide you to the right service.
             </p>
-            <Link href="#contact" className="inline-flex text-sm text-white font-medium underline-offset-4 hover:underline">
+            <Link href="#contact" className="inline-flex text-sm text-white font-medium underline-offset-4 hover:underline dark:text-emerald-300">
               Contact the clinic team
             </Link>
           </div>
         </div>
-        <div className="border-t border-green-700/60 text-center py-4 text-xs text-green-200">
+        <div className="border-t border-green-700/60 text-center py-4 text-xs text-green-200 dark:border-slate-800 dark:text-slate-500">
           © {new Date().getFullYear()} HNU Clinic Capstone Project
         </div>
       </footer>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useEffect } from "react";
 import { SessionProvider, useSession, signOut } from "next-auth/react";
+import { ThemeProvider } from "next-themes";
 import { Toaster, toast } from "sonner";
 
 /**
@@ -48,10 +49,17 @@ export default function Providers({ children }: { children: ReactNode }) {
     }, []);
 
     return (
-        <SessionProvider>
-            {children}
-            <Toaster richColors position="top-center" />
-            <SessionWatcher /> {/* runs globally */}
-        </SessionProvider>
+        <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+        >
+            <SessionProvider>
+                {children}
+                <Toaster richColors position="top-center" />
+                <SessionWatcher /> {/* runs globally */}
+            </SessionProvider>
+        </ThemeProvider>
     );
 }

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -18,6 +18,7 @@ import {
     SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export type PanelNavItem = {
     href: string;
@@ -94,13 +95,18 @@ export function PanelLayout({
                         href={item.href}
                         className={cn(
                             "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
-                            "hover:bg-green-100/70 hover:text-green-700",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-green-50",
-                            isActive && "bg-white text-green-700 shadow-sm"
+                            "hover:bg-green-100/70 hover:text-green-700 dark:hover:bg-emerald-900/40 dark:hover:text-emerald-300",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-green-50 dark:focus-visible:ring-emerald-400 dark:focus-visible:ring-offset-slate-950",
+                            isActive && "bg-white text-green-700 shadow-sm dark:bg-slate-900/80 dark:text-emerald-300"
                         )}
                         onClick={() => setMobileOpen(false)}
                     >
-                        <Icon className={cn("h-4 w-4", isActive ? "text-green-700" : "text-gray-600")} />
+                        <Icon
+                            className={cn(
+                                "h-4 w-4",
+                                isActive ? "text-green-700 dark:text-emerald-300" : "text-gray-600 dark:text-slate-300"
+                            )}
+                        />
                         {item.label}
                     </Link>
                 );
@@ -109,9 +115,9 @@ export function PanelLayout({
     );
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-100">
+        <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-100 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
             <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 pb-8 pt-6 md:flex-row md:gap-8 md:px-6 lg:px-8">
-                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-green-100/80 bg-white/80 p-6 shadow-sm backdrop-blur lg:flex">
+                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-green-100/80 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-950/70 lg:flex">
                     <div className="flex items-center gap-3 pb-6">
                         <Image
                             src="/clinic-illustration.svg"
@@ -121,24 +127,24 @@ export function PanelLayout({
                             className="h-11 w-11 object-contain drop-shadow"
                         />
                         <div>
-                            <h1 className="text-xl font-bold text-green-700">HNU Clinic</h1>
+                            <h1 className="text-xl font-bold text-green-700 dark:text-emerald-300">HNU Clinic</h1>
                         </div>
                     </div>
-                    <div className="mb-6 flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
-                        <Avatar className="h-12 w-12 border border-green-100">
+                    <div className="mb-6 flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/70">
+                        <Avatar className="h-12 w-12 border border-green-100 dark:border-slate-700">
                             <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                            <AvatarFallback className="bg-green-200 text-green-800">{avatarFallback}</AvatarFallback>
+                            <AvatarFallback className="bg-green-200 text-green-800 dark:bg-emerald-900/50 dark:text-emerald-200">{avatarFallback}</AvatarFallback>
                         </Avatar>
                         <div>
-                            <p className="text-xs text-green-500">Signed in as</p>
-                            <p className="text-sm font-semibold text-green-700">{fullName}</p>
+                            <p className="text-xs text-green-500 dark:text-emerald-300/80">Signed in as</p>
+                            <p className="text-sm font-semibold text-green-700 dark:text-emerald-200">{fullName}</p>
                         </div>
                     </div>
                     {navLinks}
                     <Separator className="my-6" />
                     <Button
                         variant="default"
-                        className="mt-auto w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-green-700"
+                        className="mt-auto w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                         onClick={handleLogout}
                         disabled={isLoggingOut}
                     >
@@ -154,12 +160,12 @@ export function PanelLayout({
                 </aside>
 
                 <div className="flex flex-1 flex-col">
-                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-green-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/60 md:px-6">
+                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-green-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:border-slate-800 dark:bg-slate-950/70 md:px-6">
                         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                             <div className="space-y-3">
                                 <Link
                                     href={homeHref}
-                                    className="flex items-center gap-3 rounded-2xl border border-green-100 bg-white/90 px-3 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:bg-green-100/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                    className="flex items-center gap-3 rounded-2xl border border-green-100 bg-white/90 px-3 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:bg-green-100/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:bg-slate-900/80 dark:text-emerald-200 dark:hover:bg-emerald-900/40 lg:hidden"
                                 >
                                     <Image
                                         src="/clinic-illustration.svg"
@@ -170,47 +176,48 @@ export function PanelLayout({
                                     />
                                     <span>HNU Clinic</span>
                                 </Link>
-                                <p className="text-xs font-semibold uppercase tracking-wider text-green-500">{panelLabel}</p>
-                                <h2 className="text-2xl font-semibold text-green-700 md:text-3xl">{title}</h2>
+                                <p className="text-xs font-semibold uppercase tracking-wider text-green-500 dark:text-emerald-300/80">{panelLabel}</p>
+                                <h2 className="text-2xl font-semibold text-green-700 md:text-3xl dark:text-emerald-200">{title}</h2>
                                 {description ? (
-                                    <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
+                                    <p className="mt-1 max-w-2xl text-sm text-muted-foreground dark:text-slate-300">{description}</p>
                                 ) : null}
                             </div>
                             <div className="flex items-center gap-3 self-start md:self-auto">
+                                <ThemeToggle size="sm" className="hidden md:inline-flex" />
                                 {actions}
                                 <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
                                     <SheetTrigger asChild>
                                         <Button
                                             variant="outline"
                                             size="icon"
-                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700 dark:text-emerald-200 dark:hover:bg-emerald-900/40 dark:focus-visible:ring-emerald-400 dark:focus-visible:ring-offset-slate-950 lg:hidden"
                                             aria-label={sheetAriaLabel}
                                         >
                                             <Menu className="h-5 w-5" />
                                         </Button>
                                     </SheetTrigger>
-                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0">
-                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6">
-                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700">
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0 dark:border-slate-800 dark:from-slate-950 dark:to-slate-900">
+                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6 dark:border-slate-800 dark:bg-slate-950/80">
+                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700 dark:text-emerald-200">
                                                 <Menu className="h-5 w-5" />
                                                 {sheetTitle}
                                             </SheetTitle>
                                         </SheetHeader>
                                         <div className="space-y-6 px-6 py-6">
-                                            <div className="flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
-                                                <Avatar className="h-11 w-11 border border-green-100">
+                                            <div className="flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4 dark:border-slate-800 dark:bg-slate-900/70">
+                                                <Avatar className="h-11 w-11 border border-green-100 dark:border-slate-700">
                                                     <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                                                    <AvatarFallback className="bg-green-200 text-green-800">{avatarFallback}</AvatarFallback>
+                                                    <AvatarFallback className="bg-green-200 text-green-800 dark:bg-emerald-900/50 dark:text-emerald-200">{avatarFallback}</AvatarFallback>
                                                 </Avatar>
                                                 <div>
-                                                    <p className="text-xs text-green-500">Signed in as</p>
-                                                    <p className="text-sm font-semibold text-green-700">{fullName}</p>
+                                                    <p className="text-xs text-green-500 dark:text-emerald-300/80">Signed in as</p>
+                                                    <p className="text-sm font-semibold text-green-700 dark:text-emerald-200">{fullName}</p>
                                                 </div>
                                             </div>
                                             {navLinks}
                                             <Button
                                                 variant="default"
-                                                className="w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm hover:bg-green-700"
+                                                className="w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                                                 onClick={handleLogout}
                                                 disabled={isLoggingOut}
                                             >

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ThemeToggleProps = {
+  className?: string;
+  size?: "sm" | "default";
+};
+
+export function ThemeToggle({ className, size = "default" }: ThemeToggleProps) {
+  const { setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size={size === "sm" ? "icon" : "default"}
+        className={cn(
+          "rounded-full border border-border/60 bg-background/80 text-foreground",
+          size === "sm" && "h-9 w-9",
+          className
+        )}
+        aria-label="Toggle theme"
+      >
+        <span className="sr-only">Toggle theme</span>
+        <Sun className="h-4 w-4" />
+      </Button>
+    );
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      size={size === "sm" ? "icon" : "default"}
+      className={cn(
+        "rounded-full border border-border/60 bg-background/80 text-foreground transition-colors",
+        "hover:bg-muted/60 hover:text-foreground",
+        size === "sm" && "h-9 w-9",
+        className
+      )}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      <span className="sr-only">Toggle theme</span>
+      <Sun className={cn("h-4 w-4", isDark && "hidden")}
+      />
+      <Moon className={cn("h-4 w-4", !isDark && "hidden")}
+      />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the app with next-themes to enable class-based dark mode switching
- add a reusable theme toggle and apply dark-friendly gradients and colors across the marketing pages and dashboard layout
- expand global CSS helpers so existing green and neutral utility classes render appropriately in dark mode and refresh the login experience accordingly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f6d7cc3dc48333894106236a2926bf