### PR TITLE
Add dark mode support with theme toggles

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Menu,
     X,
@@ -53,7 +54,7 @@ export default function AboutPage() {
     return (
         <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50">
             {/* Header */}
-            <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100">
+            <header className="w-full sticky top-0 z-50 border-b border-green-100 bg-white/80 backdrop-blur-md">
                 <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-8 py-3">
                     {/* Logo + Title */}
                     <div className="flex items-center gap-1">
@@ -76,28 +77,33 @@ export default function AboutPage() {
                     </div>
 
                     {/* Desktop Nav */}
-                    <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+                    <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
                         {navigation.map((item) => (
                             <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
                                 {item.label}
                             </Link>
                         ))}
+                        <ThemeToggle />
                         <Link href="/login">
                             <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
                         </Link>
                     </nav>
 
                     {/* Mobile Menu Button */}
-                    <button
-                        className="md:hidden p-2"
-                        onClick={() => setMenuOpen(!menuOpen)}
-                    >
-                        {menuOpen ? (
-                            <X className="w-6 h-6 text-green-600" />
-                        ) : (
-                            <Menu className="w-6 h-6 text-green-600" />
-                        )}
-                    </button>
+                    <div className="flex items-center gap-2 md:hidden">
+                        <ThemeToggle />
+                        <button
+                            className="rounded-full p-2 transition hover:bg-green-100/60"
+                            onClick={() => setMenuOpen(!menuOpen)}
+                            aria-label="Toggle navigation menu"
+                        >
+                            {menuOpen ? (
+                                <X className="w-6 h-6 text-green-600" />
+                            ) : (
+                                <Menu className="w-6 h-6 text-green-600" />
+                            )}
+                        </button>
+                    </div>
                 </div>
 
                 {/* Mobile Dropdown Nav */}
@@ -108,6 +114,7 @@ export default function AboutPage() {
                                 {item.label}
                             </Link>
                         ))}
+                        <ThemeToggle className="self-start" />
                         <Link href="/login">
                             <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
                         </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,6 +112,16 @@
   --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
   --sidebar-border: hsl(240 3.7% 15.9%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
+  --surface-solid: oklch(0.26 0.03 256.36);
+  --surface-95: oklch(0.26 0.03 256.36 / 0.95);
+  --surface-90: oklch(0.26 0.03 256.36 / 0.9);
+  --surface-85: oklch(0.26 0.03 256.36 / 0.85);
+  --surface-80: oklch(0.26 0.03 256.36 / 0.8);
+  --surface-70: oklch(0.26 0.03 256.36 / 0.7);
+  --surface-60: oklch(0.26 0.03 256.36 / 0.6);
+  --surface-20: oklch(0.26 0.03 256.36 / 0.2);
+  --surface-15: oklch(0.26 0.03 256.36 / 0.15);
+  --surface-10: oklch(0.26 0.03 256.36 / 0.1);
 }
 
 @layer base {
@@ -135,6 +145,120 @@
 
   .font-display {
     font-family: var(--font-display), system-ui, sans-serif;
+  }
+
+  .dark .bg-white {
+    background-color: var(--surface-solid) !important;
+  }
+
+  .dark .bg-white\/95 {
+    background-color: var(--surface-95) !important;
+  }
+
+  .dark .bg-white\/90 {
+    background-color: var(--surface-90) !important;
+  }
+
+  .dark .bg-white\/85 {
+    background-color: var(--surface-85) !important;
+  }
+
+  .dark .bg-white\/80 {
+    background-color: var(--surface-80) !important;
+  }
+
+  .dark .bg-white\/70 {
+    background-color: var(--surface-70) !important;
+  }
+
+  .dark .bg-white\/60 {
+    background-color: var(--surface-60) !important;
+  }
+
+  .dark .bg-white\/20 {
+    background-color: var(--surface-20) !important;
+  }
+
+  .dark .bg-white\/15 {
+    background-color: var(--surface-15) !important;
+  }
+
+  .dark .bg-white\/10 {
+    background-color: var(--surface-10) !important;
+  }
+
+  .dark .border-green-100,
+  .dark .border-green-100\/80,
+  .dark .border-green-100\/70,
+  .dark .border-green-100\/60,
+  .dark .border-green-200,
+  .dark .border-green-200\/70,
+  .dark .border-green-300,
+  .dark .border-green-300\/70 {
+    border-color: color-mix(in oklch, var(--primary) 35%, transparent) !important;
+  }
+
+  .dark .hover\:bg-green-100\/70:hover,
+  .dark .hover\:bg-green-100\/80:hover,
+  .dark .hover\:bg-green-100:hover {
+    background-color: color-mix(in oklch, var(--primary) 20%, transparent) !important;
+  }
+
+  .dark .bg-green-50,
+  .dark .bg-green-50\/60,
+  .dark .bg-green-50\/70 {
+    background-color: color-mix(in oklch, var(--primary) 20%, transparent) !important;
+  }
+
+  .dark .bg-green-100,
+  .dark .bg-green-100\/60,
+  .dark .bg-green-100\/70,
+  .dark .bg-green-100\/80 {
+    background-color: color-mix(in oklch, var(--primary) 30%, transparent) !important;
+  }
+
+  .dark .from-green-50 {
+    --tw-gradient-from: color-mix(in oklch, var(--primary) 25%, transparent) var(--tw-gradient-from-position) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, transparent);
+  }
+
+  .dark .from-green-100 {
+    --tw-gradient-from: color-mix(in oklch, var(--primary) 30%, transparent) var(--tw-gradient-from-position) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, transparent);
+  }
+
+  .dark .via-white {
+    --tw-gradient-stops: var(--tw-gradient-from), color-mix(in oklch, var(--surface-solid) 65%, transparent),
+      var(--tw-gradient-to, transparent) !important;
+  }
+
+  .dark .to-green-50 {
+    --tw-gradient-to: color-mix(in oklch, var(--primary) 15%, transparent) var(--tw-gradient-to-position) !important;
+  }
+
+  .dark .to-green-100 {
+    --tw-gradient-to: color-mix(in oklch, var(--primary) 25%, transparent) var(--tw-gradient-to-position) !important;
+  }
+
+  .dark :is(
+      .text-gray-700,
+      .text-gray-600,
+      .text-gray-500,
+      .text-gray-400,
+      .text-slate-700,
+      .text-slate-600,
+      .text-slate-500,
+      .text-slate-400
+    ) {
+    color: color-mix(in oklch, var(--foreground) 85%, white 15%) !important;
+  }
+
+  .dark :is(.text-green-500, .text-green-600, .text-green-700, .text-green-800, .text-green-900) {
+    color: color-mix(in oklch, var(--primary) 85%, white 15%) !important;
+  }
+
+  .dark .text-muted-foreground {
+    color: color-mix(in oklch, var(--muted-foreground) 80%, white 20%) !important;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html
       lang="en"
       data-scroll-behavior="smooth"
+      suppressHydrationWarning
       className={`${poppins.variable} ${inter.variable}`}
     >
       <body className="antialiased min-h-screen flex flex-col font-sans">

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Users,
     Code2,
@@ -63,7 +64,7 @@ export default function LearnMorePage() {
     return (
         <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50">
             {/* Header */}
-            <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100">
+            <header className="w-full sticky top-0 z-50 border-b border-green-100 bg-white/80 backdrop-blur-md">
                 <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-8 py-3">
                     {/* Logo + Title */}
                     <div className="flex items-center gap-1">
@@ -86,29 +87,33 @@ export default function LearnMorePage() {
                     </div>
 
                     {/* Desktop Nav */}
-                    <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+                    <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
                         {navigation.map((item) => (
                             <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
                                 {item.label}
                             </Link>
                         ))}
+                        <ThemeToggle />
                         <Link href="/login">
                             <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
                         </Link>
                     </nav>
 
                     {/* Mobile Nav Toggle */}
-                    <button
-                        className="md:hidden p-2"
-                        onClick={() => setMenuOpen(!menuOpen)}
-                        aria-label={menuOpen ? "Close menu" : "Open menu"}
-                    >
-                        {menuOpen ? (
-                            <X className="w-6 h-6 text-green-600" />
-                        ) : (
-                            <Menu className="w-6 h-6 text-green-600" />
-                        )}
-                    </button>
+                    <div className="flex items-center gap-2 md:hidden">
+                        <ThemeToggle />
+                        <button
+                            className="rounded-full p-2 transition hover:bg-green-100/60"
+                            onClick={() => setMenuOpen(!menuOpen)}
+                            aria-label={menuOpen ? "Close menu" : "Open menu"}
+                        >
+                            {menuOpen ? (
+                                <X className="w-6 h-6 text-green-600" />
+                            ) : (
+                                <Menu className="w-6 h-6 text-green-600" />
+                            )}
+                        </button>
+                    </div>
                 </div>
 
                 {/* Mobile Dropdown */}
@@ -119,6 +124,7 @@ export default function LearnMorePage() {
                                 {item.label}
                             </Link>
                         ))}
+                        <ThemeToggle className="self-start" />
                         <Link href="/login">
                             <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
                         </Link>

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { toast } from "sonner";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
+
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -293,7 +295,10 @@ export default function LoginPageClient() {
 
     // ---------- RENDER ----------
     return (
-        <div className="relative min-h-screen bg-gradient-to-br from-green-100 via-white to-green-200">
+        <div className="relative min-h-screen bg-gradient-to-br from-green-100 via-white to-green-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900">
+            <div className="absolute inset-x-0 top-0 z-10 flex justify-end px-6 py-6">
+                <ThemeToggle />
+            </div>
             <div className="absolute inset-0 overflow-hidden">
                 <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-green-300/40 blur-3xl" />
                 <div className="absolute -bottom-28 -left-16 h-72 w-72 rounded-full bg-green-300/40 blur-3xl" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Menu, X, Loader2, ShieldCheck, Clock, MapPin } from "lucide-react";
 
 // Lazy load lucide icons
@@ -66,7 +67,7 @@ export default function HomePage() {
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-b from-green-50 via-white to-green-50">
       {/* Header */}
-      <header className="w-full sticky top-0 z-50 backdrop-blur-md bg-white/80 border-b border-green-100">
+      <header className="w-full sticky top-0 z-50 border-b border-green-100 bg-white/80 backdrop-blur-md">
         <div className="max-w-7xl mx-auto flex justify-between items-center px-4 md:px-8 py-3">
           {/* Logo + Title */}
           <div className="flex items-center gap-1">
@@ -89,7 +90,7 @@ export default function HomePage() {
           </div>
 
           {/* Desktop Nav */}
-          <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+          <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
             {navigation.map((item) => (
               <Link
                 key={item.label}
@@ -99,18 +100,23 @@ export default function HomePage() {
                 {item.label}
               </Link>
             ))}
+            <ThemeToggle />
             <Link href="/login">
               <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
             </Link>
           </nav>
 
           {/* Mobile Nav Toggle */}
-          <button
-            className="md:hidden p-2"
-            onClick={() => setMenuOpen(!menuOpen)}
-          >
-            {menuOpen ? <X className="w-6 h-6 text-green-600" /> : <Menu className="w-6 h-6 text-green-600" />}
-          </button>
+          <div className="flex items-center gap-2 md:hidden">
+            <ThemeToggle />
+            <button
+              className="rounded-full p-2 transition hover:bg-green-100/60"
+              onClick={() => setMenuOpen(!menuOpen)}
+              aria-label="Toggle navigation menu"
+            >
+              {menuOpen ? <X className="w-6 h-6 text-green-600" /> : <Menu className="w-6 h-6 text-green-600" />}
+            </button>
+          </div>
         </div>
 
         {/* Mobile Dropdown */}
@@ -121,6 +127,7 @@ export default function HomePage() {
                 {item.label}
               </Link>
             ))}
+            <ThemeToggle className="self-start" />
             <Link href="/login">
               <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
             </Link>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,7 +2,10 @@
 
 import { ReactNode, useEffect } from "react";
 import { SessionProvider, useSession, signOut } from "next-auth/react";
-import { Toaster, toast } from "sonner";
+import { toast } from "sonner";
+
+import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
 
 /**
  * Monitors the session and signs out users whose accounts become inactive.
@@ -49,9 +52,11 @@ export default function Providers({ children }: { children: ReactNode }) {
 
     return (
         <SessionProvider>
-            {children}
-            <Toaster richColors position="top-center" />
-            <SessionWatcher /> {/* runs globally */}
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+                {children}
+                <Toaster richColors position="top-center" />
+                <SessionWatcher /> {/* runs globally */}
+            </ThemeProvider>
         </SessionProvider>
     );
 }

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -18,6 +18,7 @@ import {
     SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export type PanelNavItem = {
     href: string;
@@ -94,13 +95,19 @@ export function PanelLayout({
                         href={item.href}
                         className={cn(
                             "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
-                            "hover:bg-green-100/70 hover:text-green-700",
+                            "hover:bg-green-100/70 hover:text-green-700 dark:hover:bg-emerald-400/10 dark:hover:text-emerald-100",
                             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-green-50",
-                            isActive && "bg-white text-green-700 shadow-sm"
+                            "dark:focus-visible:ring-emerald-400 dark:focus-visible:ring-offset-slate-950",
+                            isActive && "bg-white text-green-700 shadow-sm dark:bg-emerald-400/10 dark:text-emerald-100"
                         )}
                         onClick={() => setMobileOpen(false)}
                     >
-                        <Icon className={cn("h-4 w-4", isActive ? "text-green-700" : "text-gray-600")} />
+                        <Icon
+                            className={cn(
+                                "h-4 w-4",
+                                isActive ? "text-green-700 dark:text-emerald-100" : "text-gray-600 dark:text-gray-300"
+                            )}
+                        />
                         {item.label}
                     </Link>
                 );
@@ -109,9 +116,9 @@ export function PanelLayout({
     );
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-100">
+        <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-100 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
             <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 pb-8 pt-6 md:flex-row md:gap-8 md:px-6 lg:px-8">
-                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-green-100/80 bg-white/80 p-6 shadow-sm backdrop-blur lg:flex">
+                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-green-100/80 bg-white/80 p-6 shadow-sm backdrop-blur transition-colors lg:flex dark:border-white/10 dark:bg-slate-900/70">
                     <div className="flex items-center gap-3 pb-6">
                         <Image
                             src="/clinic-illustration.svg"
@@ -123,6 +130,7 @@ export function PanelLayout({
                         <div>
                             <h1 className="text-xl font-bold text-green-700">HNU Clinic</h1>
                         </div>
+                        <ThemeToggle className="ml-auto hidden shrink-0 lg:inline-flex" />
                     </div>
                     <div className="mb-6 flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
                         <Avatar className="h-12 w-12 border border-green-100">
@@ -138,7 +146,7 @@ export function PanelLayout({
                     <Separator className="my-6" />
                     <Button
                         variant="default"
-                        className="mt-auto w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-green-700"
+                        className="mt-auto w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm transition-transform hover:scale-[1.01] hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                         onClick={handleLogout}
                         disabled={isLoggingOut}
                     >
@@ -154,7 +162,7 @@ export function PanelLayout({
                 </aside>
 
                 <div className="flex flex-1 flex-col">
-                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-green-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/60 md:px-6">
+                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-green-100/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur transition-colors supports-[backdrop-filter]:bg-white/60 md:px-6 dark:border-white/10 dark:bg-slate-900/70">
                         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                             <div className="space-y-3">
                                 <Link
@@ -177,21 +185,22 @@ export function PanelLayout({
                                 ) : null}
                             </div>
                             <div className="flex items-center gap-3 self-start md:self-auto">
+                                <ThemeToggle className="lg:hidden" />
                                 {actions}
                                 <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
                                     <SheetTrigger asChild>
                                         <Button
                                             variant="outline"
                                             size="icon"
-                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden dark:border-emerald-400/40 dark:text-emerald-100 dark:hover:bg-emerald-400/10"
                                             aria-label={sheetAriaLabel}
                                         >
                                             <Menu className="h-5 w-5" />
                                         </Button>
                                     </SheetTrigger>
-                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0">
-                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6">
-                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700">
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0 dark:border-white/10 dark:bg-slate-950">
+                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6 dark:border-white/10 dark:bg-slate-900/60">
+                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700 dark:text-emerald-100">
                                                 <Menu className="h-5 w-5" />
                                                 {sheetTitle}
                                             </SheetTitle>
@@ -207,10 +216,11 @@ export function PanelLayout({
                                                     <p className="text-sm font-semibold text-green-700">{fullName}</p>
                                                 </div>
                                             </div>
+                                            <ThemeToggle />
                                             {navLinks}
                                             <Button
                                                 variant="default"
-                                                className="w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm hover:bg-green-700"
+                                                className="w-full gap-2 rounded-xl bg-green-600 font-semibold text-white shadow-sm hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400"
                                                 onClick={handleLogout}
                                                 disabled={isLoggingOut}
                                             >
@@ -232,7 +242,7 @@ export function PanelLayout({
 
                     <main className="flex-1 space-y-6">{children}</main>
 
-                    <footer className="mt-10 rounded-3xl border border-green-100/70 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
+                    <footer className="mt-10 rounded-3xl border border-green-100/70 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/70">
                         {footerNote ?? <>
                             © {new Date().getFullYear()} HNU Clinic – {panelLabel}
                         </>}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ReactNode } from "react";
+
+export type ThemeProviderProps = {
+  children: ReactNode;
+  attribute?: string;
+  defaultTheme?: string;
+  enableSystem?: boolean;
+  disableTransitionOnChange?: boolean;
+};
+
+export function ThemeProvider({
+  children,
+  attribute = "class",
+  defaultTheme = "system",
+  enableSystem = true,
+  disableTransitionOnChange = true,
+}: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute={attribute}
+      defaultTheme={defaultTheme}
+      enableSystem={enableSystem}
+      disableTransitionOnChange={disableTransitionOnChange}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type ThemeToggleProps = {
+  className?: string;
+};
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const [mounted, setMounted] = useState(false);
+  const { setTheme, resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className={cn(
+        "rounded-full border border-transparent text-green-600 transition hover:border-green-200 hover:bg-green-50",
+        "dark:text-emerald-200 dark:hover:border-emerald-400/50 dark:hover:bg-emerald-400/10",
+        className
+      )}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      disabled={!mounted}
+    >
+      <Sun className={cn("h-4 w-4", mounted && isDark ? "hidden" : "")} />
+      <Moon className={cn("h-4 w-4", mounted && !isDark ? "hidden" : "")} />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the app in a next-themes provider and expose a reusable theme toggle control
- add dark-friendly overrides for legacy surfaces and gradients while wiring toggles into marketing and auth headers
- refresh the shared panel layout to honor dark mode styling and provide quick access to the theme switcher

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f6d7cc3dc48333894106236a2926bf