### PR TITLE
Allow walk-in dispensing and expand inventory insights

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -175,15 +175,18 @@ model Consultation {
 }
 
 model MedDispense {
-  dispense_id     String          @id @default(dbgenerated("concat('DESP_', (floor((random() * (1000000)::double precision)))::integer)"))
-  med_id          String
-  consultation_id String
-  quantity        Int
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @default(now()) @updatedAt
-  dispenseBatches DispenseBatch[]
-  consultation    Consultation    @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
-  med             MedInventory    @relation(fields: [med_id], references: [med_id], onDelete: Cascade)
+  dispense_id      String          @id @default(dbgenerated("concat('DESP_', (floor((random() * (1000000)::double precision)))::integer)"))
+  med_id           String
+  consultation_id  String?
+  walk_in_name     String?
+  walk_in_contact  String?
+  walk_in_notes    String?
+  quantity         Int
+  createdAt        DateTime        @default(now())
+  updatedAt        DateTime        @default(now()) @updatedAt
+  dispenseBatches  DispenseBatch[]
+  consultation     Consultation?   @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
+  med              MedInventory    @relation(fields: [med_id], references: [med_id], onDelete: Cascade)
 
   @@index([consultation_id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Users {
   medcertPatient      MedCert[]             @relation("PatientCertificates")
   passwordResetTokens PasswordResetToken[]
   student             Student?
+  scholarDispenses    MedDispense[]         @relation("ScholarDispenses")
 
   @@index([role, status])
   @@index([username])
@@ -178,6 +179,7 @@ model MedDispense {
   dispense_id      String          @id @default(dbgenerated("concat('DESP_', (floor((random() * (1000000)::double precision)))::integer)"))
   med_id           String
   consultation_id  String?
+  scholar_user_id  String?
   walk_in_name     String?
   walk_in_contact  String?
   walk_in_notes    String?
@@ -187,8 +189,10 @@ model MedDispense {
   dispenseBatches  DispenseBatch[]
   consultation     Consultation?   @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
   med              MedInventory    @relation(fields: [med_id], references: [med_id], onDelete: Cascade)
+  scholar          Users?          @relation("ScholarDispenses", fields: [scholar_user_id], references: [user_id])
 
   @@index([consultation_id])
+  @@index([scholar_user_id])
 }
 
 model DispenseBatch {

--- a/src/app/api/nurse/dispense/route.ts
+++ b/src/app/api/nurse/dispense/route.ts
@@ -16,18 +16,33 @@ export async function GET() {
 
 export async function POST(req: Request) {
     try {
-        const { med_id, consultation_id, quantity } = await req.json();
-        if (!med_id || !consultation_id || quantity === undefined) {
+        const { med_id, consultation_id, quantity, walkInName, walkInContact, walkInNotes } = await req.json();
+
+        if (!med_id || quantity === undefined) {
             return NextResponse.json(
-                { error: "med_id, consultation_id, and quantity are required" },
+                { error: "med_id and quantity are required" },
+                { status: 400 }
+            );
+        }
+
+        if (!consultation_id && !walkInName) {
+            return NextResponse.json(
+                { error: "Provide a consultation_id or walk-in name" },
                 { status: 400 }
             );
         }
 
         const newDispense = await recordDispense({
             med_id,
-            consultation_id,
+            consultation_id: consultation_id ?? null,
             quantity: Number(quantity),
+            walkIn: walkInName
+                ? {
+                    name: walkInName,
+                    contact: walkInContact ?? null,
+                    notes: walkInNotes ?? null,
+                }
+                : undefined,
         });
         return NextResponse.json(newDispense);
     } catch (err) {

--- a/src/app/api/nurse/dispense/route.ts
+++ b/src/app/api/nurse/dispense/route.ts
@@ -16,7 +16,15 @@ export async function GET() {
 
 export async function POST(req: Request) {
     try {
-        const { med_id, consultation_id, quantity, walkInName, walkInContact, walkInNotes } = await req.json();
+        const {
+            med_id,
+            consultation_id,
+            quantity,
+            walkInName,
+            walkInContact,
+            walkInNotes,
+            scholarUserId,
+        } = await req.json();
 
         if (!med_id || quantity === undefined) {
             return NextResponse.json(
@@ -32,6 +40,13 @@ export async function POST(req: Request) {
             );
         }
 
+        if (!consultation_id && walkInName && !scholarUserId) {
+            return NextResponse.json(
+                { error: "Walk-in dispenses must include the assisting scholar" },
+                { status: 400 }
+            );
+        }
+
         const newDispense = await recordDispense({
             med_id,
             consultation_id: consultation_id ?? null,
@@ -43,6 +58,7 @@ export async function POST(req: Request) {
                     notes: walkInNotes ?? null,
                 }
                 : undefined,
+            scholar_user_id: walkInName ? scholarUserId ?? null : null,
         });
         return NextResponse.json(newDispense);
     } catch (err) {

--- a/src/app/api/scholar/dispense/route.ts
+++ b/src/app/api/scholar/dispense/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { Role } from "@prisma/client";
+
+import { authOptions } from "@/lib/auth";
+import { listDispenses, recordDispense, DispenseError } from "@/lib/dispense";
+import { prisma } from "@/lib/prisma";
+
+function buildMedicineOptions(medicines: Array<{
+    med_id: string;
+    item_name: string;
+    clinic: { clinic_name: string };
+    replenishments: { remaining_qty: number }[];
+}>) {
+    return medicines
+        .map((medicine) => {
+            const remaining = medicine.replenishments.reduce(
+                (total, batch) => total + batch.remaining_qty,
+                0
+            );
+
+            return {
+                med_id: medicine.med_id,
+                item_name: medicine.item_name,
+                clinicName: medicine.clinic.clinic_name,
+                quantity: remaining,
+            };
+        })
+        .filter((entry) => entry.quantity > 0)
+        .sort((a, b) => a.item_name.localeCompare(b.item_name));
+}
+
+export async function GET() {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const scholar = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { user_id: true, role: true },
+        });
+
+        if (!scholar || scholar.role !== Role.SCHOLAR) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const now = new Date();
+
+        const [dispenses, medicines] = await Promise.all([
+            listDispenses(),
+            prisma.medInventory.findMany({
+                include: {
+                    clinic: { select: { clinic_name: true } },
+                    replenishments: {
+                        where: {
+                            remaining_qty: { gt: 0 },
+                            expiry_date: { gte: now },
+                        },
+                    },
+                },
+            }),
+        ]);
+
+        const walkInDispenses = dispenses.filter((d) => !d.consultation);
+
+        return NextResponse.json({
+            dispenses: walkInDispenses,
+            medicines: buildMedicineOptions(medicines),
+        });
+    } catch (err) {
+        console.error("GET /api/scholar/dispense error:", err);
+        return NextResponse.json({ error: "Failed to load walk-in dispenses" }, { status: 500 });
+    }
+}
+
+export async function POST(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const scholar = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { user_id: true, role: true },
+        });
+
+        if (!scholar || scholar.role !== Role.SCHOLAR) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const { med_id, quantity, walkInName, walkInContact, walkInNotes } = await req.json();
+
+        if (!med_id || quantity === undefined || !walkInName) {
+            return NextResponse.json(
+                { error: "med_id, quantity, and walkInName are required" },
+                { status: 400 }
+            );
+        }
+
+        const newDispense = await recordDispense({
+            med_id,
+            quantity: Number(quantity),
+            walkIn: {
+                name: walkInName,
+                contact: walkInContact ?? null,
+                notes: walkInNotes ?? null,
+            },
+            scholar_user_id: scholar.user_id,
+        });
+
+        return NextResponse.json(newDispense);
+    } catch (err) {
+        if (err instanceof DispenseError) {
+            return NextResponse.json({ error: err.message }, { status: err.status });
+        }
+
+        console.error("POST /api/scholar/dispense error:", err);
+        return NextResponse.json({ error: "Failed to record walk-in dispense" }, { status: 500 });
+    }
+}

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -43,7 +43,10 @@ type DispenseRecord = {
         } | null;
         doctor: { username: string } | null;
         nurse: { username: string } | null;
-    };
+    } | null;
+    walk_in_name: string | null;
+    walk_in_contact: string | null;
+    walk_in_notes: string | null;
     dispenseBatches: {
         id: string;
         quantity_used: number;
@@ -368,7 +371,8 @@ export default function DoctorDispensePage() {
                                         <TableHeader className="bg-green-100/70 text-green-700">
                                             <TableRow>
                                                 <TableHead>Clinic</TableHead>
-                                                <TableHead>Patient</TableHead>
+                                                <TableHead>Recipient</TableHead>
+                                                <TableHead>Visit Type</TableHead>
                                                 <TableHead>Medicine</TableHead>
                                                 <TableHead>Quantity</TableHead>
                                                 <TableHead>Doctor</TableHead>
@@ -381,14 +385,38 @@ export default function DoctorDispensePage() {
                                             {dispenses.length > 0 ? (
                                                 dispenses.map((d) => (
                                                     <TableRow key={d.dispense_id} className="hover:bg-green-50">
-                                                        <TableCell>{d.med.clinic.clinic_name}</TableCell>
                                                         <TableCell>
-                                                            {d.consultation.appointment?.patient?.username || "—"}
+                                                            {d.consultation?.appointment?.clinic?.clinic_name ??
+                                                                d.med.clinic.clinic_name}
                                                         </TableCell>
+                                                        <TableCell>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span className="font-medium text-gray-800">
+                                                                    {d.consultation?.appointment?.patient?.username ??
+                                                                        d.walk_in_name ??
+                                                                        "—"}
+                                                                </span>
+                                                                {!d.consultation && (
+                                                                    <>
+                                                                        {d.walk_in_contact ? (
+                                                                            <span className="text-xs text-gray-500">
+                                                                                Contact: {d.walk_in_contact}
+                                                                            </span>
+                                                                        ) : null}
+                                                                        {d.walk_in_notes ? (
+                                                                            <span className="text-xs text-gray-500">
+                                                                                Notes: {d.walk_in_notes}
+                                                                            </span>
+                                                                        ) : null}
+                                                                    </>
+                                                                )}
+                                                            </div>
+                                                        </TableCell>
+                                                        <TableCell>{d.consultation ? "Consultation" : "Walk-in"}</TableCell>
                                                         <TableCell>{d.med.item_name}</TableCell>
                                                         <TableCell>{d.quantity}</TableCell>
-                                                        <TableCell>{d.consultation.doctor?.username || "—"}</TableCell>
-                                                        <TableCell>{d.consultation.nurse?.username || "—"}</TableCell>
+                                                        <TableCell>{d.consultation?.doctor?.username || "—"}</TableCell>
+                                                        <TableCell>{d.consultation?.nurse?.username || "—"}</TableCell>
                                                         <TableCell>{formatDateTime(d.createdAt)}</TableCell>
                                                         <TableCell>
                                                             {d.dispenseBatches.length > 0 ? (
@@ -408,7 +436,7 @@ export default function DoctorDispensePage() {
                                                 ))
                                             ) : (
                                                 <TableRow>
-                                                    <TableCell colSpan={8} className="py-6 text-center text-muted-foreground">
+                                                    <TableCell colSpan={9} className="py-6 text-center text-muted-foreground">
                                                         No dispense records found
                                                     </TableCell>
                                                 </TableRow>

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -47,6 +47,12 @@ type DispenseRecord = {
     walk_in_name: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
+    scholar: {
+        user_id: string;
+        username: string;
+        student: { fname: string | null; mname: string | null; lname: string | null } | null;
+        employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+    } | null;
     dispenseBatches: {
         id: string;
         quantity_used: number;
@@ -97,6 +103,28 @@ function formatDate(value: string | null | undefined) {
         minute: undefined,
     });
     return formatted || "—";
+}
+
+function formatStaffName(
+    staff:
+        | {
+              username: string;
+              student: { fname: string | null; mname: string | null; lname: string | null } | null;
+              employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+          }
+        | null
+) {
+    if (!staff) return "—";
+    const fromStudent = staff.student
+        ? [staff.student.fname, staff.student.mname, staff.student.lname].filter(Boolean).join(" ")
+        : "";
+    if (fromStudent) return fromStudent;
+
+    const fromEmployee = staff.employee
+        ? [staff.employee.fname, staff.employee.mname, staff.employee.lname].filter(Boolean).join(" ")
+        : "";
+
+    return fromEmployee || staff.username || "—";
 }
 
 export default function DoctorDispensePage() {
@@ -369,19 +397,20 @@ export default function DoctorDispensePage() {
                                 <div className="overflow-x-auto">
                                     <Table className="min-w-full text-sm">
                                         <TableHeader className="bg-green-100/70 text-green-700">
-                                            <TableRow>
-                                                <TableHead>Clinic</TableHead>
-                                                <TableHead>Recipient</TableHead>
-                                                <TableHead>Visit Type</TableHead>
-                                                <TableHead>Medicine</TableHead>
-                                                <TableHead>Quantity</TableHead>
-                                                <TableHead>Doctor</TableHead>
-                                                <TableHead>Nurse</TableHead>
-                                                <TableHead>Dispensed At</TableHead>
-                                                <TableHead>Batch Details</TableHead>
-                                            </TableRow>
-                                        </TableHeader>
-                                        <TableBody>
+                                        <TableRow>
+                                            <TableHead>Clinic</TableHead>
+                                            <TableHead>Recipient</TableHead>
+                                            <TableHead>Visit Type</TableHead>
+                                            <TableHead>Medicine</TableHead>
+                                            <TableHead>Quantity</TableHead>
+                                            <TableHead>Doctor</TableHead>
+                                            <TableHead>Nurse</TableHead>
+                                            <TableHead>Scholar</TableHead>
+                                            <TableHead>Dispensed At</TableHead>
+                                            <TableHead>Batch Details</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
                                             {dispenses.length > 0 ? (
                                                 dispenses.map((d) => (
                                                     <TableRow key={d.dispense_id} className="hover:bg-green-50">
@@ -417,6 +446,7 @@ export default function DoctorDispensePage() {
                                                         <TableCell>{d.quantity}</TableCell>
                                                         <TableCell>{d.consultation?.doctor?.username || "—"}</TableCell>
                                                         <TableCell>{d.consultation?.nurse?.username || "—"}</TableCell>
+                                                        <TableCell>{formatStaffName(d.scholar)}</TableCell>
                                                         <TableCell>{formatDateTime(d.createdAt)}</TableCell>
                                                         <TableCell>
                                                             {d.dispenseBatches.length > 0 ? (
@@ -436,9 +466,9 @@ export default function DoctorDispensePage() {
                                                 ))
                                             ) : (
                                                 <TableRow>
-                                                    <TableCell colSpan={9} className="py-6 text-center text-muted-foreground">
-                                                        No dispense records found
-                                                    </TableCell>
+                                                <TableCell colSpan={10} className="py-6 text-center text-muted-foreground">
+                                                    No dispense records found
+                                                </TableCell>
                                                 </TableRow>
                                             )}
                                         </TableBody>

--- a/src/app/nurse/accounts/page.tsx
+++ b/src/app/nurse/accounts/page.tsx
@@ -1050,7 +1050,7 @@ export default function NurseAccountsPage() {
                             </Button>
                         </form>
                         <AlertDialog open={showCreateConfirm} onOpenChange={handleCreateDialogChange}>
-                            <AlertDialogContent className="max-w-lg">
+                            <AlertDialogContent className="w-[95%] max-w-md rounded-3xl border">
                                 <AlertDialogHeader>
                                     <AlertDialogTitle>Confirm new user account</AlertDialogTitle>
                                     <AlertDialogDescription>
@@ -1134,7 +1134,7 @@ export default function NurseAccountsPage() {
                             </AlertDialogContent>
                         </AlertDialog>
                         <Dialog open={showCreateSuccess} onOpenChange={handleCreateSuccessChange}>
-                            <DialogContent className="max-w-sm rounded-3xl border border-green-100/80 bg-white/95">
+                            <DialogContent className="w-[95%] max-w-md rounded-3xl border border-green-100/80 bg-white/95">
                                 <DialogHeader>
                                     <DialogTitle className="flex items-center gap-2 text-green-700">
                                         <CheckCircle2 className="h-5 w-5" /> Account created

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -37,6 +37,11 @@ type Dispense = {
     walk_in_name: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
+    scholar: {
+        username: string;
+        student: { fname: string | null; mname: string | null; lname: string | null } | null;
+        employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+    } | null;
     dispenseBatches: {
         quantity_used: number;
         replenishment: {
@@ -69,6 +74,32 @@ export default function NurseDispensePage() {
         loadDispenses();
     }, []);
 
+    function formatStaffName(
+        staff:
+            | {
+                  username: string;
+                  student: { fname: string | null; mname: string | null; lname: string | null } | null;
+                  employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+              }
+            | null
+    ) {
+        if (!staff) return "—";
+
+        const fromStudent = staff.student
+            ? [staff.student.fname, staff.student.mname, staff.student.lname].filter(Boolean).join(" ")
+            : "";
+
+        if (fromStudent) {
+            return fromStudent;
+        }
+
+        const fromEmployee = staff.employee
+            ? [staff.employee.fname, staff.employee.mname, staff.employee.lname].filter(Boolean).join(" ")
+            : "";
+
+        return fromEmployee || staff.username || "—";
+    }
+
 
 
     if (initializing) {
@@ -99,6 +130,7 @@ export default function NurseDispensePage() {
                                         <TableHead>Quantity</TableHead>
                                         <TableHead>Doctor</TableHead>
                                         <TableHead>Nurse</TableHead>
+                                        <TableHead>Scholar</TableHead>
                                         <TableHead>Dispensed At</TableHead>
                                         <TableHead>Batch Details</TableHead>
                                     </TableRow>
@@ -143,6 +175,7 @@ export default function NurseDispensePage() {
                                                 <TableCell>
                                                     {d.consultation?.nurse?.username || "—"}
                                                 </TableCell>
+                                                <TableCell>{formatStaffName(d.scholar)}</TableCell>
                                                 <TableCell>{formatManilaDateTime(d.createdAt) || "—"}</TableCell>
                                                 <TableCell>
                                                     {d.dispenseBatches.length > 0 ? (
@@ -162,7 +195,7 @@ export default function NurseDispensePage() {
                                         ))
                                     ) : (
                                         <TableRow>
-                                            <TableCell colSpan={9} className="py-6 text-center text-gray-500">
+                                            <TableCell colSpan={10} className="py-6 text-center text-gray-500">
                                                 No dispense records found
                                             </TableCell>
                                         </TableRow>

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { NurseLayout } from "@/components/nurse/nurse-layout";
 
@@ -13,6 +13,7 @@ import {
     TableHeader,
     TableRow,
 } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 import { formatManilaDateTime } from "@/lib/time";
 
 import NurseDispenseLoading from "./loading";
@@ -54,6 +55,32 @@ type Dispense = {
 export default function NurseDispensePage() {
     const [dispenses, setDispenses] = useState<Dispense[]>([]);
     const [initializing, setInitializing] = useState(true);
+
+    const { total, consultations, walkIns, latestDispense, totalQuantity } = useMemo(() => {
+        let walkInCount = 0;
+        let latest: string | null = null;
+        let quantityTotal = 0;
+
+        for (const record of dispenses) {
+            if (!record.consultation) {
+                walkInCount += 1;
+            }
+
+            quantityTotal += Number(record.quantity) || 0;
+
+            if (!latest || new Date(record.createdAt).getTime() > new Date(latest).getTime()) {
+                latest = record.createdAt;
+            }
+        }
+
+        return {
+            total: dispenses.length,
+            consultations: dispenses.length - walkInCount,
+            walkIns: walkInCount,
+            latestDispense: latest,
+            totalQuantity: quantityTotal,
+        };
+    }, [dispenses]);
 
     async function loadDispenses() {
         try {
@@ -112,6 +139,55 @@ export default function NurseDispensePage() {
             description="Monitor dispensed medicines and review batch usage for accurate stock tracking."
         >
             <section className="px-4 sm:px-6 py-6 sm:py-8 w-full max-w-6xl mx-auto flex-1 flex flex-col space-y-8">
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                    <Card className="rounded-3xl border border-green-100/70 bg-gradient-to-br from-green-50 via-white to-green-100/60 shadow-sm">
+                        <CardHeader className="pb-2">
+                            <CardTitle className="text-sm font-medium text-muted-foreground">Total dispenses</CardTitle>
+                        </CardHeader>
+                        <CardContent className="pb-6">
+                            <p className="text-3xl font-bold text-green-700">{total}</p>
+                            <p className="mt-2 text-xs text-muted-foreground">
+                                {totalQuantity > 0 ? `${totalQuantity} total items issued` : "No medicines dispensed yet."}
+                            </p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="pb-2">
+                            <CardTitle className="text-sm font-medium text-muted-foreground">Consultations served</CardTitle>
+                        </CardHeader>
+                        <CardContent className="pb-6">
+                            <p className="text-3xl font-bold text-green-700">{consultations}</p>
+                            <p className="mt-2 text-xs text-muted-foreground">
+                                Dispenses linked to consultations handled by the clinic team.
+                            </p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="pb-2">
+                            <CardTitle className="text-sm font-medium text-muted-foreground">Walk-ins assisted</CardTitle>
+                        </CardHeader>
+                        <CardContent className="pb-6">
+                            <p className="text-3xl font-bold text-green-700">{walkIns}</p>
+                            <p className="mt-2 text-xs text-muted-foreground">
+                                Walk-ins coordinated with scholars for medicine requests.
+                            </p>
+                        </CardContent>
+                    </Card>
+                    <Card className="rounded-3xl border border-green-100/70 bg-white/90 shadow-sm">
+                        <CardHeader className="pb-2">
+                            <CardTitle className="text-sm font-medium text-muted-foreground">Last dispense</CardTitle>
+                        </CardHeader>
+                        <CardContent className="pb-6">
+                            <p className="text-lg font-semibold text-green-700">
+                                {latestDispense ? formatManilaDateTime(latestDispense) : "Awaiting first record"}
+                            </p>
+                            <p className="mt-2 text-xs text-muted-foreground">
+                                Timestamps are adjusted to Manila local time.
+                            </p>
+                        </CardContent>
+                    </Card>
+                </div>
+
                 <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/80 shadow-sm transition hover:-translate-y-[1px] hover:shadow-md">
                     <CardHeader className="border-b border-green-100/60">
                         <CardTitle className="text-xl sm:text-2xl font-bold text-green-600">
@@ -121,18 +197,18 @@ export default function NurseDispensePage() {
                     <CardContent className="flex-1 flex flex-col pt-4">
                         <div className="overflow-x-auto w-full">
                             <Table className="min-w-full text-sm">
-                                <TableHeader>
+                                <TableHeader className="bg-green-50 text-green-700">
                                     <TableRow>
-                                        <TableHead>Clinic</TableHead>
-                                        <TableHead>Recipient</TableHead>
-                                        <TableHead>Visit Type</TableHead>
-                                        <TableHead>Medicine</TableHead>
-                                        <TableHead>Quantity</TableHead>
-                                        <TableHead>Doctor</TableHead>
-                                        <TableHead>Nurse</TableHead>
-                                        <TableHead>Scholar</TableHead>
-                                        <TableHead>Dispensed At</TableHead>
-                                        <TableHead>Batch Details</TableHead>
+                                        <TableHead className="whitespace-nowrap">Clinic</TableHead>
+                                        <TableHead className="whitespace-nowrap">Recipient</TableHead>
+                                        <TableHead className="whitespace-nowrap">Visit Type</TableHead>
+                                        <TableHead className="whitespace-nowrap">Medicine</TableHead>
+                                        <TableHead className="whitespace-nowrap">Quantity</TableHead>
+                                        <TableHead className="whitespace-nowrap">Doctor</TableHead>
+                                        <TableHead className="whitespace-nowrap">Nurse</TableHead>
+                                        <TableHead className="whitespace-nowrap">Scholar</TableHead>
+                                        <TableHead className="whitespace-nowrap">Dispensed At</TableHead>
+                                        <TableHead className="whitespace-nowrap">Batch Details</TableHead>
                                     </TableRow>
                                 </TableHeader>
                                 <TableBody>
@@ -140,12 +216,17 @@ export default function NurseDispensePage() {
                                         dispenses.map((d) => (
                                             <TableRow key={d.dispense_id} className="transition hover:bg-green-50">
                                                 <TableCell>
-                                                    {d.consultation?.appointment?.clinic?.clinic_name ??
-                                                        d.med.clinic.clinic_name}
+                                                    <Badge
+                                                        className="rounded-full border border-green-200 bg-green-50 px-3 py-1 text-[0.7rem] font-semibold text-green-700"
+                                                        variant="outline"
+                                                    >
+                                                        {d.consultation?.appointment?.clinic?.clinic_name ??
+                                                            d.med.clinic.clinic_name}
+                                                    </Badge>
                                                 </TableCell>
                                                 <TableCell>
                                                     <div className="flex flex-col gap-1">
-                                                        <span className="font-medium text-gray-800">
+                                                        <span className="font-semibold text-gray-900">
                                                             {d.consultation?.appointment?.patient?.username ??
                                                                 d.walk_in_name ??
                                                                 "—"}
@@ -153,12 +234,12 @@ export default function NurseDispensePage() {
                                                         {!d.consultation && (
                                                             <>
                                                                 {d.walk_in_contact ? (
-                                                                    <span className="text-xs text-gray-500">
+                                                                    <span className="text-xs text-muted-foreground">
                                                                         Contact: {d.walk_in_contact}
                                                                     </span>
                                                                 ) : null}
                                                                 {d.walk_in_notes ? (
-                                                                    <span className="text-xs text-gray-500">
+                                                                    <span className="text-xs text-muted-foreground">
                                                                         Notes: {d.walk_in_notes}
                                                                     </span>
                                                                 ) : null}
@@ -166,24 +247,67 @@ export default function NurseDispensePage() {
                                                         )}
                                                     </div>
                                                 </TableCell>
-                                                <TableCell>{d.consultation ? "Consultation" : "Walk-in"}</TableCell>
-                                                <TableCell>{d.med.item_name}</TableCell>
-                                                <TableCell>{d.quantity}</TableCell>
                                                 <TableCell>
-                                                    {d.consultation?.doctor?.username || "—"}
+                                                    <Badge
+                                                        variant="outline"
+                                                        className={
+                                                            d.consultation
+                                                                ? "rounded-full border-green-200 bg-green-100/80 px-3 py-1 text-[0.7rem] font-semibold text-green-700"
+                                                                : "rounded-full border-amber-200 bg-amber-50 px-3 py-1 text-[0.7rem] font-semibold text-amber-600"
+                                                        }
+                                                    >
+                                                        {d.consultation ? "Consultation" : "Walk-in"}
+                                                    </Badge>
                                                 </TableCell>
                                                 <TableCell>
-                                                    {d.consultation?.nurse?.username || "—"}
+                                                    <div className="flex flex-col">
+                                                        <span className="font-medium text-gray-900">{d.med.item_name}</span>
+                                                        <span className="text-xs text-muted-foreground">
+                                                            {d.med.clinic.clinic_name}
+                                                        </span>
+                                                    </div>
                                                 </TableCell>
-                                                <TableCell>{formatStaffName(d.scholar)}</TableCell>
-                                                <TableCell>{formatManilaDateTime(d.createdAt) || "—"}</TableCell>
+                                                <TableCell>
+                                                    <Badge className="rounded-full bg-green-600/10 px-3 py-1 text-[0.75rem] font-semibold text-green-700">
+                                                        ×{d.quantity}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <span className="text-sm font-medium text-gray-800">
+                                                        {d.consultation?.doctor?.username || "—"}
+                                                    </span>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <span className="text-sm font-medium text-gray-800">
+                                                        {d.consultation?.nurse?.username || "—"}
+                                                    </span>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <span className="text-sm font-medium text-gray-800">
+                                                        {formatStaffName(d.scholar)}
+                                                    </span>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <span className="text-sm text-muted-foreground">
+                                                        {formatManilaDateTime(d.createdAt) || "—"}
+                                                    </span>
+                                                </TableCell>
                                                 <TableCell>
                                                     {d.dispenseBatches.length > 0 ? (
-                                                        <ul className="space-y-1 text-sm text-gray-700">
+                                                        <ul className="space-y-2 text-xs text-muted-foreground">
                                                             {d.dispenseBatches.map((batch, i) => (
-                                                                <li key={i}>
-                                                                    <span className="font-medium">{batch.quantity_used}</span>{" "}
-                                                                    used from batch (Expiry: {new Date(batch.replenishment.expiry_date).toLocaleDateString()}, Received: {new Date(batch.replenishment.date_received).toLocaleDateString()})
+                                                                <li
+                                                                    key={i}
+                                                                    className="rounded-2xl border border-green-100 bg-green-50/60 px-3 py-2 shadow-sm"
+                                                                >
+                                                                    <div className="flex items-center justify-between text-[0.7rem] font-semibold text-green-700">
+                                                                        <span>Batch usage</span>
+                                                                        <span>−{batch.quantity_used}</span>
+                                                                    </div>
+                                                                    <div className="mt-1 space-y-1 text-[0.65rem] text-muted-foreground">
+                                                                        <p>Expiry: {new Date(batch.replenishment.expiry_date).toLocaleDateString()}</p>
+                                                                        <p>Received: {new Date(batch.replenishment.date_received).toLocaleDateString()}</p>
+                                                                    </div>
                                                                 </li>
                                                             ))}
                                                         </ul>

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -28,12 +28,15 @@ type Dispense = {
     };
     consultation: {
         appointment: {
-            patient: { username: string };
-            clinic: { clinic_name: string };
-        };
+            patient: { username: string } | null;
+            clinic: { clinic_name: string } | null;
+        } | null;
         doctor: { username: string } | null;
         nurse: { username: string } | null;
-    };
+    } | null;
+    walk_in_name: string | null;
+    walk_in_contact: string | null;
+    walk_in_notes: string | null;
     dispenseBatches: {
         quantity_used: number;
         replenishment: {
@@ -90,7 +93,8 @@ export default function NurseDispensePage() {
                                 <TableHeader>
                                     <TableRow>
                                         <TableHead>Clinic</TableHead>
-                                        <TableHead>Patient</TableHead>
+                                        <TableHead>Recipient</TableHead>
+                                        <TableHead>Visit Type</TableHead>
                                         <TableHead>Medicine</TableHead>
                                         <TableHead>Quantity</TableHead>
                                         <TableHead>Doctor</TableHead>
@@ -103,15 +107,41 @@ export default function NurseDispensePage() {
                                     {dispenses.length > 0 ? (
                                         dispenses.map((d) => (
                                             <TableRow key={d.dispense_id} className="transition hover:bg-green-50">
-                                                <TableCell>{d.med.clinic.clinic_name}</TableCell>
-                                                <TableCell>{d.consultation.appointment.patient.username}</TableCell>
+                                                <TableCell>
+                                                    {d.consultation?.appointment?.clinic?.clinic_name ??
+                                                        d.med.clinic.clinic_name}
+                                                </TableCell>
+                                                <TableCell>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span className="font-medium text-gray-800">
+                                                            {d.consultation?.appointment?.patient?.username ??
+                                                                d.walk_in_name ??
+                                                                "—"}
+                                                        </span>
+                                                        {!d.consultation && (
+                                                            <>
+                                                                {d.walk_in_contact ? (
+                                                                    <span className="text-xs text-gray-500">
+                                                                        Contact: {d.walk_in_contact}
+                                                                    </span>
+                                                                ) : null}
+                                                                {d.walk_in_notes ? (
+                                                                    <span className="text-xs text-gray-500">
+                                                                        Notes: {d.walk_in_notes}
+                                                                    </span>
+                                                                ) : null}
+                                                            </>
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>{d.consultation ? "Consultation" : "Walk-in"}</TableCell>
                                                 <TableCell>{d.med.item_name}</TableCell>
                                                 <TableCell>{d.quantity}</TableCell>
                                                 <TableCell>
-                                                    {d.consultation.doctor?.username || "—"}
+                                                    {d.consultation?.doctor?.username || "—"}
                                                 </TableCell>
                                                 <TableCell>
-                                                    {d.consultation.nurse?.username || "—"}
+                                                    {d.consultation?.nurse?.username || "—"}
                                                 </TableCell>
                                                 <TableCell>{formatManilaDateTime(d.createdAt) || "—"}</TableCell>
                                                 <TableCell>
@@ -132,7 +162,7 @@ export default function NurseDispensePage() {
                                         ))
                                     ) : (
                                         <TableRow>
-                                            <TableCell colSpan={8} className="py-6 text-center text-gray-500">
+                                            <TableCell colSpan={9} className="py-6 text-center text-gray-500">
                                                 No dispense records found
                                             </TableCell>
                                         </TableRow>

--- a/src/app/nurse/inventory/page.tsx
+++ b/src/app/nurse/inventory/page.tsx
@@ -65,6 +65,8 @@ type InventoryItem = {
     clinic: { clinic_name: string; clinic_location?: string };
     replenishments: { expiry_date: string; remaining_qty: number; status: string; daysLeft: number }[];
     archivedReplenishments: ArchivedReplenishment[];
+    totalDispensed: number;
+    walkInDispensed: number;
 };
 
 type Clinic = {
@@ -397,6 +399,8 @@ export default function NurseInventoryPage() {
                                             <TableHead>Item Type</TableHead>
                                             <TableHead>Strength</TableHead>
                                             <TableHead>Total Quantity</TableHead>
+                                            <TableHead>Dispensed (All Time)</TableHead>
+                                            <TableHead>Walk-in Dispensed</TableHead>
                                             <TableHead>Expiry Batches</TableHead>
                                         </TableRow>
                                     </TableHeader>
@@ -412,6 +416,8 @@ export default function NurseInventoryPage() {
                                                         {item.strength ? `${item.strength} ${item.unit || ""}` : "-"}
                                                     </TableCell>
                                                     <TableCell>{item.quantity}</TableCell>
+                                                    <TableCell>{item.totalDispensed}</TableCell>
+                                                    <TableCell>{item.walkInDispensed}</TableCell>
                                                     <TableCell>
                                                         <div className="space-y-1">
                                                             {item.replenishments.length > 0 ? (
@@ -454,7 +460,7 @@ export default function NurseInventoryPage() {
                                             ))
                                         ) : (
                                             <TableRow>
-                                                <TableCell colSpan={7} className="text-center text-gray-500 py-6">
+                                                <TableCell colSpan={9} className="text-center text-gray-500 py-6">
                                                     No items found
                                                 </TableCell>
                                             </TableRow>

--- a/src/app/scholar/dispense/loading.tsx
+++ b/src/app/scholar/dispense/loading.tsx
@@ -1,0 +1,61 @@
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ScholarDispenseLoading() {
+    return (
+        <ScholarLayout
+            title="Walk-in dispensing"
+            description="Log medicines provided to community walk-ins and highlight the scholars assisting them."
+            actions={<Skeleton className="h-10 w-28 rounded-xl" />}
+        >
+            <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-10 pt-6 sm:px-6">
+                <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                    <CardHeader className="space-y-2 border-b border-green-100/70">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="grid gap-4 sm:grid-cols-2">
+                        {Array.from({ length: 5 }).map((_, index) => (
+                            <div key={index} className="space-y-2">
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-10 w-full rounded-xl" />
+                            </div>
+                        ))}
+                        <div className="sm:col-span-2 flex justify-end">
+                            <Skeleton className="h-10 w-44 rounded-xl" />
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-green-100/70 bg-white/90 shadow-sm">
+                    <CardHeader className="space-y-2 border-b border-green-100/70">
+                        <Skeleton className="h-5 w-1/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {Array.from({ length: 4 }).map((_, index) => (
+                            <div
+                                key={index}
+                                className="rounded-2xl border border-green-50 bg-white/80 p-4 shadow-sm"
+                            >
+                                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                    <div className="flex flex-col gap-2">
+                                        <Skeleton className="h-5 w-40" />
+                                        <Skeleton className="h-4 w-28" />
+                                        <Skeleton className="h-4 w-32" />
+                                    </div>
+                                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+                                        <Skeleton className="h-4 w-32" />
+                                        <Skeleton className="h-4 w-16" />
+                                        <Skeleton className="h-4 w-24" />
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+            </section>
+        </ScholarLayout>
+    );
+}

--- a/src/app/scholar/dispense/page.tsx
+++ b/src/app/scholar/dispense/page.tsx
@@ -64,10 +64,10 @@ type DispenseResponse = {
 function formatScholarName(
     scholar:
         | {
-              username: string;
-              student: { fname: string | null; mname: string | null; lname: string | null } | null;
-              employee: { fname: string | null; mname: string | null; lname: string | null } | null;
-          }
+            username: string;
+            student: { fname: string | null; mname: string | null; lname: string | null } | null;
+            employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+        }
         | null
 ) {
     if (!scholar) return "—";
@@ -235,7 +235,7 @@ export default function ScholarDispensePage() {
         >
             <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-10 pt-6 sm:px-6">
                 <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                    <Card className="rounded-3xl border border-green-100/70 bg-gradient-to-br from-green-50 via-white to-green-100/60 shadow-sm">
+                    <Card className="rounded-3xl border border-green-100/70 bg-linear-to-br from-green-50 via-white to-green-100/60 shadow-sm">
                         <CardHeader className="pb-2">
                             <CardTitle className="text-sm font-medium text-muted-foreground">Walk-ins recorded</CardTitle>
                         </CardHeader>
@@ -311,13 +311,13 @@ export default function ScholarDispensePage() {
 
                             <div className="space-y-2 sm:col-span-2">
                                 <Label className="font-medium text-green-700">Medicine</Label>
-                                    <Select
-                                        value={form.med_id}
-                                        onValueChange={(value) => setForm((prev) => ({ ...prev, med_id: value }))}
-                                    >
-                                        <SelectTrigger className="w-full rounded-xl border border-green-100/80 bg-white/80">
-                                            <SelectValue placeholder="Select medicine" />
-                                        </SelectTrigger>
+                                <Select
+                                    value={form.med_id}
+                                    onValueChange={(value) => setForm((prev) => ({ ...prev, med_id: value }))}
+                                >
+                                    <SelectTrigger className="w-full rounded-xl border border-green-100/80 bg-white/80">
+                                        <SelectValue placeholder="Select medicine" />
+                                    </SelectTrigger>
                                     <SelectContent>
                                         {medicines.length > 0 ? (
                                             medicines.map((medicine) => (
@@ -339,23 +339,23 @@ export default function ScholarDispensePage() {
                                 </Select>
                             </div>
 
-                                <div className="space-y-2">
-                                    <Label className="font-medium text-green-700">Quantity</Label>
-                                    <Input
-                                        type="number"
-                                        min={1}
-                                        value={form.quantity}
-                                        onChange={(event) => setForm((prev) => ({ ...prev, quantity: event.target.value }))}
-                                        placeholder="Enter quantity"
-                                        required
-                                        className="rounded-xl border border-green-100/80 bg-white/80 focus-visible:ring-green-500"
-                                    />
-                                    {selectedMedicine ? (
-                                        <p className="text-xs text-muted-foreground">
-                                            Available stock: {selectedMedicine.quantity}
-                                        </p>
-                                    ) : null}
-                                </div>
+                            <div className="space-y-2">
+                                <Label className="font-medium text-green-700">Quantity</Label>
+                                <Input
+                                    type="number"
+                                    min={1}
+                                    value={form.quantity}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, quantity: event.target.value }))}
+                                    placeholder="Enter quantity"
+                                    required
+                                    className="rounded-xl border border-green-100/80 bg-white/80 focus-visible:ring-green-500"
+                                />
+                                {selectedMedicine ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        Available stock: {selectedMedicine.quantity}
+                                    </p>
+                                ) : null}
+                            </div>
 
                             <div className="space-y-2 sm:col-span-2">
                                 <Label className="font-medium text-green-700">Notes</Label>

--- a/src/app/scholar/dispense/page.tsx
+++ b/src/app/scholar/dispense/page.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import ScholarLayout from "@/components/scholar/scholar-layout";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { formatManilaDateTime } from "@/lib/time";
+
+import ScholarDispenseLoading from "./loading";
+
+type DispenseRecord = {
+    dispense_id: string;
+    quantity: number;
+    createdAt: string;
+    med: {
+        item_name: string;
+        clinic: { clinic_name: string };
+    };
+    walk_in_name: string | null;
+    walk_in_contact: string | null;
+    walk_in_notes: string | null;
+    scholar: {
+        username: string;
+        student: { fname: string | null; mname: string | null; lname: string | null } | null;
+        employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+    } | null;
+};
+
+type MedicineOption = {
+    med_id: string;
+    item_name: string;
+    clinicName: string;
+    quantity: number;
+};
+
+type DispenseResponse = {
+    dispenses: DispenseRecord[];
+    medicines: MedicineOption[];
+    error?: string;
+};
+
+function formatScholarName(
+    scholar:
+        | {
+              username: string;
+              student: { fname: string | null; mname: string | null; lname: string | null } | null;
+              employee: { fname: string | null; mname: string | null; lname: string | null } | null;
+          }
+        | null
+) {
+    if (!scholar) return "—";
+
+    const fromStudent = scholar.student
+        ? [scholar.student.fname, scholar.student.mname, scholar.student.lname].filter(Boolean).join(" ")
+        : "";
+
+    if (fromStudent) return fromStudent;
+
+    const fromEmployee = scholar.employee
+        ? [scholar.employee.fname, scholar.employee.mname, scholar.employee.lname].filter(Boolean).join(" ")
+        : "";
+
+    return fromEmployee || scholar.username || "—";
+}
+
+export default function ScholarDispensePage() {
+    const [dispenses, setDispenses] = useState<DispenseRecord[]>([]);
+    const [medicines, setMedicines] = useState<MedicineOption[]>([]);
+    const [initializing, setInitializing] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [form, setForm] = useState({
+        name: "",
+        contact: "",
+        notes: "",
+        med_id: "",
+        quantity: "",
+    });
+
+    const selectedMedicine = useMemo(
+        () => medicines.find((medicine) => medicine.med_id === form.med_id) ?? null,
+        [form.med_id, medicines]
+    );
+
+    async function loadData() {
+        try {
+            setLoading(true);
+            const res = await fetch("/api/scholar/dispense", { cache: "no-store" });
+            const data: DispenseResponse = await res.json();
+
+            if (!res.ok) {
+                toast.error(data?.error || "Failed to load walk-in dispenses");
+                return;
+            }
+
+            setDispenses(Array.isArray(data.dispenses) ? data.dispenses : []);
+            setMedicines(Array.isArray(data.medicines) ? data.medicines : []);
+        } catch (error) {
+            console.error(error);
+            toast.error("Failed to load walk-in dispenses");
+        } finally {
+            setInitializing(false);
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        loadData();
+    }, []);
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (!form.name.trim() || !form.med_id || !form.quantity) {
+            toast.error("Please complete the required fields");
+            return;
+        }
+
+        const quantity = Number(form.quantity);
+        if (!Number.isFinite(quantity) || quantity <= 0) {
+            toast.error("Quantity must be a positive number");
+            return;
+        }
+
+        if (selectedMedicine && quantity > selectedMedicine.quantity) {
+            toast.error("Quantity exceeds available stock");
+            return;
+        }
+
+        try {
+            setSubmitting(true);
+            const res = await fetch("/api/scholar/dispense", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    med_id: form.med_id,
+                    quantity,
+                    walkInName: form.name.trim(),
+                    walkInContact: form.contact.trim() || null,
+                    walkInNotes: form.notes.trim() || null,
+                }),
+            });
+
+            const data = await res.json();
+            if (!res.ok) {
+                toast.error(data?.error || "Failed to record walk-in dispense");
+                return;
+            }
+
+            setDispenses((previous) => [data as DispenseRecord, ...previous]);
+            setMedicines((previous) =>
+                previous.map((medicine) =>
+                    medicine.med_id === form.med_id
+                        ? { ...medicine, quantity: Math.max(0, medicine.quantity - quantity) }
+                        : medicine
+                )
+            );
+            setForm({ name: "", contact: "", notes: "", med_id: "", quantity: "" });
+            toast.success("Walk-in dispense recorded");
+        } catch (error) {
+            console.error(error);
+            toast.error("Failed to record walk-in dispense");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (initializing) {
+        return <ScholarDispenseLoading />;
+    }
+
+    return (
+        <ScholarLayout
+            title="Walk-in dispensing"
+            description="Log medicines provided to community walk-ins and highlight the scholars assisting them."
+            actions={
+                <Button
+                    className="rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
+                    onClick={() => loadData()}
+                    disabled={loading}
+                >
+                    {loading ? (
+                        <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Refreshing
+                        </>
+                    ) : (
+                        "Refresh"
+                    )}
+                </Button>
+            }
+        >
+            <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-10 pt-6 sm:px-6">
+                <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
+                    <CardHeader className="space-y-1 border-b border-green-100/70">
+                        <CardTitle className="text-lg font-semibold text-green-700 sm:text-xl">
+                            Record a walk-in dispense
+                        </CardTitle>
+                        <p className="text-sm text-muted-foreground">
+                            Capture walk-in details and medicine usage to keep the stock ledger balanced.
+                        </p>
+                    </CardHeader>
+                    <CardContent className="pt-6">
+                        <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
+                            <div className="space-y-2">
+                                <Label className="font-medium text-green-700">Walk-in name</Label>
+                                <Input
+                                    value={form.name}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                                    placeholder="Enter walk-in's name"
+                                    required
+                                />
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label className="font-medium text-green-700">Contact number</Label>
+                                <Input
+                                    value={form.contact}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, contact: event.target.value }))}
+                                    placeholder="Optional contact information"
+                                />
+                            </div>
+
+                            <div className="space-y-2 sm:col-span-2">
+                                <Label className="font-medium text-green-700">Medicine</Label>
+                                <Select
+                                    value={form.med_id}
+                                    onValueChange={(value) => setForm((prev) => ({ ...prev, med_id: value }))}
+                                >
+                                    <SelectTrigger className="w-full">
+                                        <SelectValue placeholder="Select medicine" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {medicines.length > 0 ? (
+                                            medicines.map((medicine) => (
+                                                <SelectItem key={medicine.med_id} value={medicine.med_id}>
+                                                    <div className="flex flex-col text-left">
+                                                        <span className="font-medium">{medicine.item_name}</span>
+                                                        <span className="text-xs text-muted-foreground">
+                                                            {medicine.clinicName} · Stock: {medicine.quantity}
+                                                        </span>
+                                                    </div>
+                                                </SelectItem>
+                                            ))
+                                        ) : (
+                                            <SelectItem value="no_medicine" disabled>
+                                                No medicines available
+                                            </SelectItem>
+                                        )}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label className="font-medium text-green-700">Quantity</Label>
+                                <Input
+                                    type="number"
+                                    min={1}
+                                    value={form.quantity}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, quantity: event.target.value }))}
+                                    placeholder="Enter quantity"
+                                    required
+                                />
+                                {selectedMedicine ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        Available stock: {selectedMedicine.quantity}
+                                    </p>
+                                ) : null}
+                            </div>
+
+                            <div className="space-y-2 sm:col-span-2">
+                                <Label className="font-medium text-green-700">Notes</Label>
+                                <Textarea
+                                    value={form.notes}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+                                    rows={3}
+                                    placeholder="Optional context about the request"
+                                />
+                            </div>
+
+                            <div className="sm:col-span-2 flex justify-end">
+                                <Button
+                                    type="submit"
+                                    className="rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
+                                    disabled={submitting}
+                                >
+                                    {submitting ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving
+                                        </>
+                                    ) : (
+                                        "Record walk-in dispense"
+                                    )}
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border border-green-100/70 bg-white/85 shadow-sm">
+                    <CardHeader className="border-b border-green-100/70">
+                        <CardTitle className="text-lg font-semibold text-green-700 sm:text-xl">
+                            Recent walk-in dispenses
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="pt-4">
+                        {dispenses.length > 0 ? (
+                            <div className="overflow-x-auto">
+                                <Table className="min-w-full text-sm">
+                                    <TableHeader className="bg-green-100/70 text-green-700">
+                                        <TableRow>
+                                            <TableHead>Clinic</TableHead>
+                                            <TableHead>Walk-in</TableHead>
+                                            <TableHead>Medicine</TableHead>
+                                            <TableHead>Quantity</TableHead>
+                                            <TableHead>Scholar</TableHead>
+                                            <TableHead>Dispensed At</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {dispenses.map((dispense) => (
+                                            <TableRow key={dispense.dispense_id} className="hover:bg-green-50">
+                                                <TableCell>{dispense.med.clinic.clinic_name}</TableCell>
+                                                <TableCell>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span className="font-medium text-gray-800">
+                                                            {dispense.walk_in_name ?? "—"}
+                                                        </span>
+                                                        {dispense.walk_in_contact ? (
+                                                            <span className="text-xs text-gray-500">
+                                                                Contact: {dispense.walk_in_contact}
+                                                            </span>
+                                                        ) : null}
+                                                        {dispense.walk_in_notes ? (
+                                                            <span className="text-xs text-gray-500">
+                                                                Notes: {dispense.walk_in_notes}
+                                                            </span>
+                                                        ) : null}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>{dispense.med.item_name}</TableCell>
+                                                <TableCell>{dispense.quantity}</TableCell>
+                                                <TableCell>{formatScholarName(dispense.scholar)}</TableCell>
+                                                <TableCell>{formatManilaDateTime(dispense.createdAt) || "—"}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        ) : (
+                            <div className="py-10 text-center text-sm text-muted-foreground">
+                                No walk-in dispenses recorded yet.
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            </section>
+        </ScholarLayout>
+    );
+}

--- a/src/app/scholar/page.tsx
+++ b/src/app/scholar/page.tsx
@@ -84,7 +84,7 @@ export default function ScholarDashboardPage() {
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 p-6 shadow-sm">
+            <section className="rounded-3xl border border-green-100/70 bg-linear-to-r from-green-100/70 via-white to-green-50/80 p-6 shadow-sm">
                 <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
                     <div className="space-y-3">
                         <p className="text-sm font-semibold uppercase tracking-[0.2em] text-green-500">Welcome back</p>
@@ -125,7 +125,7 @@ export default function ScholarDashboardPage() {
                         </CardContent>
                     </Card>
                 ))}
-                <Card className="h-full rounded-3xl border-green-100/70 bg-gradient-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-md">
+                <Card className="h-full rounded-3xl border-green-100/70 bg-linear-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-md">
                     <CardHeader>
                         <CardTitle className="flex items-center gap-3 text-lg">
                             <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">

--- a/src/components/scholar/scholar-layout.tsx
+++ b/src/components/scholar/scholar-layout.tsx
@@ -13,7 +13,7 @@ const NAV_ITEMS = [
     { href: "/scholar/account", label: "Account", icon: User },
     { href: "/scholar/appointments", label: "Appointments", icon: CalendarDays },
     { href: "/scholar/patients", label: "Patients", icon: Search },
-    { href: "/scholar/dispense", label: "Walk-in dispense", icon: Pill },
+    { href: "/scholar/dispense", label: "Dispense", icon: Pill },
 ] as const satisfies readonly PanelNavItem[];
 
 export type ScholarLayoutProps = PanelLayoutContentProps;

--- a/src/components/scholar/scholar-layout.tsx
+++ b/src/components/scholar/scholar-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CalendarDays, Home, Search, User } from "lucide-react";
+import { CalendarDays, Home, Pill, Search, User } from "lucide-react";
 
 import {
     PanelLayout,
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
     { href: "/scholar/account", label: "Account", icon: User },
     { href: "/scholar/appointments", label: "Appointments", icon: CalendarDays },
     { href: "/scholar/patients", label: "Patients", icon: Search },
+    { href: "/scholar/dispense", label: "Walk-in dispense", icon: Pill },
 ] as const satisfies readonly PanelNavItem[];
 
 export type ScholarLayoutProps = PanelLayoutContentProps;


### PR DESCRIPTION
## Summary
- allow medicine dispensing without consultations by storing optional walk-in details
- surface visit type and walk-in information in nurse and doctor dispense logs
- add aggregate dispense totals to the inventory API and display walk-in usage on the stock table

## Testing
- npm run lint