### PR TITLE
Improve API resiliency and reduce redundant queries

### DIFF
--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,65 +1,113 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 
-// define minimal relation types manually
-type UserRelation = {
-    user: {
-        user_id: string;
-        role: string;
-        password: string;
-    } | null;
+import { prisma } from "@/lib/prisma";
+import { withDb } from "@/lib/withDb";
+import { Prisma, Role } from "@prisma/client";
+
+type LoginPayload = {
+    role?: string;
+    employee_id?: string;
+    school_id?: string;
+    patient_id?: string;
+    password?: string;
 };
 
-type EmployeeWithUser = {
-    fname: string;
-    lname: string;
-} & UserRelation;
+function normalizeRole(role: unknown): Role | null {
+    const value = typeof role === "string" ? role.toUpperCase() : null;
+    return value && (Object.values(Role) as string[]).includes(value)
+        ? (value as Role)
+        : null;
+}
 
-type StudentWithUser = {
-    fname: string;
-    lname: string;
-} & UserRelation;
+function buildWhereClause(
+    role: Role,
+    payload: LoginPayload
+): Prisma.UsersWhereInput | null {
+    switch (role) {
+        case Role.NURSE:
+        case Role.DOCTOR:
+            if (!payload.employee_id) return null;
+            return {
+                role,
+                employee: { employee_id: payload.employee_id },
+            };
+        case Role.SCHOLAR:
+            if (!payload.school_id) return null;
+            return {
+                role,
+                student: { student_id: payload.school_id },
+            };
+        case Role.PATIENT:
+            if (!payload.patient_id) return null;
+            return {
+                OR: [
+                    { student: { student_id: payload.patient_id } },
+                    { employee: { employee_id: payload.patient_id } },
+                ],
+            };
+        default:
+            return null;
+    }
+}
+
+function deriveFullName(user: {
+    student: { fname: string; lname: string } | null;
+    employee: { fname: string; lname: string } | null;
+}): string {
+    if (user.student) return `${user.student.fname} ${user.student.lname}`;
+    if (user.employee) return `${user.employee.fname} ${user.employee.lname}`;
+    return "";
+}
 
 export async function POST(req: Request) {
     try {
-        const { role, employee_id, school_id, patient_id, password } =
-            await req.json();
+        const body = (await req.json()) as LoginPayload;
+        const role = normalizeRole(body.role);
 
-        let userRecord: EmployeeWithUser | StudentWithUser | null = null;
-
-        if (role === "NURSE" || role === "DOCTOR") {
-            userRecord = (await prisma.employee.findUnique({
-                where: { employee_id },
-                include: { user: true },
-            })) as EmployeeWithUser | null;
-        } else if (role === "SCHOLAR") {
-            userRecord = (await prisma.student.findUnique({
-                where: { student_id: school_id },
-                include: { user: true },
-            })) as StudentWithUser | null;
-        } else if (role === "PATIENT") {
-            userRecord =
-                ((await prisma.student.findUnique({
-                    where: { student_id: patient_id },
-                    include: { user: true },
-                })) as StudentWithUser | null) ||
-                ((await prisma.employee.findUnique({
-                    where: { employee_id: patient_id },
-                    include: { user: true },
-                })) as EmployeeWithUser | null);
+        if (!body.password) {
+            return NextResponse.json(
+                { error: "Password is required" },
+                { status: 400 }
+            );
         }
 
-        // not found
-        if (!userRecord || !userRecord.user) {
+        if (!role) {
+            return NextResponse.json(
+                { error: "Invalid role" },
+                { status: 400 }
+            );
+        }
+
+        const where = buildWhereClause(role, body);
+        if (!where) {
+            return NextResponse.json(
+                { error: "Missing login identifier" },
+                { status: 400 }
+            );
+        }
+
+        const user = await withDb(() =>
+            prisma.users.findFirst({
+                where,
+                select: {
+                    user_id: true,
+                    role: true,
+                    password: true,
+                    student: { select: { fname: true, lname: true, student_id: true } },
+                    employee: { select: { fname: true, lname: true, employee_id: true } },
+                },
+            })
+        );
+
+        if (!user) {
             return NextResponse.json(
                 { error: "Invalid credentials" },
                 { status: 401 }
             );
         }
 
-        // password check
-        const isValid = await bcrypt.compare(password, userRecord.user.password);
+        const isValid = await bcrypt.compare(body.password, user.password);
         if (!isValid) {
             return NextResponse.json(
                 { error: "Invalid credentials" },
@@ -69,9 +117,9 @@ export async function POST(req: Request) {
 
         return NextResponse.json({
             success: true,
-            fullName: `${userRecord.fname} ${userRecord.lname}`,
-            role: userRecord.user.role,
-            user_id: userRecord.user.user_id,
+            fullName: deriveFullName(user),
+            role: user.role,
+            user_id: user.user_id,
         });
     } catch (error) {
         console.error("Login error:", error);

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,15 +1,30 @@
 // src/app/api/users/route.ts
+import crypto from "crypto";
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 
-// mirror Prisma enums manually (since they aren’t exported)
-type Role = "NURSE" | "DOCTOR" | "SCHOLAR" | "PATIENT" | "ADMIN";
-type AccountStatus = "Active" | "Inactive";
+import { prisma } from "@/lib/prisma";
+import { withDb } from "@/lib/withDb";
+import { AccountStatus, Role } from "@prisma/client";
 
-// --------------------
-// Error Handler Helper
-// --------------------
+type CreateUserPayload = {
+    role: string;
+    fname: string;
+    mname?: string | null;
+    lname: string;
+    date_of_birth: string;
+    gender: "Male" | "Female";
+    employee_id?: string | null;
+    student_id?: string | null;
+    school_id?: string | null;
+    patientType?: "student" | "employee" | null;
+};
+
+type UpdateStatusPayload = {
+    userId?: string;
+    status?: string;
+};
+
 function handleError(error: unknown, message = "Server error") {
     if (error instanceof Error) {
         console.error(error.message);
@@ -19,118 +34,175 @@ function handleError(error: unknown, message = "Server error") {
     return NextResponse.json({ error: message }, { status: 500 });
 }
 
-// --------------------
-// Create User (POST)
-// --------------------
+function randomId(prefix: string) {
+    return `${prefix}-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+function normalizeRole(role: unknown): Role | null {
+    const value = typeof role === "string" ? role.toUpperCase() : null;
+    return value && (Object.values(Role) as string[]).includes(value)
+        ? (value as Role)
+        : null;
+}
+
+function parseDate(value: unknown): Date | null {
+    if (!value) return null;
+    const date = new Date(value as string);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normalizeStatus(status: unknown): AccountStatus | null {
+    if (typeof status !== "string") return null;
+    return (Object.values(AccountStatus) as string[]).includes(status)
+        ? (status as AccountStatus)
+        : null;
+}
+
+function resolveUsername(role: Role, ids: Record<string, string | null | undefined>) {
+    switch (role) {
+        case Role.NURSE:
+        case Role.DOCTOR:
+            return ids.employee_id ?? randomId("EMP");
+        case Role.SCHOLAR:
+            return ids.school_id ?? randomId("SCH");
+        case Role.PATIENT:
+            if (ids.patientType === "student") {
+                return ids.student_id ?? randomId("STUD");
+            }
+            return ids.employee_id ?? randomId("EMP");
+        default:
+            return randomId("USER");
+    }
+}
+
 export async function POST(req: Request) {
     try {
-        const body = await req.json();
+        const body = (await req.json()) as CreateUserPayload;
 
-        const role = (body.role as string).toUpperCase() as Role;
-        const fname: string = body.fname;
-        const mname: string | null = body.mname || null;
-        const lname: string = body.lname;
-        const date_of_birth: Date = new Date(body.date_of_birth);
-        const gender: "Male" | "Female" = body.gender;
-
-        const employee_id: string | null = body.employee_id || null;
-        const student_id: string | null = body.student_id || null;
-        const school_id: string | null = body.school_id || null;
-        const patientType: "student" | "employee" | null = body.patientType || null;
-
-        // Generate random password
-        const rawPassword = Math.random().toString(36).slice(-8);
-        const hashedPassword = await bcrypt.hash(rawPassword, 10);
-
-        let username: string | null = null;
-        let createdId: string | null = null;
-
-        if (role === "NURSE" || role === "DOCTOR") {
-            username = employee_id || `EMP-${Date.now()}`;
-            createdId = username;
-        } else if (role === "PATIENT") {
-            if (patientType === "student") {
-                username = student_id || `STUD-${Date.now()}`;
-                createdId = username;
-            } else {
-                username = employee_id || `EMP-${Date.now()}`;
-                createdId = username;
-            }
-        } else if (role === "SCHOLAR") {
-            username = school_id || `SCH-${Date.now()}`;
-            createdId = username;
+        const role = normalizeRole(body.role);
+        if (!role) {
+            return NextResponse.json(
+                { error: "Invalid role supplied" },
+                { status: 400 }
+            );
         }
 
-        // Create User first
-        const user = await prisma.users.create({
-            data: {
-                username: username!,
-                password: hashedPassword,
-                role, // now typed as Role
-            },
+        if (!body.fname || !body.lname) {
+            return NextResponse.json(
+                { error: "First name and last name are required" },
+                { status: 400 }
+            );
+        }
+
+        const birthDate = parseDate(body.date_of_birth);
+        if (!birthDate) {
+            return NextResponse.json(
+                { error: "Invalid date of birth" },
+                { status: 400 }
+            );
+        }
+
+        if (body.gender !== "Male" && body.gender !== "Female") {
+            return NextResponse.json(
+                { error: "Invalid gender value" },
+                { status: 400 }
+            );
+        }
+
+        const username = resolveUsername(role, {
+            employee_id: body.employee_id,
+            school_id: body.school_id,
+            student_id: body.student_id,
+            patientType: body.patientType,
         });
 
-        // Attach profile
-        let finalId = createdId;
+        const rawPassword = crypto.randomBytes(12).toString("base64url").slice(0, 12);
+        const hashedPassword = await bcrypt.hash(rawPassword, 10);
 
-        if (role === "NURSE" || role === "DOCTOR") {
-            const emp = await prisma.employee.create({
-                data: {
-                    user_id: user.user_id,
-                    employee_id: createdId!,
-                    fname,
-                    mname,
-                    lname,
-                    date_of_birth,
-                    gender,
-                },
-            });
-            finalId = emp.employee_id;
-        } else if (role === "PATIENT" && patientType === "student") {
-            const stud = await prisma.student.create({
-                data: {
-                    user_id: user.user_id,
-                    student_id: createdId!,
-                    fname,
-                    mname,
-                    lname,
-                    date_of_birth,
-                    gender,
-                },
-            });
-            finalId = stud.student_id;
-        } else if (role === "PATIENT" && patientType === "employee") {
-            const emp = await prisma.employee.create({
-                data: {
-                    user_id: user.user_id,
-                    employee_id: createdId!,
-                    fname,
-                    mname,
-                    lname,
-                    date_of_birth,
-                    gender,
-                },
-            });
-            finalId = emp.employee_id;
-        } else if (role === "SCHOLAR") {
-            const stud = await prisma.student.create({
-                data: {
-                    user_id: user.user_id,
-                    student_id: createdId!,
-                    fname,
-                    mname,
-                    lname,
-                    date_of_birth,
-                    gender,
-                },
-            });
-            finalId = stud.student_id;
-        }
+        const profileId = await withDb(async () =>
+            prisma.$transaction(async (tx) => {
+                const user = await tx.users.create({
+                    data: {
+                        username,
+                        password: hashedPassword,
+                        role,
+                    },
+                });
+
+                switch (role) {
+                    case Role.NURSE:
+                    case Role.DOCTOR: {
+                        const identifier = body.employee_id ?? username;
+                        const emp = await tx.employee.create({
+                            data: {
+                                user_id: user.user_id,
+                                employee_id: identifier,
+                                fname: body.fname,
+                                mname: body.mname ?? null,
+                                lname: body.lname,
+                                date_of_birth: birthDate,
+                                gender: body.gender,
+                            },
+                        });
+                        return emp.employee_id;
+                    }
+                    case Role.SCHOLAR: {
+                        const identifier = body.school_id ?? username;
+                        const stud = await tx.student.create({
+                            data: {
+                                user_id: user.user_id,
+                                student_id: identifier,
+                                fname: body.fname,
+                                mname: body.mname ?? null,
+                                lname: body.lname,
+                                date_of_birth: birthDate,
+                                gender: body.gender,
+                            },
+                        });
+                        return stud.student_id;
+                    }
+                    case Role.PATIENT: {
+                        const patientType = body.patientType ?? "employee";
+                        if (patientType === "student") {
+                            const identifier = body.student_id ?? username;
+                            const stud = await tx.student.create({
+                                data: {
+                                    user_id: user.user_id,
+                                    student_id: identifier,
+                                    fname: body.fname,
+                                    mname: body.mname ?? null,
+                                    lname: body.lname,
+                                    date_of_birth: birthDate,
+                                    gender: body.gender,
+                                },
+                            });
+                            return stud.student_id;
+                        }
+
+                        const identifier = body.employee_id ?? username;
+                        const emp = await tx.employee.create({
+                            data: {
+                                user_id: user.user_id,
+                                employee_id: identifier,
+                                fname: body.fname,
+                                mname: body.mname ?? null,
+                                lname: body.lname,
+                                date_of_birth: birthDate,
+                                gender: body.gender,
+                            },
+                        });
+                        return emp.employee_id;
+                    }
+                    default:
+                        return user.user_id;
+                }
+            })
+        );
 
         return NextResponse.json(
             {
                 success: true,
-                id: finalId,
+                id: profileId,
                 password: rawPassword,
             },
             { status: 201 }
@@ -140,24 +212,31 @@ export async function POST(req: Request) {
     }
 }
 
-// --------------------
-// Get Users (GET)
-// --------------------
 export async function GET() {
     try {
-        const users = await prisma.users.findMany({
-            include: {
-                student: true,
-                employee: true,
-            },
-            orderBy: { createdAt: "desc" },
-        });
+        const users = await withDb(() =>
+            prisma.users.findMany({
+                select: {
+                    user_id: true,
+                    username: true,
+                    role: true,
+                    status: true,
+                    student: {
+                        select: { fname: true, lname: true },
+                    },
+                    employee: {
+                        select: { fname: true, lname: true },
+                    },
+                },
+                orderBy: { createdAt: "desc" },
+            })
+        );
 
-        const formatted = users.map((u: typeof users[number]) => ({
+        const formatted = users.map((u) => ({
             user_id: u.user_id,
             username: u.username,
-            role: u.role as Role,
-            status: u.status as AccountStatus,
+            role: u.role,
+            status: u.status,
             fullName: u.student
                 ? `${u.student.fname} ${u.student.lname}`
                 : u.employee
@@ -171,20 +250,30 @@ export async function GET() {
     }
 }
 
-// --------------------
-// Update Status (PATCH)
-// --------------------
 export async function PATCH(req: Request) {
     try {
-        const { userId, status } = (await req.json()) as {
-            userId: string;
-            status: AccountStatus;
-        };
+        const body = (await req.json()) as UpdateStatusPayload;
+        if (!body.userId) {
+            return NextResponse.json(
+                { error: "User ID is required" },
+                { status: 400 }
+            );
+        }
 
-        await prisma.users.update({
-            where: { user_id: userId },
-            data: { status }, // typed properly
-        });
+        const status = normalizeStatus(body.status);
+        if (!status) {
+            return NextResponse.json(
+                { error: "Invalid status supplied" },
+                { status: 400 }
+            );
+        }
+
+        await withDb(() =>
+            prisma.users.update({
+                where: { user_id: body.userId! },
+                data: { status },
+            })
+        );
 
         return NextResponse.json({ success: true });
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- wrap user management endpoints with shared Prisma retry helpers and tighten validation for bad input
- create new transactional create flow with secure password generation to reduce race conditions under load
- reuse a single SMTP transporter instance and collapse login lookups into a single query to avoid redundant database calls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f88b7106548333a6c1fe96173b1cbc