### PR TITLE
Add loading skeletons for panel pages

### DIFF
--- a/src/app/doctor/account/loading.tsx
+++ b/src/app/doctor/account/loading.tsx
@@ -1,0 +1,57 @@
+import DoctorLayout from "@/components/doctor/doctor-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DoctorAccountLoading() {
+    return (
+        <DoctorLayout
+            title="Account Management"
+            description="Keep your clinic profile accurate, secure, and ready for seamless coordination."
+        >
+            <div className="mx-auto w-full max-w-4xl space-y-10">
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/4" />
+                        <Skeleton className="h-4 w-2/3" />
+                    </CardHeader>
+                    <CardContent className="space-y-8">
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 8 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <Skeleton className="h-10 w-full" />
+                        <Skeleton className="h-10 w-full" />
+                    </CardContent>
+                </Card>
+            </div>
+        </DoctorLayout>
+    );
+}

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -12,6 +12,8 @@ import { AccountCard } from "@/components/account/account-card";
 import { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
+import DoctorAccountLoading from "./loading";
+
 import {
     AlertDialog,
     AlertDialogAction,
@@ -70,6 +72,7 @@ const reverseBloodTypeEnumMap = Object.fromEntries(
 export default function DoctorAccountPage() {
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(false);
+    const [initializing, setInitializing] = useState(true);
 
     const [tempDOB, setTempDOB] = useState("");
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
@@ -118,6 +121,8 @@ export default function DoctorAccountPage() {
         } catch (err) {
             console.error("Failed to load profile:", err);
             toast.error("Failed to load profile");
+        } finally {
+            setInitializing(false);
         }
     }, []);
 
@@ -221,6 +226,10 @@ export default function DoctorAccountPage() {
     );
 
     const bloodTypeOptions = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+
+    if (initializing) {
+        return <DoctorAccountLoading />;
+    }
 
     return (
         <DoctorLayout

--- a/src/app/doctor/appointments/loading.tsx
+++ b/src/app/doctor/appointments/loading.tsx
@@ -1,0 +1,80 @@
+import DoctorLayout from "@/components/doctor/doctor-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DoctorAppointmentsLoading() {
+    return (
+        <DoctorLayout
+            title="Appointment management"
+            description="Oversee consultation requests, confirm schedules, and coordinate adjustments with patients."
+            actions={<Skeleton className="h-10 w-32 rounded-xl" />}
+        >
+            <div className="flex flex-col gap-6">
+                <section className="grid gap-4 md:grid-cols-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <Card
+                            key={index}
+                            className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm"
+                        >
+                            <CardHeader className="space-y-3">
+                                <Skeleton className="h-4 w-2/3" />
+                                <Skeleton className="h-4 w-1/2" />
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <Skeleton className="h-8 w-20" />
+                                <Skeleton className="h-4 w-3/5" />
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="flex flex-wrap items-center gap-3">
+                            {Array.from({ length: 3 }).map((_, index) => (
+                                <Skeleton key={index} className="h-3 w-32 rounded-full" />
+                            ))}
+                        </div>
+                        <div className="rounded-2xl border border-green-100 p-4">
+                            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                                <div className="flex flex-wrap gap-3">
+                                    <Skeleton className="h-10 w-48" />
+                                    <Skeleton className="h-10 w-32" />
+                                    <Skeleton className="h-10 w-36" />
+                                </div>
+                                <div className="flex gap-3">
+                                    <Skeleton className="h-10 w-28" />
+                                    <Skeleton className="h-10 w-28" />
+                                </div>
+                            </div>
+                        </div>
+                        <div className="space-y-3">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div
+                                    key={index}
+                                    className="rounded-2xl border border-green-50 bg-white/70 p-4 shadow-sm"
+                                >
+                                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                        <div className="flex flex-col gap-2">
+                                            <Skeleton className="h-5 w-48" />
+                                            <Skeleton className="h-4 w-32" />
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-3">
+                                            <Skeleton className="h-6 w-16 rounded-full" />
+                                            <Skeleton className="h-8 w-28" />
+                                            <Skeleton className="h-8 w-28" />
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </DoctorLayout>
+    );
+}

--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -48,6 +48,8 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { formatManilaDateTime, formatManilaISODate, manilaNow } from "@/lib/time";
 
+import DoctorAppointmentsLoading from "./loading";
+
 const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
 
 type AppointmentStatus = (typeof STATUS_ORDER)[number];
@@ -142,6 +144,7 @@ function parseStartDate(appointment: Appointment) {
 export default function DoctorAppointmentsPage() {
     const [appointments, setAppointments] = useState<Appointment[]>([]);
     const [loading, setLoading] = useState(true);
+    const [initializing, setInitializing] = useState(true);
     const [actionType, setActionType] = useState<"cancel" | "move" | null>(null);
     const [selectedAppt, setSelectedAppt] = useState<Appointment | null>(null);
     const [reason, setReason] = useState("");
@@ -167,6 +170,7 @@ export default function DoctorAppointmentsPage() {
             toast.error("Failed to load appointments");
         } finally {
             setLoading(false);
+            setInitializing(false);
         }
     }, []);
 
@@ -431,6 +435,10 @@ export default function DoctorAppointmentsPage() {
             setDialogOpen(true);
         }
     };
+
+    if (initializing) {
+        return <DoctorAppointmentsLoading />;
+    }
 
     return (
         <DoctorLayout

--- a/src/app/doctor/consultation/loading.tsx
+++ b/src/app/doctor/consultation/loading.tsx
@@ -1,0 +1,66 @@
+import DoctorLayout from "@/components/doctor/doctor-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DoctorConsultationLoading() {
+    return (
+        <DoctorLayout
+            title="Consultation availability"
+            description="Manage your duty hours, adjust clinic assignments, and publish new consultation slots."
+        >
+            <div className="space-y-6">
+                <section className="mx-auto w-full max-w-6xl space-y-6 px-4 sm:px-6">
+                    <Card className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 shadow-sm">
+                        <CardHeader className="space-y-2">
+                            <Skeleton className="h-4 w-1/3" />
+                            <Skeleton className="h-4 w-1/2" />
+                        </CardHeader>
+                    </Card>
+
+                    <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
+                        <CardHeader className="flex flex-col gap-3 border-b border-green-100/70 sm:flex-row sm:items-center sm:justify-between">
+                            <Skeleton className="h-6 w-48" />
+                            <Skeleton className="h-10 w-40 rounded-xl" />
+                        </CardHeader>
+                        <CardContent className="space-y-6">
+                            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                                {Array.from({ length: 6 }).map((_, index) => (
+                                    <div key={index} className="rounded-2xl border border-green-50 bg-white/80 p-4">
+                                        <Skeleton className="mb-3 h-4 w-24" />
+                                        <div className="space-y-2">
+                                            <Skeleton className="h-4 w-32" />
+                                            <Skeleton className="h-4 w-20" />
+                                            <Skeleton className="h-4 w-28" />
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="mx-auto w-full max-w-6xl space-y-6 px-4 sm:px-6">
+                    <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
+                        <CardHeader className="border-b border-green-100/70 pb-4">
+                            <Skeleton className="h-5 w-1/3" />
+                        </CardHeader>
+                        <CardContent className="space-y-5 pt-6">
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <Skeleton className="h-10 w-full" />
+                                <Skeleton className="h-10 w-full" />
+                            </div>
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <Skeleton className="h-10 w-full" />
+                                <Skeleton className="h-10 w-full" />
+                            </div>
+                            <div className="flex justify-end gap-3">
+                                <Skeleton className="h-10 w-28" />
+                                <Skeleton className="h-10 w-32" />
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+            </div>
+        </DoctorLayout>
+    );
+}

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -33,6 +33,8 @@ import {
     toManilaTimeString,
 } from "@/lib/time";
 
+import DoctorConsultationLoading from "./loading";
+
 
 type Clinic = {
     clinic_id: string;
@@ -52,6 +54,7 @@ export default function DoctorConsultationPage() {
     const [savingDutyHours, setSavingDutyHours] = useState(false);
     const [slots, setSlots] = useState<Availability[]>([]);
     const [clinics, setClinics] = useState<Clinic[]>([]);
+    const [initializing, setInitializing] = useState(true);
     const [formData, setFormData] = useState({
         clinic_id: "",
         available_date: "",
@@ -77,6 +80,7 @@ export default function DoctorConsultationPage() {
             toast.error("Failed to load consultation slots");
         } finally {
             setLoading(false);
+            setInitializing(false);
         }
     }
 
@@ -166,6 +170,10 @@ export default function DoctorConsultationPage() {
             setLoading(false);
             setSavingDutyHours(false);
         }
+    }
+
+    if (initializing) {
+        return <DoctorConsultationLoading />;
     }
 
     return (

--- a/src/app/doctor/dispense/loading.tsx
+++ b/src/app/doctor/dispense/loading.tsx
@@ -1,0 +1,79 @@
+import DoctorLayout from "@/components/doctor/doctor-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DoctorDispenseLoading() {
+    return (
+        <DoctorLayout
+            title="Dispensing log"
+            description="Document issued medicines, validate stock balances, and maintain accurate clinic records."
+            actions={<Skeleton className="h-10 w-28 rounded-xl" />}
+        >
+            <div className="space-y-6">
+                <section className="mx-auto w-full max-w-6xl space-y-6 px-4 sm:px-6">
+                    <Card className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 shadow-sm">
+                        <CardHeader className="space-y-2">
+                            <Skeleton className="h-4 w-1/3" />
+                            <Skeleton className="h-4 w-1/2" />
+                        </CardHeader>
+                    </Card>
+                    <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
+                        <CardHeader className="space-y-2 border-b border-green-100/70">
+                            <Skeleton className="h-5 w-1/3" />
+                            <Skeleton className="h-4 w-2/3" />
+                        </CardHeader>
+                        <CardContent className="space-y-6 pt-6">
+                            <div className="space-y-4">
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-[90px] w-full rounded-xl" />
+                            </div>
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <div className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-12 w-full" />
+                                </div>
+                                <div className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-12 w-full" />
+                                </div>
+                            </div>
+                            <div className="flex justify-end gap-3">
+                                <Skeleton className="h-10 w-24" />
+                                <Skeleton className="h-10 w-32" />
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="mx-auto w-full max-w-6xl space-y-4 px-4 sm:px-6">
+                    <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
+                        <CardHeader className="space-y-2 border-b border-green-100/70">
+                            <Skeleton className="h-5 w-1/3" />
+                            <Skeleton className="h-4 w-1/2" />
+                        </CardHeader>
+                        <CardContent className="space-y-4 pt-6">
+                            {Array.from({ length: 5 }).map((_, index) => (
+                                <div
+                                    key={index}
+                                    className="rounded-2xl border border-green-50 bg-white/80 p-4"
+                                >
+                                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                        <div className="space-y-2">
+                                            <Skeleton className="h-5 w-36" />
+                                            <Skeleton className="h-4 w-24" />
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-3">
+                                            <Skeleton className="h-6 w-16 rounded-full" />
+                                            <Skeleton className="h-8 w-24" />
+                                            <Skeleton className="h-8 w-28" />
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                </section>
+            </div>
+        </DoctorLayout>
+    );
+}

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/components/ui/table";
 import { formatManilaDateTime } from "@/lib/time";
 
+import DoctorDispenseLoading from "./loading";
+
 type DispenseRecord = {
     dispense_id: string;
     quantity: number;
@@ -100,6 +102,7 @@ export default function DoctorDispensePage() {
     const [dispenses, setDispenses] = useState<DispenseRecord[]>([]);
     const [consultations, setConsultations] = useState<ConsultationOption[]>([]);
     const [medicines, setMedicines] = useState<MedicineOption[]>([]);
+    const [initializing, setInitializing] = useState(true);
     const [form, setForm] = useState({
         consultation_id: "",
         med_id: "",
@@ -131,6 +134,7 @@ export default function DoctorDispensePage() {
                 toast.error("Failed to load dispense data");
             } finally {
                 setLoading(false);
+                setInitializing(false);
             }
         }
 
@@ -191,6 +195,10 @@ export default function DoctorDispensePage() {
         } finally {
             setSubmitting(false);
         }
+    }
+
+    if (initializing) {
+        return <DoctorDispenseLoading />;
     }
 
     return (

--- a/src/app/doctor/patients/loading.tsx
+++ b/src/app/doctor/patients/loading.tsx
@@ -1,0 +1,80 @@
+import DoctorLayout from "@/components/doctor/doctor-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DoctorPatientsLoading() {
+    return (
+        <DoctorLayout
+            title="Patient registry"
+            description="Review medical records, follow up on clinic visits, and capture key notes for coordinated care."
+            actions={<Skeleton className="h-10 w-36 rounded-xl" />}
+        >
+            <div className="space-y-6">
+                <section className="mx-auto w-full max-w-6xl space-y-8 px-4 sm:px-6">
+                    <div className="grid gap-4 md:grid-cols-3">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <Card
+                                key={index}
+                                className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm"
+                            >
+                                <CardHeader className="space-y-2">
+                                    <Skeleton className="h-4 w-2/3" />
+                                    <Skeleton className="h-4 w-1/2" />
+                                </CardHeader>
+                                <CardContent>
+                                    <Skeleton className="h-10 w-20" />
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                            <div className="space-y-2">
+                                <Skeleton className="h-5 w-40" />
+                                <Skeleton className="h-4 w-64" />
+                            </div>
+                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                                {Array.from({ length: 4 }).map((_, index) => (
+                                    <div key={index} className="space-y-2">
+                                        <Skeleton className="h-4 w-24" />
+                                        <Skeleton className="h-10 w-full" />
+                                    </div>
+                                ))}
+                            </div>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                <Skeleton className="h-10 w-full max-w-md" />
+                                <Skeleton className="h-10 w-40" />
+                            </div>
+                            <div className="space-y-3">
+                                {Array.from({ length: 6 }).map((_, index) => (
+                                    <div
+                                        key={index}
+                                        className="rounded-2xl border border-green-50 bg-white/80 p-4"
+                                    >
+                                        <div className="grid gap-3 md:grid-cols-[1.2fr_1fr_1fr]">
+                                            <div className="space-y-2">
+                                                <Skeleton className="h-5 w-48" />
+                                                <Skeleton className="h-4 w-40" />
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Skeleton className="h-4 w-24" />
+                                                <Skeleton className="h-4 w-32" />
+                                            </div>
+                                            <div className="flex flex-wrap items-center justify-end gap-3">
+                                                <Skeleton className="h-8 w-24" />
+                                                <Skeleton className="h-8 w-24" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+            </div>
+        </DoctorLayout>
+    );
+}

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -31,6 +31,8 @@ import { Badge } from "@/components/ui/badge";
 import { formatManilaDateTime } from "@/lib/time";
 import { BLOOD_TYPES } from "@/lib/patient-records-update";
 
+import DoctorPatientsLoading from "./loading";
+
 type PatientRecord = {
     id: string;
     userId: string;
@@ -199,6 +201,7 @@ export default function DoctorPatientsPage() {
     const [typeFilter, setTypeFilter] = useState("All");
     const [appointmentFilter, setAppointmentFilter] = useState("All");
     const [loadingRecords, setLoadingRecords] = useState(false);
+    const [initializing, setInitializing] = useState(true);
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
     const [detailOpen, setDetailOpen] = useState(false);
@@ -221,6 +224,7 @@ export default function DoctorPatientsPage() {
             toast.error(error instanceof Error ? error.message : "Failed to load patient records");
         } finally {
             setLoadingRecords(false);
+            setInitializing(false);
         }
     }, []);
 
@@ -349,6 +353,10 @@ export default function DoctorPatientsPage() {
         } finally {
             setSavingNotesPatientId(null);
         }
+    }
+
+    if (initializing) {
+        return <DoctorPatientsLoading />;
     }
 
     return (

--- a/src/app/nurse/accounts/loading.tsx
+++ b/src/app/nurse/accounts/loading.tsx
@@ -1,0 +1,58 @@
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function NurseAccountsLoading() {
+    return (
+        <NurseLayout
+            title="Accounts Management"
+            description="Create and manage user accounts, update your profile, and control access from one workspace."
+        >
+            <section className="mx-auto w-full max-w-6xl space-y-10 px-4 py-6 sm:px-6 sm:py-8">
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-2/3" />
+                    </CardHeader>
+                    <CardContent className="space-y-8">
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <Skeleton className="h-10 w-full" />
+                        <Skeleton className="h-10 w-full" />
+                    </CardContent>
+                </Card>
+            </section>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/accounts/page.tsx
+++ b/src/app/nurse/accounts/page.tsx
@@ -42,6 +42,8 @@ import { AccountCard } from "@/components/account/account-card";
 import { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
+import NurseAccountsLoading from "./loading";
+
 // Types aligned with API
 type User = {
     user_id: string;
@@ -118,6 +120,9 @@ export default function NurseAccountsPage() {
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(false);
 
+    const [profileLoaded, setProfileLoaded] = useState(false);
+    const [usersLoaded, setUsersLoaded] = useState(false);
+
     const [currentPage, setCurrentPage] = useState(1);
 
     const [originalProfile, setOriginalProfile] = useState<Profile | null>(null);
@@ -126,6 +131,8 @@ export default function NurseAccountsPage() {
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
 
     const [specialization, setSpecialization] = useState<"Physician" | "Dentist" | null>(null);
+
+    const initializing = !(profileLoaded && usersLoaded);
 
 
     // Fetch users (deduplicated but allows same visible ID across different roles)
@@ -181,6 +188,8 @@ export default function NurseAccountsPage() {
         } catch (err) {
             console.error("Failed to load users:", err);
             toast.error("Failed to load users", { position: "top-center" });
+        } finally {
+            setUsersLoaded(true);
         }
     }
 
@@ -232,6 +241,8 @@ export default function NurseAccountsPage() {
         } catch (err) {
             console.error("Failed to load profile:", err);
             toast.error("Failed to load profile");
+        } finally {
+            setProfileLoaded(true);
         }
     }, []);
 
@@ -437,6 +448,10 @@ export default function NurseAccountsPage() {
 
 
     const bloodTypeOptions = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+
+    if (initializing) {
+        return <NurseAccountsLoading />;
+    }
 
     return (
         <NurseLayout

--- a/src/app/nurse/clinic/loading.tsx
+++ b/src/app/nurse/clinic/loading.tsx
@@ -1,0 +1,44 @@
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function NurseClinicLoading() {
+    return (
+        <NurseLayout
+            title="Clinic Management"
+            description="Maintain clinic locations, contact information, and update details for campus services."
+        >
+            <section className="mx-auto w-full max-w-6xl space-y-6 px-4 py-6 sm:px-6 sm:py-10">
+                <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="flex flex-col gap-3 border-b sm:flex-row sm:items-center sm:justify-between">
+                        <Skeleton className="h-6 w-40" />
+                        <Skeleton className="h-10 w-32 rounded-xl" />
+                    </CardHeader>
+                    <CardContent className="space-y-4 pt-6">
+                        {Array.from({ length: 5 }).map((_, index) => (
+                            <div
+                                key={index}
+                                className="rounded-2xl border border-green-50 bg-white/80 p-4 shadow-sm"
+                            >
+                                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                    <div className="space-y-2">
+                                        <Skeleton className="h-5 w-48" />
+                                        <Skeleton className="h-4 w-40" />
+                                    </div>
+                                    <div className="space-y-2 text-sm">
+                                        <Skeleton className="h-4 w-32" />
+                                        <Skeleton className="h-4 w-28" />
+                                    </div>
+                                    <div className="flex gap-3">
+                                        <Skeleton className="h-9 w-24" />
+                                        <Skeleton className="h-9 w-24" />
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+            </section>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/clinic/page.tsx
+++ b/src/app/nurse/clinic/page.tsx
@@ -25,6 +25,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 
+import NurseClinicLoading from "./loading";
+
 type Clinic = {
     clinic_id: string;
     clinic_name: string;
@@ -36,11 +38,22 @@ export default function NurseClinicPage() {
     const [clinics, setClinics] = useState<Clinic[]>([]);
     const [selectedClinic, setSelectedClinic] = useState<Clinic | null>(null);
     const [loading, setLoading] = useState(false);
+    const [initializing, setInitializing] = useState(true);
 
     async function loadClinics() {
-        const res = await fetch("/api/nurse/clinic");
-        const data = await res.json();
-        setClinics(data);
+        try {
+            const res = await fetch("/api/nurse/clinic");
+            if (!res.ok) {
+                throw new Error("Failed to load clinics");
+            }
+            const data = await res.json();
+            setClinics(data);
+        } catch (error) {
+            console.error(error);
+            toast.error("Failed to load clinics");
+        } finally {
+            setInitializing(false);
+        }
     }
 
     useEffect(() => {
@@ -101,6 +114,10 @@ export default function NurseClinicPage() {
         } else {
             toast.error("Failed to update clinic");
         }
+    }
+
+    if (initializing) {
+        return <NurseClinicLoading />;
     }
 
     return (

--- a/src/app/nurse/dispense/loading.tsx
+++ b/src/app/nurse/dispense/loading.tsx
@@ -1,0 +1,41 @@
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function NurseDispenseLoading() {
+    return (
+        <NurseLayout
+            title="Dispense Records"
+            description="Monitor dispensed medicines and review batch usage for accurate stock tracking."
+        >
+            <section className="mx-auto flex w-full max-w-6xl flex-1 flex-col space-y-8 px-4 py-6 sm:px-6 sm:py-8">
+                <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="border-b border-green-100/60">
+                        <Skeleton className="h-6 w-48" />
+                    </CardHeader>
+                    <CardContent className="flex flex-1 flex-col pt-4">
+                        <div className="overflow-x-auto">
+                            <div className="min-w-full space-y-3">
+                                <div className="grid grid-cols-8 gap-3 rounded-2xl bg-green-50/60 p-3 text-sm font-medium text-green-700">
+                                    {Array.from({ length: 8 }).map((_, index) => (
+                                        <Skeleton key={index} className="h-4 w-full" />
+                                    ))}
+                                </div>
+                                {Array.from({ length: 6 }).map((_, rowIndex) => (
+                                    <div
+                                        key={rowIndex}
+                                        className="grid grid-cols-8 gap-3 rounded-2xl border border-green-50 bg-white/80 p-3 text-sm"
+                                    >
+                                        {Array.from({ length: 8 }).map((_, colIndex) => (
+                                            <Skeleton key={colIndex} className="h-4 w-full" />
+                                        ))}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/table";
 import { formatManilaDateTime } from "@/lib/time";
 
+import NurseDispenseLoading from "./loading";
+
 // Extend Dispense type to include batch usage
 type Dispense = {
     dispense_id: string;
@@ -43,11 +45,21 @@ type Dispense = {
 
 export default function NurseDispensePage() {
     const [dispenses, setDispenses] = useState<Dispense[]>([]);
+    const [initializing, setInitializing] = useState(true);
 
     async function loadDispenses() {
-        const res = await fetch("/api/nurse/dispense", { cache: "no-store" });
-        const data = await res.json();
-        setDispenses(data);
+        try {
+            const res = await fetch("/api/nurse/dispense", { cache: "no-store" });
+            if (!res.ok) {
+                throw new Error("Failed to load dispense records");
+            }
+            const data = await res.json();
+            setDispenses(Array.isArray(data) ? data : []);
+        } catch (error) {
+            console.error(error);
+        } finally {
+            setInitializing(false);
+        }
     }
 
     useEffect(() => {
@@ -55,6 +67,10 @@ export default function NurseDispensePage() {
     }, []);
 
 
+
+    if (initializing) {
+        return <NurseDispenseLoading />;
+    }
 
     return (
         <NurseLayout

--- a/src/app/nurse/inventory/loading.tsx
+++ b/src/app/nurse/inventory/loading.tsx
@@ -1,0 +1,47 @@
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function NurseInventoryLoading() {
+    return (
+        <NurseLayout
+            title="Inventory Management"
+            description="Monitor clinic stocks, update batch details, and keep replenishments on track."
+        >
+            <section className="mx-auto flex w-full max-w-7xl flex-1 flex-col space-y-10 px-4 pb-12 pt-6 sm:px-6 sm:pt-8">
+                <Card className="flex flex-1 flex-col rounded-3xl border border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <Skeleton className="h-6 w-40" />
+                        <div className="flex w-full flex-col gap-2 sm:flex-row md:w-auto">
+                            <Skeleton className="h-10 w-full sm:w-72" />
+                            <Skeleton className="h-10 w-full sm:w-44" />
+                            <Skeleton className="h-10 w-full sm:w-48" />
+                            <Skeleton className="h-10 w-full sm:w-32" />
+                        </div>
+                    </CardHeader>
+                    <CardContent className="space-y-4 pt-4">
+                        <div className="overflow-x-auto">
+                            <div className="min-w-full space-y-3">
+                                <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-3 rounded-2xl bg-green-50/60 p-3 text-sm font-medium text-green-700">
+                                    {Array.from({ length: 4 }).map((_, index) => (
+                                        <Skeleton key={index} className="h-4 w-full" />
+                                    ))}
+                                </div>
+                                {Array.from({ length: 7 }).map((_, rowIndex) => (
+                                    <div
+                                        key={rowIndex}
+                                        className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-3 rounded-2xl border border-green-50 bg-white/80 p-3 text-sm"
+                                    >
+                                        {Array.from({ length: 4 }).map((_, colIndex) => (
+                                            <Skeleton key={colIndex} className="h-4 w-full" />
+                                        ))}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/inventory/page.tsx
+++ b/src/app/nurse/inventory/page.tsx
@@ -37,6 +37,8 @@ import {
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 
+import NurseInventoryLoading from "./loading";
+
 // Types
 type ArchivedReplenishment = {
     replenishment_id: string;
@@ -84,6 +86,11 @@ export default function NurseInventoryPage() {
     // Separate loading states
     const [loadingInventory, setLoadingInventory] = useState(false);
     const [savingStock, setSavingStock] = useState(false);
+    const [inventoryLoaded, setInventoryLoaded] = useState(false);
+    const [clinicsLoaded, setClinicsLoaded] = useState(false);
+    const [enumsLoaded, setEnumsLoaded] = useState(false);
+
+    const initializing = !(inventoryLoaded && clinicsLoaded && enumsLoaded);
     // no menu state needed; navigation handled by NurseLayout
 
     // Load inventory
@@ -110,6 +117,7 @@ export default function NurseInventoryPage() {
             toast.error("Failed to load inventory.");
         } finally {
             setLoadingInventory(false);
+            setInventoryLoaded(true);
         }
     }
 
@@ -121,6 +129,8 @@ export default function NurseInventoryPage() {
             setClinics(data);
         } catch {
             toast.error("Failed to load clinics.");
+        } finally {
+            setClinicsLoaded(true);
         }
     }
 
@@ -134,6 +144,8 @@ export default function NurseInventoryPage() {
             setMedTypes(data.medTypes);
         } catch {
             toast.error("Failed to load enums.");
+        } finally {
+            setEnumsLoaded(true);
         }
     }
 
@@ -181,6 +193,10 @@ export default function NurseInventoryPage() {
     });
 
 
+
+    if (initializing) {
+        return <NurseInventoryLoading />;
+    }
 
     return (
         <NurseLayout

--- a/src/app/nurse/records/loading.tsx
+++ b/src/app/nurse/records/loading.tsx
@@ -1,0 +1,80 @@
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function NurseRecordsLoading() {
+    return (
+        <NurseLayout
+            title="Patient records"
+            description="Coordinate patient histories, capture consultation notes, and support physicians during follow-ups."
+            actions={<Skeleton className="h-10 w-36 rounded-xl" />}
+        >
+            <div className="space-y-6">
+                <section className="mx-auto w-full max-w-6xl space-y-8 px-4 sm:px-6">
+                    <div className="grid gap-4 md:grid-cols-3">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <Card
+                                key={index}
+                                className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm"
+                            >
+                                <CardHeader className="space-y-2">
+                                    <Skeleton className="h-4 w-2/3" />
+                                    <Skeleton className="h-4 w-1/2" />
+                                </CardHeader>
+                                <CardContent>
+                                    <Skeleton className="h-10 w-20" />
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                            <div className="space-y-2">
+                                <Skeleton className="h-5 w-40" />
+                                <Skeleton className="h-4 w-60" />
+                            </div>
+                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                                {Array.from({ length: 4 }).map((_, index) => (
+                                    <div key={index} className="space-y-2">
+                                        <Skeleton className="h-4 w-24" />
+                                        <Skeleton className="h-10 w-full" />
+                                    </div>
+                                ))}
+                            </div>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                <Skeleton className="h-10 w-full max-w-md" />
+                                <Skeleton className="h-10 w-40" />
+                            </div>
+                            <div className="space-y-3">
+                                {Array.from({ length: 6 }).map((_, index) => (
+                                    <div
+                                        key={index}
+                                        className="rounded-2xl border border-green-50 bg-white/80 p-4"
+                                    >
+                                        <div className="grid gap-3 md:grid-cols-[1.2fr_1fr_1fr]">
+                                            <div className="space-y-2">
+                                                <Skeleton className="h-5 w-48" />
+                                                <Skeleton className="h-4 w-40" />
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Skeleton className="h-4 w-24" />
+                                                <Skeleton className="h-4 w-32" />
+                                            </div>
+                                            <div className="flex flex-wrap items-center justify-end gap-3">
+                                                <Skeleton className="h-8 w-24" />
+                                                <Skeleton className="h-8 w-24" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+            </div>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/records/page.tsx
+++ b/src/app/nurse/records/page.tsx
@@ -39,6 +39,8 @@ import { toast } from "sonner";
 import { formatManilaDateTime } from "@/lib/time";
 import { BLOOD_TYPES } from "@/lib/patient-records-update";
 
+import NurseRecordsLoading from "./loading";
+
 type PatientRecord = {
     id: string;
     userId: string;
@@ -208,6 +210,7 @@ export default function NurseRecordsPage() {
     const [typeFilter, setTypeFilter] = useState("All");
     const [appointmentFilter, setAppointmentFilter] = useState("All");
     const [loadingRecords, setLoadingRecords] = useState(false);
+    const [initializing, setInitializing] = useState(true);
     const [detailOpen, setDetailOpen] = useState(false);
     const [selectedRecord, setSelectedRecord] = useState<PatientRecord | null>(null);
     const [activeTab, setActiveTab] = useState<"details" | "update" | "notes">("details");
@@ -225,6 +228,7 @@ export default function NurseRecordsPage() {
             toast.error("Error loading records.");
         } finally {
             setLoadingRecords(false);
+            setInitializing(false);
         }
     }, []);
 
@@ -349,6 +353,10 @@ export default function NurseRecordsPage() {
         } finally {
             setSavingNotesPatientId(null);
         }
+    }
+
+    if (initializing) {
+        return <NurseRecordsLoading />;
     }
 
     return (

--- a/src/app/nurse/reports/loading.tsx
+++ b/src/app/nurse/reports/loading.tsx
@@ -1,0 +1,70 @@
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function NurseReportsLoading() {
+    return (
+        <NurseLayout
+            title="Quarterly Reports"
+            description="Generate patient and illness insights for any quarter to prepare compliance-ready summaries."
+            actions={<Skeleton className="h-9 w-36 rounded-xl" />}
+        >
+            <section className="space-y-6">
+                <Card className="rounded-3xl border-transparent bg-white/80 shadow-sm md:border-green-100/70">
+                    <CardHeader className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                        <div className="space-y-2">
+                            <Skeleton className="h-5 w-40" />
+                            <Skeleton className="h-4 w-64" />
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                            <Skeleton className="h-10 w-32" />
+                            <Skeleton className="h-10 w-32" />
+                            <Skeleton className="h-10 w-32" />
+                        </div>
+                    </CardHeader>
+                </Card>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/85 shadow-sm">
+                    <CardHeader className="space-y-2 border-b border-green-100/70 pb-4">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="grid gap-6 pt-6 md:grid-cols-2">
+                        <div className="space-y-4">
+                            <Skeleton className="h-4 w-32" />
+                            <Skeleton className="h-40 w-full rounded-2xl" />
+                        </div>
+                        <div className="space-y-4">
+                            <Skeleton className="h-4 w-28" />
+                            <div className="space-y-3">
+                                {Array.from({ length: 4 }).map((_, index) => (
+                                    <div key={index} className="flex items-center justify-between">
+                                        <Skeleton className="h-4 w-40" />
+                                        <Skeleton className="h-4 w-16" />
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/85 shadow-sm">
+                    <CardHeader className="space-y-2 border-b border-green-100/70 pb-4">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-4 pt-6">
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                            {Array.from({ length: 8 }).map((_, index) => (
+                                <div key={index} className="rounded-2xl border border-green-50 bg-white/80 p-4">
+                                    <Skeleton className="mb-2 h-4 w-32" />
+                                    <Skeleton className="h-8 w-16" />
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/reports/page.tsx
+++ b/src/app/nurse/reports/page.tsx
@@ -36,6 +36,8 @@ import {
 } from "@/components/ui/chart";
 import { formatManilaDateTime } from "@/lib/time";
 
+import NurseReportsLoading from "./loading";
+
 type PatientTypeKey = "Student" | "Employee" | "Unknown";
 
 type DiagnosisCount = {
@@ -187,6 +189,7 @@ export default function NurseReportsPage() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [exportingPdf, setExportingPdf] = useState(false);
+    const [initializing, setInitializing] = useState(true);
 
     const years = useMemo(() => {
         return Array.from({ length: 5 }, (_, index) => currentYear - index);
@@ -232,6 +235,7 @@ export default function NurseReportsPage() {
             } finally {
                 if (!ignore) {
                     setLoading(false);
+                    setInitializing(false);
                 }
             }
         }
@@ -273,6 +277,10 @@ export default function NurseReportsPage() {
     }, [selectedQuarter]);
 
     const hasData = !!data && data.quarters.some((item) => item.consultations > 0);
+
+    if (initializing) {
+        return <NurseReportsLoading />;
+    }
 
     return (
         <NurseLayout

--- a/src/app/patient/account/loading.tsx
+++ b/src/app/patient/account/loading.tsx
@@ -1,0 +1,59 @@
+import PatientLayout from "@/components/patient/patient-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PatientAccountLoading() {
+    return (
+        <PatientLayout
+            title="Loading profile"
+            description="Please wait while we retrieve your account data."
+            actions={<Skeleton className="hidden h-8 w-36 rounded-xl md:block" />}
+        >
+            <div className="space-y-6">
+                <Card className="rounded-3xl border-green-100/80 bg-white/90 p-8 text-center shadow-sm">
+                    <div className="flex flex-col items-center gap-3 text-green-700">
+                        <Skeleton className="h-6 w-6 rounded-full" />
+                        <Skeleton className="h-4 w-48" />
+                    </div>
+                </Card>
+
+                <Card className="rounded-3xl border-green-100/80 bg-white/90 shadow-sm">
+                    <CardHeader className="space-y-2">
+                        <Skeleton className="h-4 w-1/3" />
+                        <Skeleton className="h-4 w-2/3" />
+                    </CardHeader>
+                    <CardContent className="space-y-6">
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="flex justify-end gap-3">
+                            <Skeleton className="h-10 w-28" />
+                            <Skeleton className="h-10 w-32" />
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </PatientLayout>
+    );
+}

--- a/src/app/patient/account/page.tsx
+++ b/src/app/patient/account/page.tsx
@@ -31,6 +31,8 @@ import { AccountCard } from "@/components/account/account-card";
 import { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
+import PatientAccountLoading from "./loading";
+
 
 // Enum ↔ Label Mappings
 const departmentEnumMap: Record<string, string> = {
@@ -168,6 +170,8 @@ export default function PatientAccountPage() {
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(false);
 
+    const [initializing, setInitializing] = useState(true);
+
     const [profileType, setProfileType] = useState<"student" | "employee" | null>(null);
 
     const [tempDOB, setTempDOB] = useState("");
@@ -215,6 +219,8 @@ export default function PatientAccountPage() {
             });
         } catch {
             toast.error("Failed to load profile");
+        } finally {
+            setInitializing(false);
         }
     }, []);
 
@@ -340,6 +346,10 @@ export default function PatientAccountPage() {
         },
         []
     );
+
+    if (initializing) {
+        return <PatientAccountLoading />;
+    }
 
     return (
         <PatientLayout

--- a/src/app/patient/appointments/loading.tsx
+++ b/src/app/patient/appointments/loading.tsx
@@ -1,0 +1,104 @@
+import PatientLayout from "@/components/patient/patient-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PatientAppointmentsLoading() {
+    return (
+        <PatientLayout
+            title="Appointments"
+            description="Plan and manage your clinic visits — from booking a slot to tracking approvals and changes."
+            actions={<Skeleton className="hidden h-9 w-60 rounded-2xl md:flex" />}
+        >
+            <section className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] 2xl:gap-8">
+                <div className="space-y-6">
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="space-y-2">
+                            <Skeleton className="h-5 w-1/3" />
+                            <Skeleton className="h-4 w-2/3" />
+                        </CardHeader>
+                        <CardContent className="space-y-5">
+                            {Array.from({ length: 5 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/3" />
+                                    <Skeleton className="h-10 w-full rounded-xl" />
+                                </div>
+                            ))}
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <div className="space-y-2">
+                                    <Skeleton className="h-4 w-24" />
+                                    <Skeleton className="h-10 w-full rounded-xl" />
+                                </div>
+                                <div className="space-y-2">
+                                    <Skeleton className="h-4 w-24" />
+                                    <Skeleton className="h-10 w-full rounded-xl" />
+                                </div>
+                            </div>
+                            <div className="flex justify-end gap-3">
+                                <Skeleton className="h-10 w-24" />
+                                <Skeleton className="h-10 w-32" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="space-y-2">
+                            <Skeleton className="h-5 w-1/3" />
+                            <Skeleton className="h-4 w-1/2" />
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div
+                                    key={index}
+                                    className="rounded-2xl border border-green-50 bg-white/80 p-4"
+                                >
+                                    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                        <div className="space-y-2">
+                                            <Skeleton className="h-5 w-48" />
+                                            <Skeleton className="h-4 w-32" />
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-3">
+                                            <Skeleton className="h-6 w-20 rounded-full" />
+                                            <Skeleton className="h-8 w-24" />
+                                            <Skeleton className="h-8 w-24" />
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="space-y-6">
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="space-y-2">
+                            <Skeleton className="h-5 w-1/2" />
+                            <Skeleton className="h-4 w-2/3" />
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <Skeleton className="h-40 w-full rounded-2xl" />
+                            <div className="space-y-2">
+                                <Skeleton className="h-4 w-32" />
+                                <Skeleton className="h-4 w-48" />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="space-y-2">
+                            <Skeleton className="h-5 w-1/3" />
+                            <Skeleton className="h-4 w-1/2" />
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {Array.from({ length: 5 }).map((_, index) => (
+                                <div key={index} className="space-y-2 rounded-2xl border border-green-50 bg-white/80 p-4">
+                                    <Skeleton className="h-5 w-40" />
+                                    <Skeleton className="h-4 w-32" />
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                </div>
+            </section>
+        </PatientLayout>
+    );
+}

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -51,6 +51,8 @@ import { getServiceOptionsForSpecialization, resolveServiceType } from "@/lib/se
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
+import PatientAppointmentsLoading from "./loading";
+
 type Clinic = { clinic_id: string; clinic_name: string };
 type Doctor = { user_id: string; name: string; specialization: "Physician" | "Dentist" | null };
 type Slot = { start: string; end: string };
@@ -209,6 +211,8 @@ export default function PatientAppointmentsPage() {
     // My appointments
     const [appointments, setAppointments] = useState<Appointment[]>([]);
     const [loadingAppointments, setLoadingAppointments] = useState(true);
+    const [clinicsLoaded, setClinicsLoaded] = useState(false);
+    const [appointmentsLoaded, setAppointmentsLoaded] = useState(false);
     const [searchAppointments, setSearchAppointments] = useState("");
     const [statusFilter, setStatusFilter] = useState<string>("active");
 
@@ -224,6 +228,8 @@ export default function PatientAppointmentsPage() {
     const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
     const [cancelTarget, setCancelTarget] = useState<Appointment | null>(null);
     const [cancelSubmitting, setCancelSubmitting] = useState(false);
+
+    const initializing = !(clinicsLoaded && appointmentsLoaded);
 
     const handleClinicChange = (nextClinicId: string) => {
         setClinicId(nextClinicId);
@@ -358,6 +364,7 @@ export default function PatientAppointmentsPage() {
                 toast.error("Failed to load clinics");
             } finally {
                 setLoadingClinics(false);
+                setClinicsLoaded(true);
             }
         })();
     }, []);
@@ -621,6 +628,7 @@ export default function PatientAppointmentsPage() {
             toast.error("Could not load your appointments");
         } finally {
             setLoadingAppointments(false);
+            setAppointmentsLoaded(true);
         }
     }
 
@@ -707,6 +715,10 @@ export default function PatientAppointmentsPage() {
         });
         return sorted[0] ?? null;
     }, [upcomingAppointments]);
+
+    if (initializing) {
+        return <PatientAppointmentsLoading />;
+    }
 
     return (
         <PatientLayout

--- a/src/app/patient/notification/loading.tsx
+++ b/src/app/patient/notification/loading.tsx
@@ -1,0 +1,69 @@
+import PatientLayout from "@/components/patient/patient-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PatientNotificationLoading() {
+    return (
+        <PatientLayout
+            title="Notification center"
+            description="Stay on top of appointment approvals, updates, and reminders for your clinic visits."
+            actions={<Skeleton className="hidden h-8 w-40 rounded-xl md:flex" />}
+        >
+            <div className="space-y-8">
+                <Card className="rounded-3xl border-green-100/80 bg-gradient-to-r from-green-100/80 via-white to-green-50/80 shadow-sm">
+                    <CardHeader className="space-y-2 text-center">
+                        <Skeleton className="mx-auto h-8 w-64" />
+                        <Skeleton className="mx-auto h-4 w-72" />
+                    </CardHeader>
+                    <CardContent className="flex flex-wrap items-center justify-center gap-3 text-xs font-medium text-green-700">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <Skeleton key={index} className="h-6 w-32 rounded-full" />
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <div className="grid gap-6 md:grid-cols-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <Card
+                            key={index}
+                            className="h-full rounded-3xl border-green-100/70 bg-white/90 shadow-sm"
+                        >
+                            <CardHeader className="flex flex-col items-start gap-3">
+                                <Skeleton className="h-10 w-10 rounded-2xl" />
+                                <Skeleton className="h-5 w-32" />
+                            </CardHeader>
+                            <CardContent className="space-y-2 text-sm text-muted-foreground">
+                                <Skeleton className="h-4 w-full" />
+                                <Skeleton className="h-4 w-5/6" />
+                                <Skeleton className="h-4 w-2/3" />
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+
+                <Card className="rounded-3xl border-green-100/80 bg-white/90 shadow-sm">
+                    <CardHeader className="space-y-2">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {Array.from({ length: 4 }).map((_, index) => (
+                            <div key={index} className="rounded-2xl border border-green-50 bg-white/80 p-4">
+                                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                                    <div className="space-y-2">
+                                        <Skeleton className="h-5 w-40" />
+                                        <Skeleton className="h-4 w-32" />
+                                    </div>
+                                    <div className="flex gap-2">
+                                        <Skeleton className="h-8 w-24" />
+                                        <Skeleton className="h-8 w-24" />
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+            </div>
+        </PatientLayout>
+    );
+}

--- a/src/app/patient/notification/page.tsx
+++ b/src/app/patient/notification/page.tsx
@@ -16,6 +16,8 @@ import PatientLayout from "@/components/patient/patient-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
+import PatientNotificationLoading from "./loading";
+
 const notificationHighlights = [
     {
         icon: Mail,
@@ -72,7 +74,11 @@ const statusUpdates = [
 ];
 
 export default function PatientNotificationPage() {
-    const { data: session } = useSession();
+    const { data: session, status } = useSession();
+
+    if (status === "loading") {
+        return <PatientNotificationLoading />;
+    }
 
     const fullName = session?.user?.name ?? "Patient";
 

--- a/src/app/scholar/account/loading.tsx
+++ b/src/app/scholar/account/loading.tsx
@@ -1,0 +1,58 @@
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ScholarAccountLoading() {
+    return (
+        <ScholarLayout
+            title="Account Management"
+            description="Review your personal information, keep emergency contacts current, and manage your clinic credentials."
+        >
+            <section className="space-y-6">
+                <Card className="rounded-3xl border border-green-100/70 bg-white/80 shadow-sm">
+                    <CardContent className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+                        <Skeleton className="h-5 w-5 rounded-full" />
+                        <Skeleton className="h-4 w-40" />
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border border-green-100/70 bg-white/80 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-6">
+                        <div className="grid gap-4 md:grid-cols-2">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-1/2" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="flex justify-end gap-3">
+                            <Skeleton className="h-10 w-28" />
+                            <Skeleton className="h-10 w-32" />
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+        </ScholarLayout>
+    );
+}

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -30,6 +30,8 @@ import {
 } from "@/components/ui/select";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
+import ScholarAccountLoading from "./loading";
+
 const departmentEnumMap: Record<string, string> = {
     EDUCATION: "College of Education",
     ARTS_AND_SCIENCES: "College of Arts and Sciences",
@@ -232,6 +234,7 @@ function formatRequestPayload(profile: Profile) {
 export default function ScholarAccountPage() {
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(true);
+    const [initializing, setInitializing] = useState(true);
     const [updating, setUpdating] = useState(false);
     const [dobConfirmOpen, setDobConfirmOpen] = useState(false);
     const [dobSaving, setDobSaving] = useState(false);
@@ -259,6 +262,7 @@ export default function ScholarAccountPage() {
             setProfile(null);
         } finally {
             setProfileLoading(false);
+            setInitializing(false);
         }
     }, []);
 
@@ -401,6 +405,10 @@ export default function ScholarAccountPage() {
             setDobSaving(false);
         }
     }, [loadProfile, profile, tempDOB]);
+
+    if (initializing) {
+        return <ScholarAccountLoading />;
+    }
 
     return (
         <ScholarLayout

--- a/src/app/scholar/appointments/loading.tsx
+++ b/src/app/scholar/appointments/loading.tsx
@@ -1,0 +1,80 @@
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ScholarAppointmentsLoading() {
+    return (
+        <ScholarLayout
+            title="Appointment coordination"
+            description="Track campus clinic bookings, monitor status changes, and keep students informed about their schedules."
+            actions={<Skeleton className="h-10 w-32 rounded-xl" />}
+        >
+            <div className="flex flex-col gap-6">
+                <section className="grid gap-4 md:grid-cols-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <Card
+                            key={index}
+                            className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm"
+                        >
+                            <CardHeader className="space-y-2">
+                                <Skeleton className="h-4 w-2/3" />
+                                <Skeleton className="h-4 w-1/2" />
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <Skeleton className="h-8 w-20" />
+                                <Skeleton className="h-4 w-3/5" />
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                    <CardHeader className="space-y-3">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="flex flex-wrap items-center gap-3">
+                            {Array.from({ length: 3 }).map((_, index) => (
+                                <Skeleton key={index} className="h-3 w-32 rounded-full" />
+                            ))}
+                        </div>
+                        <div className="rounded-2xl border border-green-100 p-4">
+                            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                                <div className="flex flex-wrap gap-3">
+                                    <Skeleton className="h-10 w-48" />
+                                    <Skeleton className="h-10 w-32" />
+                                    <Skeleton className="h-10 w-36" />
+                                </div>
+                                <div className="flex gap-3">
+                                    <Skeleton className="h-10 w-28" />
+                                    <Skeleton className="h-10 w-28" />
+                                </div>
+                            </div>
+                        </div>
+                        <div className="space-y-3">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div
+                                    key={index}
+                                    className="rounded-2xl border border-green-50 bg-white/80 p-4 shadow-sm"
+                                >
+                                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                        <div className="flex flex-col gap-2">
+                                            <Skeleton className="h-5 w-48" />
+                                            <Skeleton className="h-4 w-32" />
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-3">
+                                            <Skeleton className="h-6 w-16 rounded-full" />
+                                            <Skeleton className="h-8 w-28" />
+                                            <Skeleton className="h-8 w-28" />
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </ScholarLayout>
+    );
+}

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/lib/time";
 import { getServiceOptionsForSpecialization, resolveServiceType } from "@/lib/service-options";
 
+import ScholarAppointmentsLoading from "./loading";
+
 const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
 
 type AppointmentStatus = (typeof STATUS_ORDER)[number];
@@ -146,6 +148,7 @@ function formatTimeWindow(start: string, end: string) {
 export default function ScholarAppointmentsPage() {
     const [appointments, setAppointments] = useState<ScholarAppointment[]>([]);
     const [loading, setLoading] = useState(true);
+    const [initializing, setInitializing] = useState(true);
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState<string>("active");
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -255,6 +258,7 @@ export default function ScholarAppointmentsPage() {
             toast.error("Unable to load appointments");
         } finally {
             setLoading(false);
+            setInitializing(false);
         }
     }, []);
 
@@ -539,6 +543,10 @@ export default function ScholarAppointmentsPage() {
         } finally {
             setCreateSubmitting(false);
         }
+    }
+
+    if (initializing) {
+        return <ScholarAppointmentsLoading />;
     }
 
     return (

--- a/src/app/scholar/patients/loading.tsx
+++ b/src/app/scholar/patients/loading.tsx
@@ -1,0 +1,78 @@
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ScholarPatientsLoading() {
+    return (
+        <ScholarLayout
+            title="Patient intake overview"
+            description="Review student and employee profiles, confirm eligibility, and keep contact details ready for the care team."
+            actions={<Skeleton className="h-10 w-36 rounded-xl" />}
+        >
+            <div className="flex flex-col gap-6">
+                <section className="grid gap-4 md:grid-cols-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <Card
+                            key={index}
+                            className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm"
+                        >
+                            <CardHeader className="space-y-2">
+                                <Skeleton className="h-4 w-2/3" />
+                                <Skeleton className="h-4 w-1/2" />
+                            </CardHeader>
+                            <CardContent>
+                                <Skeleton className="h-10 w-20" />
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                        <div className="space-y-2">
+                            <Skeleton className="h-5 w-40" />
+                            <Skeleton className="h-4 w-64" />
+                        </div>
+                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                            {Array.from({ length: 4 }).map((_, index) => (
+                                <div key={index} className="space-y-2">
+                                    <Skeleton className="h-4 w-24" />
+                                    <Skeleton className="h-10 w-full" />
+                                </div>
+                            ))}
+                        </div>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                            <Skeleton className="h-10 w-full max-w-md" />
+                            <Skeleton className="h-10 w-40" />
+                        </div>
+                        <div className="space-y-3">
+                            {Array.from({ length: 6 }).map((_, index) => (
+                                <div
+                                    key={index}
+                                    className="rounded-2xl border border-green-50 bg-white/80 p-4"
+                                >
+                                    <div className="grid gap-3 md:grid-cols-[1.2fr_1fr_1fr]">
+                                        <div className="space-y-2">
+                                            <Skeleton className="h-5 w-48" />
+                                            <Skeleton className="h-4 w-40" />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Skeleton className="h-4 w-24" />
+                                            <Skeleton className="h-4 w-32" />
+                                        </div>
+                                        <div className="flex flex-wrap items-center justify-end gap-3">
+                                            <Skeleton className="h-8 w-24" />
+                                            <Skeleton className="h-8 w-24" />
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </ScholarLayout>
+    );
+}

--- a/src/app/scholar/patients/page.tsx
+++ b/src/app/scholar/patients/page.tsx
@@ -29,6 +29,8 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { formatManilaDateTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
+import ScholarPatientsLoading from "./loading";
+
 const DEPARTMENT_LABELS: Record<string, string> = {
     EDUCATION: "College of Education",
     ARTS_AND_SCIENCES: "College of Arts and Sciences",
@@ -159,6 +161,7 @@ function formatDOB(value: string | null | undefined) {
 export default function ScholarPatientsPage() {
     const [records, setRecords] = useState<PatientRecord[]>([]);
     const [loading, setLoading] = useState(true);
+    const [initializing, setInitializing] = useState(true);
     const [search, setSearch] = useState("");
     const [typeFilter, setTypeFilter] = useState("all");
     const [statusFilter, setStatusFilter] = useState("active");
@@ -184,6 +187,7 @@ export default function ScholarPatientsPage() {
             toast.error("Unable to load patients");
         } finally {
             setLoading(false);
+            setInitializing(false);
         }
     }, []);
 
@@ -249,6 +253,10 @@ export default function ScholarPatientsPage() {
     function closeDetails() {
         setDetailOpen(false);
         setSelected(null);
+    }
+
+    if (initializing) {
+        return <ScholarPatientsLoading />;
     }
 
     return (


### PR DESCRIPTION
## Summary
- add skeleton-based loading fallbacks for doctor account, appointments, consultation, dispense, and patient registry screens
- implement nurse workspace loading skeletons covering accounts, clinic management, dispensing, inventory, records, and reporting views
- introduce patient and scholar loading skeletons to provide placeholders while profile and scheduling data loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f79ea5631c83338012d5c79038b7a4