### PR TITLE
Improve API concurrency and email delivery pooling

### DIFF
--- a/src/app/api/meta/clinics/route.ts
+++ b/src/app/api/meta/clinics/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { withDb } from "@/lib/withDb";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 
@@ -16,15 +17,17 @@ export async function GET() {
         }
 
         // Fetch clinics
-        const clinics = await prisma.clinic.findMany({
-            select: {
-                clinic_id: true,
-                clinic_name: true,
-                clinic_location: true,
-                clinic_contactno: true,
-            },
-            orderBy: { clinic_name: "asc" },
-        });
+        const clinics = await withDb(() =>
+            prisma.clinic.findMany({
+                select: {
+                    clinic_id: true,
+                    clinic_name: true,
+                    clinic_location: true,
+                    clinic_contactno: true,
+                },
+                orderBy: { clinic_name: "asc" },
+            })
+        );
 
         return NextResponse.json(clinics);
     } catch (err) {


### PR DESCRIPTION
## Summary
- reuse a pooled Nodemailer transporter for all outbound email and extend the helper to support reply-to and text fallbacks
- switch the contact form endpoint to the shared email helper and harden configuration validation
- reduce database round-trips in clinic metadata APIs by using concurrent queries and the withDb guard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f88b7106548333a6c1fe96173b1cbc