### PR TITLE
Add dark mode support with theme toggle

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Menu,
     X,
@@ -76,15 +77,18 @@ export default function AboutPage() {
                     </div>
 
                     {/* Desktop Nav */}
-                    <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+                    <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
                         {navigation.map((item) => (
-                            <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
+                            <Link key={item.label} href={item.href} className="text-gray-700 transition hover:text-green-600">
                                 {item.label}
                             </Link>
                         ))}
-                        <Link href="/login">
-                            <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
-                        </Link>
+                        <div className="flex items-center gap-2">
+                            <ThemeToggle className="border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
+                            <Link href="/login">
+                                <Button className="bg-green-600 text-white shadow-sm hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
+                            </Link>
+                        </div>
                     </nav>
 
                     {/* Mobile Menu Button */}
@@ -102,15 +106,16 @@ export default function AboutPage() {
 
                 {/* Mobile Dropdown Nav */}
                 {menuOpen && (
-                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95">
+                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95 dark:bg-slate-900/95">
                         {navigation.map((item) => (
                             <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
                                 {item.label}
                             </Link>
                         ))}
                         <Link href="/login">
-                            <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
+                            <Button className="w-full bg-green-600 hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
                         </Link>
+                        <ThemeToggle className="ml-auto border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
                     </div>
                 )}
             </header>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,6 +136,81 @@
   .font-display {
     font-family: var(--font-display), system-ui, sans-serif;
   }
+
+  :root {
+    --surface-elevated: oklch(0.98 0.01 155.658);
+    --surface-muted: oklch(0.96 0.02 155.658);
+    --surface-highlight: oklch(0.92 0.04 149.605 / 0.2);
+    --accent-emerald: oklch(0.63 0.19 156.752);
+    --accent-emerald-soft: oklch(0.53 0.12 156.752 / 0.7);
+  }
+
+  .dark {
+    --surface-elevated: oklch(0.28 0.02 248.693);
+    --surface-muted: oklch(0.23 0.02 248.693);
+    --surface-highlight: oklch(0.4 0.03 228.242 / 0.25);
+    --accent-emerald: oklch(0.73 0.18 156.752);
+    --accent-emerald-soft: oklch(0.6 0.14 156.752 / 0.55);
+  }
+
+  .dark .bg-white,
+  .dark .bg-white\/90,
+  .dark .bg-white\/80,
+  .dark .bg-white\/70,
+  .dark .bg-white\/60 {
+    background-color: var(--surface-elevated) !important;
+  }
+
+  .dark .bg-green-50,
+  .dark .bg-green-50\/70,
+  .dark .bg-green-100,
+  .dark .bg-gradient-to-b.from-green-50,
+  .dark .bg-gradient-to-b.from-green-100,
+  .dark .bg-gradient-to-br.from-green-50,
+  .dark .bg-gradient-to-br.from-green-100,
+  .dark .bg-gradient-to-br.from-green-200,
+  .dark .bg-green-600\/10,
+  .dark .bg-green-600\/20 {
+    background-color: var(--surface-muted) !important;
+  }
+
+  .dark .bg-gradient-to-b.from-green-50,
+  .dark .bg-gradient-to-b.from-green-100,
+  .dark .bg-gradient-to-br.from-green-50,
+  .dark .bg-gradient-to-br.from-green-100,
+  .dark .bg-gradient-to-br.from-green-200 {
+    background-image: linear-gradient(
+      to bottom right,
+      color-mix(in oklch, var(--surface-muted) 88%, transparent),
+      color-mix(in oklch, var(--background) 94%, transparent)
+    ) !important;
+  }
+
+  .dark .text-gray-700,
+  .dark .text-gray-600,
+  .dark .text-gray-500 {
+    color: color-mix(in oklch, var(--foreground) 80%, transparent) !important;
+  }
+
+  .dark .text-green-700,
+  .dark .text-green-600,
+  .dark .text-green-500 {
+    color: var(--accent-emerald) !important;
+  }
+
+  .dark .border-green-100,
+  .dark .border-green-100\/80,
+  .dark .border-green-100\/70,
+  .dark .border-green-200,
+  .dark .border-green-200\/80 {
+    border-color: color-mix(in oklch, var(--surface-elevated) 60%, transparent) !important;
+  }
+
+  .dark .hover\:bg-green-100\/70:hover,
+  .dark .hover\:bg-green-600\/10:hover,
+  .dark .hover\:bg-green-600\/20:hover {
+    background-color: var(--accent-emerald-soft) !important;
+  }
 }
 
 html {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html
       lang="en"
       data-scroll-behavior="smooth"
+      suppressHydrationWarning
       className={`${poppins.variable} ${inter.variable}`}
     >
       <body className="antialiased min-h-screen flex flex-col font-sans">

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Users,
     Code2,
@@ -86,15 +87,18 @@ export default function LearnMorePage() {
                     </div>
 
                     {/* Desktop Nav */}
-                    <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+                    <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
                         {navigation.map((item) => (
-                            <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600 transition">
+                            <Link key={item.label} href={item.href} className="text-gray-700 transition hover:text-green-600">
                                 {item.label}
                             </Link>
                         ))}
-                        <Link href="/login">
-                            <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
-                        </Link>
+                        <div className="flex items-center gap-2">
+                            <ThemeToggle className="border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
+                            <Link href="/login">
+                                <Button className="bg-green-600 text-white shadow-sm hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
+                            </Link>
+                        </div>
                     </nav>
 
                     {/* Mobile Nav Toggle */}
@@ -113,15 +117,16 @@ export default function LearnMorePage() {
 
                 {/* Mobile Dropdown */}
                 {menuOpen && (
-                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95">
+                    <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95 dark:bg-slate-900/95">
                         {navigation.map((item) => (
                             <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600">
                                 {item.label}
                             </Link>
                         ))}
                         <Link href="/login">
-                            <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
+                            <Button className="w-full bg-green-600 hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
                         </Link>
+                        <ThemeToggle className="ml-auto border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
                     </div>
                 )}
             </header>

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Dialog,
     DialogContent,
@@ -294,6 +295,7 @@ export default function LoginPageClient() {
     // ---------- RENDER ----------
     return (
         <div className="relative min-h-screen bg-gradient-to-br from-green-100 via-white to-green-200">
+            <ThemeToggle className="absolute right-6 top-6 border-none bg-white/70 shadow-sm hover:bg-green-100/70 dark:bg-slate-900/70 dark:hover:bg-emerald-500/20" />
             <div className="absolute inset-0 overflow-hidden">
                 <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-green-300/40 blur-3xl" />
                 <div className="absolute -bottom-28 -left-16 h-72 w-72 rounded-full bg-green-300/40 blur-3xl" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Menu, X, Loader2, ShieldCheck, Clock, MapPin } from "lucide-react";
 
 // Lazy load lucide icons
@@ -89,19 +90,22 @@ export default function HomePage() {
           </div>
 
           {/* Desktop Nav */}
-          <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
+          <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
             {navigation.map((item) => (
               <Link
                 key={item.label}
                 href={item.href}
-                className="text-gray-700 hover:text-green-600 transition"
+                className="text-gray-700 transition hover:text-green-600"
               >
                 {item.label}
               </Link>
             ))}
-            <Link href="/login">
-              <Button className="bg-green-600 hover:bg-green-700 shadow-sm">Login</Button>
-            </Link>
+            <div className="flex items-center gap-2">
+              <ThemeToggle className="border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
+              <Link href="/login">
+                <Button className="bg-green-600 text-white shadow-sm hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
+              </Link>
+            </div>
           </nav>
 
           {/* Mobile Nav Toggle */}
@@ -115,15 +119,16 @@ export default function HomePage() {
 
         {/* Mobile Dropdown */}
         {menuOpen && (
-          <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95">
+          <div className="flex flex-col gap-3 px-4 pb-5 md:hidden bg-white/95 dark:bg-slate-900/95">
             {navigation.map((item) => (
               <Link key={item.label} href={item.href} className="text-gray-700 hover:text-green-600">
                 {item.label}
               </Link>
             ))}
             <Link href="/login">
-              <Button className="w-full bg-green-600 hover:bg-green-700">Login</Button>
+              <Button className="w-full bg-green-600 hover:bg-green-700 dark:bg-emerald-500 dark:hover:bg-emerald-400">Login</Button>
             </Link>
+            <ThemeToggle className="ml-auto border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
           </div>
         )}
       </header>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useEffect } from "react";
 import { SessionProvider, useSession, signOut } from "next-auth/react";
+import { ThemeProvider } from "next-themes";
 import { Toaster, toast } from "sonner";
 
 /**
@@ -48,10 +49,17 @@ export default function Providers({ children }: { children: ReactNode }) {
     }, []);
 
     return (
-        <SessionProvider>
-            {children}
-            <Toaster richColors position="top-center" />
-            <SessionWatcher /> {/* runs globally */}
-        </SessionProvider>
+        <ThemeProvider
+            attribute="class"
+            defaultTheme="light"
+            enableSystem
+            disableTransitionOnChange
+        >
+            <SessionProvider>
+                {children}
+                <Toaster richColors position="top-center" />
+                <SessionWatcher /> {/* runs globally */}
+            </SessionProvider>
+        </ThemeProvider>
     );
 }

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -10,6 +10,7 @@ import { LogOut, Menu, type LucideIcon } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { ThemeToggle } from "@/components/theme-toggle";
 import {
     Sheet,
     SheetContent,
@@ -177,26 +178,28 @@ export function PanelLayout({
                                 ) : null}
                             </div>
                             <div className="flex items-center gap-3 self-start md:self-auto">
+                                <ThemeToggle className="hidden border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20 md:inline-flex" />
                                 {actions}
                                 <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
                                     <SheetTrigger asChild>
                                         <Button
                                             variant="outline"
                                             size="icon"
-                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/80 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-800 dark:text-emerald-200 dark:hover:bg-emerald-500/20 lg:hidden"
                                             aria-label={sheetAriaLabel}
                                         >
                                             <Menu className="h-5 w-5" />
                                         </Button>
                                     </SheetTrigger>
-                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0">
-                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6">
-                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700">
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-green-100 bg-gradient-to-b from-white to-green-50/60 p-0 dark:border-slate-800 dark:from-slate-950 dark:to-slate-900">
+                                        <SheetHeader className="border-b border-green-100 bg-white/80 p-6 dark:border-slate-800 dark:bg-slate-950/80">
+                                            <SheetTitle className="flex items-center gap-3 text-lg text-green-700 dark:text-emerald-200">
                                                 <Menu className="h-5 w-5" />
                                                 {sheetTitle}
                                             </SheetTitle>
                                         </SheetHeader>
                                         <div className="space-y-6 px-6 py-6">
+                                            <ThemeToggle className="ml-auto border-none bg-transparent shadow-none hover:bg-green-100/70 dark:hover:bg-emerald-500/20" />
                                             <div className="flex items-center gap-3 rounded-2xl border border-green-100 bg-green-50/70 p-4">
                                                 <Avatar className="h-11 w-11 border border-green-100">
                                                     <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = resolvedTheme === "dark";
+
+  function handleToggle() {
+    setTheme(isDark ? "light" : "dark");
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={handleToggle}
+      className={cn(
+        "relative h-9 w-9 overflow-hidden rounded-full border border-border/60 bg-background/80 transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        className,
+      )}
+      aria-label={isDark ? "Activate light mode" : "Activate dark mode"}
+      disabled={!mounted}
+    >
+      <Sun
+        className={cn(
+          "absolute h-4 w-4 transition-all",
+          mounted ? (isDark ? "-translate-y-6 opacity-0" : "translate-y-0 opacity-100") : "opacity-0",
+        )}
+        aria-hidden
+      />
+      <Moon
+        className={cn(
+          "absolute h-4 w-4 transition-all",
+          mounted ? (isDark ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0") : "opacity-0",
+        )}
+        aria-hidden
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the app in a ThemeProvider and add a reusable theme toggle control
- adjust public marketing pages, the login flow, and panel layout headers to surface the toggle
- introduce dark-mode aware surface tokens and overrides so existing light designs adapt when the dark theme is active

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f6d7cc3dc48333894106236a2926bf