### PR TITLE
Enhance doctor duty hour scheduling and archiving

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,6 +126,7 @@ model DoctorAvailability {
   available_date      DateTime
   available_timestart DateTime
   available_timeend   DateTime
+  archivedAt          DateTime?
   clinic              Clinic   @relation(fields: [clinic_id], references: [clinic_id], onDelete: Cascade)
   doctor              Users    @relation(fields: [doctor_user_id], references: [user_id], onDelete: Cascade)
 

--- a/src/app/api/doctor/appointments/[id]/route.ts
+++ b/src/app/api/doctor/appointments/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { archiveExpiredDutyHours } from "@/lib/duty-hours";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { AppointmentStatus } from "@prisma/client";
@@ -266,10 +267,13 @@ export async function PATCH(
             const dayStart = startOfManilaDay(newDate);
             const dayEnd = endOfManilaDay(newDate);
 
+            await archiveExpiredDutyHours({ doctor_user_id: appointment.doctor_user_id });
+
             const availabilities = await prisma.doctorAvailability.findMany({
                 where: {
                     doctor_user_id: appointment.doctor_user_id,
                     clinic_id: appointment.clinic_id,
+                    archivedAt: null,
                     available_date: { gte: dayStart, lte: dayEnd },
                 },
             });

--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -3,16 +3,33 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { DoctorSpecialization, Prisma, Role } from "@prisma/client";
+import { archiveExpiredDutyHours } from "@/lib/duty-hours";
 import {
     buildManilaDate,
     endOfManilaDay,
     formatManilaISODate,
     getManilaWeekday,
     manilaNow,
+    rangesOverlap,
     startOfManilaDay,
+    toManilaTimeString,
 } from "@/lib/time";
-const DEFAULT_WEEKS = 4;
-const MAX_WEEKS = 12;
+
+function getCurrentMonthStart(): Date {
+    const now = manilaNow();
+    const today = formatManilaISODate(now);
+    const [year, month] = today.split("-");
+    const monthStartDate = `${year}-${month}-01`;
+    return startOfManilaDay(monthStartDate);
+}
+
+function getGenerationEndExclusive(start: Date): Date {
+    const limit = new Date(start);
+    limit.setUTCFullYear(limit.getUTCFullYear() + 1);
+    return limit;
+}
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 /**
  * GET — Fetch all consultation slots for logged-in doctor
@@ -32,8 +49,10 @@ export async function GET() {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
+        await archiveExpiredDutyHours({ doctor_user_id: doctor.user_id });
+
         const slots = await prisma.doctorAvailability.findMany({
-            where: { doctor_user_id: doctor.user_id },
+            where: { doctor_user_id: doctor.user_id, archivedAt: null },
             include: {
                 clinic: { select: { clinic_id: true, clinic_name: true } },
             },
@@ -72,7 +91,6 @@ export async function POST(req: Request) {
             clinic_id,
             available_timestart,
             available_timeend,
-            weeks = DEFAULT_WEEKS,
         } = await req.json();
 
         if (!clinic_id || !available_timestart || !available_timeend) {
@@ -101,18 +119,17 @@ export async function POST(req: Request) {
                 : [1, 2, 3, 4, 5]
         );
 
-        const scheduleWeeks = Math.max(1, Math.min(Number(weeks) || DEFAULT_WEEKS, MAX_WEEKS));
-        const daysToGenerate = scheduleWeeks * 7;
-
-        const base = manilaNow();
+        const monthStart = getCurrentMonthStart();
+        const endExclusive = getGenerationEndExclusive(monthStart);
         const toCreate: Prisma.DoctorAvailabilityCreateManyInput[] = [];
         const generatedDates: string[] = [];
 
-        for (let i = 0; i < daysToGenerate; i += 1) {
-            const current = new Date(base);
-            current.setUTCDate(current.getUTCDate() + i);
-
-            const manilaDate = formatManilaISODate(current);
+        for (
+            let cursor = new Date(monthStart);
+            cursor < endExclusive;
+            cursor = new Date(cursor.getTime() + DAY_IN_MS)
+        ) {
+            const manilaDate = formatManilaISODate(cursor);
             const weekday = getManilaWeekday(manilaDate);
 
             if (Number.isNaN(weekday)) continue;
@@ -126,6 +143,7 @@ export async function POST(req: Request) {
                 available_date: startOfManilaDay(manilaDate),
                 available_timestart: buildManilaDate(manilaDate, available_timestart),
                 available_timeend: buildManilaDate(manilaDate, available_timeend),
+                archivedAt: null,
             });
         }
 
@@ -139,14 +157,65 @@ export async function POST(req: Request) {
             );
         }
 
-        const rangeStart = startOfManilaDay(generatedDates[0]);
-        const rangeEnd = endOfManilaDay(generatedDates[generatedDates.length - 1]);
+        const rangeStart = monthStart;
+        const lastGeneratedDate = generatedDates[generatedDates.length - 1];
+        const rangeEnd = lastGeneratedDate
+            ? endOfManilaDay(lastGeneratedDate)
+            : endOfManilaDay(formatManilaISODate(new Date(endExclusive.getTime() - DAY_IN_MS)));
+
+        const conflicting = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: doctor.user_id,
+                archivedAt: null,
+                clinic_id: { not: clinic_id },
+                available_date: { gte: rangeStart, lte: rangeEnd },
+            },
+            select: {
+                availability_id: true,
+                clinic_id: true,
+                available_date: true,
+                available_timestart: true,
+                available_timeend: true,
+            },
+        });
+
+        for (const candidate of toCreate) {
+            const candidateDate = formatManilaISODate(candidate.available_date);
+            for (const existing of conflicting) {
+                const existingDate = formatManilaISODate(existing.available_date);
+                if (existingDate !== candidateDate) continue;
+
+                if (
+                    rangesOverlap(
+                        candidate.available_timestart,
+                        candidate.available_timeend,
+                        existing.available_timestart,
+                        existing.available_timeend,
+                    )
+                ) {
+                    const conflictStart = formatManilaISODate(existing.available_date);
+                    const conflictStartTime = toManilaTimeString(
+                        existing.available_timestart.toISOString(),
+                    );
+                    const conflictEndTime = toManilaTimeString(
+                        existing.available_timeend.toISOString(),
+                    );
+                    return NextResponse.json(
+                        {
+                            error: `Conflict detected with an existing duty hour on ${conflictStart} from ${conflictStartTime} to ${conflictEndTime}. Adjust the time range to avoid overlaps across clinics.`,
+                        },
+                        { status: 409 },
+                    );
+                }
+            }
+        }
 
         await prisma.$transaction(async (tx) => {
             await tx.doctorAvailability.deleteMany({
                 where: {
                     doctor_user_id: doctor.user_id,
                     clinic_id,
+                    archivedAt: null,
                     available_date: { gte: rangeStart, lte: rangeEnd },
                 },
             });
@@ -154,16 +223,20 @@ export async function POST(req: Request) {
             await tx.doctorAvailability.createMany({ data: toCreate });
         });
 
+        await archiveExpiredDutyHours({ doctor_user_id: doctor.user_id });
+
         const refreshed = await prisma.doctorAvailability.findMany({
-            where: { doctor_user_id: doctor.user_id },
+            where: { doctor_user_id: doctor.user_id, archivedAt: null },
             include: {
                 clinic: { select: { clinic_id: true, clinic_name: true } },
             },
             orderBy: [{ available_date: "asc" }, { available_timestart: "asc" }],
         });
 
-        const firstDay = generatedDates[0];
-        const lastDay = generatedDates[generatedDates.length - 1];
+        const firstDay = generatedDates[0] ?? formatManilaISODate(monthStart);
+        const lastDay =
+            generatedDates[generatedDates.length - 1] ??
+            formatManilaISODate(new Date(endExclusive.getTime() - DAY_IN_MS));
 
         return NextResponse.json({
             message: `Duty hours generated for ${generatedDates.length} day${
@@ -198,6 +271,8 @@ export async function PUT(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
+        await archiveExpiredDutyHours({ doctor_user_id: doctor.user_id });
+
         const {
             availability_id,
             clinic_id,
@@ -210,22 +285,87 @@ export async function PUT(req: Request) {
             return NextResponse.json({ error: "Missing availability ID" }, { status: 400 });
         }
 
-        const updateData: Prisma.DoctorAvailabilityUpdateInput = {};
+        const existing = await prisma.doctorAvailability.findUnique({
+            where: { availability_id },
+        });
+
+        if (!existing || existing.doctor_user_id !== doctor.user_id) {
+            return NextResponse.json({ error: "Availability not found" }, { status: 404 });
+        }
+
+        if (existing.archivedAt) {
+            return NextResponse.json(
+                { error: "This duty hour has already been archived" },
+                { status: 400 },
+            );
+        }
+
+        const targetClinicId = clinic_id ?? existing.clinic_id;
 
         if (clinic_id) {
-            updateData.clinic = { connect: { clinic_id } };
+            const clinic = await prisma.clinic.findUnique({ where: { clinic_id } });
+            if (!clinic) {
+                return NextResponse.json({ error: "Clinic not found" }, { status: 404 });
+            }
         }
 
-        if (available_date) {
-            updateData.available_date = startOfManilaDay(available_date);
+        const targetDate = available_date ?? formatManilaISODate(existing.available_date);
+
+        const targetStartTime = available_timestart
+            ? available_timestart
+            : toManilaTimeString(existing.available_timestart.toISOString());
+
+        const targetEndTime = available_timeend
+            ? available_timeend
+            : toManilaTimeString(existing.available_timeend.toISOString());
+
+        if (!targetStartTime || !targetEndTime) {
+            return NextResponse.json(
+                { error: "Start and end times are required" },
+                { status: 400 },
+            );
         }
 
-        if (available_timestart && available_date) {
-            updateData.available_timestart = buildManilaDate(available_date, available_timestart);
+        const newStart = buildManilaDate(targetDate, targetStartTime);
+        const newEnd = buildManilaDate(targetDate, targetEndTime);
+
+        if (!(newStart < newEnd)) {
+            return NextResponse.json(
+                { error: "End time must be after start time" },
+                { status: 400 },
+            );
         }
-        if (available_timeend && available_date) {
-            updateData.available_timeend = buildManilaDate(available_date, available_timeend);
+
+        const dayStart = startOfManilaDay(targetDate);
+        const dayEnd = endOfManilaDay(targetDate);
+
+        const conflicts = await prisma.doctorAvailability.findMany({
+            where: {
+                doctor_user_id: doctor.user_id,
+                archivedAt: null,
+                availability_id: { not: availability_id },
+                available_date: { gte: dayStart, lte: dayEnd },
+            },
+        });
+
+        const hasOverlap = conflicts.some((entry) =>
+            rangesOverlap(newStart, newEnd, entry.available_timestart, entry.available_timeend),
+        );
+
+        if (hasOverlap) {
+            return NextResponse.json(
+                { error: "Updated time overlaps with another duty hour" },
+                { status: 409 },
+            );
         }
+
+        const updateData: Prisma.DoctorAvailabilityUpdateInput = {
+            clinic: { connect: { clinic_id: targetClinicId } },
+            available_date: dayStart,
+            available_timestart: newStart,
+            available_timeend: newEnd,
+            archivedAt: null,
+        };
 
         const updated = await prisma.doctorAvailability.update({
             where: { availability_id },

--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -24,9 +24,9 @@ function getCurrentMonthStart(): Date {
 }
 
 function getGenerationEndExclusive(start: Date): Date {
-    const limit = new Date(start);
-    limit.setUTCFullYear(limit.getUTCFullYear() + 1);
-    return limit;
+    const startYear = Number.parseInt(formatManilaISODate(start).slice(0, 4), 10);
+    const januaryNextYear = `${startYear + 1}-01-01`;
+    return startOfManilaDay(januaryNextYear);
 }
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;

--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -108,6 +108,8 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
+        await archiveExpiredDutyHours({ doctor_user_id: doctor.user_id });
+
         const {
             clinic_id,
             available_timestart,

--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -12,15 +12,10 @@ import {
 } from "@/lib/time";
 import { AppointmentStatus, Role, ServiceType } from "@prisma/client";
 import { archiveExpiredDutyHours } from "@/lib/duty-hours";
-
-const MIN_BOOKING_LEAD_DAYS = 3;
-const DAY_IN_MS = 24 * 60 * 60 * 1000;
-
-function computeEarliestBookingStart(now: Date): Date {
-    const future = new Date(now.getTime() + MIN_BOOKING_LEAD_DAYS * DAY_IN_MS);
-    const earliestDate = formatManilaISODate(future);
-    return startOfManilaDay(earliestDate);
-}
+import {
+    computeDoctorEarliestBookingStart,
+    DEFAULT_MIN_BOOKING_LEAD_DAYS,
+} from "@/lib/booking";
 
 export async function GET() {
     try {
@@ -102,7 +97,10 @@ export async function POST(req: Request) {
         const clinic = await prisma.clinic.findUnique({ where: { clinic_id } });
         if (!clinic) return NextResponse.json({ message: "Clinic not found" }, { status: 404 });
 
-        const doctor = await prisma.users.findUnique({ where: { user_id: doctor_user_id } });
+        const doctor = await prisma.users.findUnique({
+            where: { user_id: doctor_user_id },
+            select: { role: true, specialization: true },
+        });
         if (!doctor || doctor.role !== Role.DOCTOR)
             return NextResponse.json({ message: "Doctor not found" }, { status: 404 });
 
@@ -113,7 +111,11 @@ export async function POST(req: Request) {
         const dayStart = startOfManilaDay(date);
         const dayEnd = endOfManilaDay(date);
         const now = manilaNow();
-        const earliestBookingStart = computeEarliestBookingStart(now);
+        const earliestBookingStart = computeDoctorEarliestBookingStart(
+            now,
+            doctor.specialization,
+            DEFAULT_MIN_BOOKING_LEAD_DAYS,
+        );
 
         if (!(appointment_timestart < appointment_timeend))
             return NextResponse.json({ message: "Invalid time range" }, { status: 400 });

--- a/src/app/api/scholar/appointments/route.ts
+++ b/src/app/api/scholar/appointments/route.ts
@@ -4,6 +4,7 @@ import { AppointmentStatus, Prisma, Role, ServiceType } from "@prisma/client";
 
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { archiveExpiredDutyHours } from "@/lib/duty-hours";
 import {
     buildManilaDate,
     endOfManilaDay,
@@ -261,10 +262,13 @@ export async function POST(req: Request) {
         const dayStart = appointment_date;
         const dayEnd = endOfManilaDay(date);
 
+        await archiveExpiredDutyHours({ doctor_user_id });
+
         const availabilities = await prisma.doctorAvailability.findMany({
             where: {
                 doctor_user_id,
                 clinic_id,
+                archivedAt: null,
                 available_date: { gte: dayStart, lte: dayEnd },
             },
         });

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -210,7 +210,7 @@ export default function DoctorConsultationPage() {
             <div className="space-y-6">
                 {/* Consultation Section */}
                 <section className="mx-auto w-full max-w-6xl space-y-6 px-4 sm:px-6">
-                    <Card className="rounded-3xl border border-green-100/70 bg-gradient-to-r from-green-100/70 via-white to-green-50/80 shadow-sm">
+                    <Card className="rounded-3xl border border-green-100/70 bg-linear-to-r from-green-100/70 via-white to-green-50/80 shadow-sm">
                         <CardHeader className="space-y-1">
                             <CardTitle className="text-base font-semibold text-green-700">
                                 Availability overview

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -232,7 +232,7 @@ export default function DoctorConsultationPage() {
                                         </DialogDescription>
                                         {!editingSlot && (
                                             <p className="text-sm text-muted-foreground">
-                                                Duty hours will be plotted on weekdays (Mon–Fri for physicians, Mon–Sat for dentists) for the next four weeks.
+                                                Duty hours will be plotted on working days (Mon–Fri for physicians, Mon–Sat for dentists) from this month through the rest of the year.
                                             </p>
                                         )}
                                     </DialogHeader>

--- a/src/app/doctor/consultation/page.tsx
+++ b/src/app/doctor/consultation/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Loader2, PlusCircle, Pencil } from "lucide-react";
 
@@ -49,12 +49,17 @@ type Availability = {
     clinic: Clinic;
 };
 
+const PAGE_SIZE = 25;
+
 export default function DoctorConsultationPage() {
     const [loading, setLoading] = useState(false);
     const [savingDutyHours, setSavingDutyHours] = useState(false);
     const [slots, setSlots] = useState<Availability[]>([]);
     const [clinics, setClinics] = useState<Clinic[]>([]);
     const [initializing, setInitializing] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [totalSlots, setTotalSlots] = useState(0);
+    const [totalPages, setTotalPages] = useState(1);
     const [formData, setFormData] = useState({
         clinic_id: "",
         available_date: "",
@@ -69,20 +74,47 @@ export default function DoctorConsultationPage() {
         [slots]
     );
 
-    async function loadSlots() {
+    const loadSlots = useCallback(async (targetPage: number) => {
         try {
             setLoading(true);
-            const res = await fetch("/api/doctor/consultation", { cache: "no-store" });
+            const res = await fetch(
+                `/api/doctor/consultation?page=${targetPage}&pageSize=${PAGE_SIZE}`,
+                { cache: "no-store" }
+            );
             const data = await res.json();
-            if (data.error) toast.error(data.error);
-            else setSlots(data);
+            if (data.error) {
+                toast.error(data.error);
+                setSlots([]);
+                setTotalSlots(0);
+                setTotalPages(1);
+                return;
+            }
+
+            const normalizedTotal = typeof data.total === "number" ? data.total : 0;
+            const normalizedPageSize =
+                typeof data.pageSize === "number" && data.pageSize > 0 ? data.pageSize : PAGE_SIZE;
+            const normalizedPage = typeof data.page === "number" ? data.page : targetPage;
+            const normalizedTotalPages =
+                typeof data.totalPages === "number"
+                    ? data.totalPages
+                    : Math.max(1, Math.ceil((normalizedTotal || 1) / normalizedPageSize));
+
+            setSlots(Array.isArray(data.data) ? data.data : []);
+            setTotalSlots(normalizedTotal);
+            setTotalPages(normalizedTotalPages);
+            setCurrentPage(normalizedPage);
         } catch {
             toast.error("Failed to load consultation slots");
         } finally {
             setLoading(false);
             setInitializing(false);
         }
-    }
+    }, []);
+
+    const showingStart = totalSlots === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1;
+    const showingEnd = totalSlots === 0 ? 0 : showingStart + slots.length - 1;
+    const canGoPrevious = currentPage > 1;
+    const canGoNext = currentPage < totalPages;
 
     async function loadClinics() {
         try {
@@ -95,9 +127,9 @@ export default function DoctorConsultationPage() {
     }
 
     useEffect(() => {
-        loadSlots();
-        loadClinics();
-    }, []);
+        void loadSlots(1);
+        void loadClinics();
+    }, [loadSlots]);
 
     async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -144,16 +176,10 @@ export default function DoctorConsultationPage() {
             } else {
                 if (isEditing) {
                     toast.success("Schedule updated!");
-                    setSlots((prev) =>
-                        prev.map((slot) =>
-                            slot.availability_id === editingSlot!.availability_id ? data : slot
-                        )
-                    );
+                    await loadSlots(currentPage);
                 } else {
                     toast.success(data.message ?? "Duty hours generated!");
-                    if (Array.isArray(data.slots)) {
-                        setSlots(data.slots);
-                    }
+                    await loadSlots(1);
                 }
                 setDialogOpen(false);
                 setFormData({
@@ -190,9 +216,9 @@ export default function DoctorConsultationPage() {
                                 Availability overview
                             </CardTitle>
                             <p className="text-sm text-muted-foreground">
-                                {slots.length === 0
+                                {totalSlots === 0
                                     ? "No active slots yet. Generate duty hours to publish a new schedule."
-                                    : `You currently have ${slots.length} availability ${slots.length === 1 ? "entry" : "entries"} across ${uniqueClinicCount} clinic${uniqueClinicCount === 1 ? "" : "s"}.`}
+                                    : `You currently have ${totalSlots} availability ${totalSlots === 1 ? "entry" : "entries"}. This page shows ${slots.length} entr${slots.length === 1 ? "y" : "ies"} across ${uniqueClinicCount} clinic${uniqueClinicCount === 1 ? "" : "s"}.`}
                             </p>
                         </CardHeader>
                     </Card>
@@ -317,48 +343,73 @@ export default function DoctorConsultationPage() {
                                     <Loader2 className="h-5 w-5 animate-spin" /> Loading slots...
                                 </div>
                             ) : slots.length > 0 ? (
-                                <div className="overflow-x-auto w-full">
-                                    <Table className="min-w-full text-sm">
-                                        <TableHeader>
-                                            <TableRow>
-                                                <TableHead>Date</TableHead>
-                                                <TableHead>Start Time</TableHead>
-                                                <TableHead>End Time</TableHead>
-                                                <TableHead>Clinic</TableHead>
-                                                <TableHead className="text-right">Actions</TableHead>
-                                            </TableRow>
-                                        </TableHeader>
-                                        <TableBody>
-                                            {slots.map((slot) => (
-                                                <TableRow key={slot.availability_id} className="hover:bg-green-50 transition">
-                                                    <TableCell>{toManilaDateString(slot.available_date)}</TableCell>
-                                                    <TableCell>{format12Hour(slot.available_timestart)}</TableCell>
-                                                    <TableCell>{format12Hour(slot.available_timeend)}</TableCell>
-                                                    <TableCell>{slot.clinic.clinic_name}</TableCell>
-                                                    <TableCell className="text-right">
-                                                        <Button
-                                                            size="sm"
-                                                            variant="outline"
-                                                            className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70 gap-2"
-                                                            onClick={() => {
-                                                                setEditingSlot(slot);
-                                                                setFormData({
-                                                                    clinic_id: slot.clinic.clinic_id,
-                                                                    available_date: toManilaDateString(slot.available_date),
-                                                                    available_timestart: toManilaTimeString(slot.available_timestart),
-                                                                    available_timeend: toManilaTimeString(slot.available_timeend),
-                                                                });
-                                                                setDialogOpen(true);
-                                                            }}
-                                                        >
-                                                            <Pencil className="h-4 w-4" /> Edit
-                                                        </Button>
-                                                    </TableCell>
+                                <div className="flex flex-col gap-4">
+                                    <div className="overflow-x-auto w-full">
+                                        <Table className="min-w-full text-sm">
+                                            <TableHeader>
+                                                <TableRow>
+                                                    <TableHead>Date</TableHead>
+                                                    <TableHead>Start Time</TableHead>
+                                                    <TableHead>End Time</TableHead>
+                                                    <TableHead>Clinic</TableHead>
+                                                    <TableHead className="text-right">Actions</TableHead>
                                                 </TableRow>
-                                            ))}
-                                        </TableBody>
+                                            </TableHeader>
+                                            <TableBody>
+                                                {slots.map((slot) => (
+                                                    <TableRow key={slot.availability_id} className="hover:bg-green-50 transition">
+                                                        <TableCell>{toManilaDateString(slot.available_date)}</TableCell>
+                                                        <TableCell>{format12Hour(slot.available_timestart)}</TableCell>
+                                                        <TableCell>{format12Hour(slot.available_timeend)}</TableCell>
+                                                        <TableCell>{slot.clinic.clinic_name}</TableCell>
+                                                        <TableCell className="text-right">
+                                                            <Button
+                                                                size="sm"
+                                                                variant="outline"
+                                                                className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70 gap-2"
+                                                                onClick={() => {
+                                                                    setEditingSlot(slot);
+                                                                    setFormData({
+                                                                        clinic_id: slot.clinic.clinic_id,
+                                                                        available_date: toManilaDateString(slot.available_date),
+                                                                        available_timestart: toManilaTimeString(slot.available_timestart),
+                                                                        available_timeend: toManilaTimeString(slot.available_timeend),
+                                                                    });
+                                                                    setDialogOpen(true);
+                                                                }}
+                                                            >
+                                                                <Pencil className="h-4 w-4" /> Edit
+                                                            </Button>
+                                                        </TableCell>
+                                                    </TableRow>
+                                                ))}
+                                            </TableBody>
 
-                                    </Table>
+                                        </Table>
+                                    </div>
+                                    <div className="flex flex-col gap-3 border-t border-green-100 pt-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                                        <p>
+                                            Showing {showingStart}–{showingEnd} of {totalSlots} slot{totalSlots === 1 ? "" : "s"}. Page {currentPage} of {totalPages}.
+                                        </p>
+                                        <div className="flex items-center gap-2">
+                                            <Button
+                                                variant="outline"
+                                                className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
+                                                disabled={loading || !canGoPrevious}
+                                                onClick={() => void loadSlots(currentPage - 1)}
+                                            >
+                                                Previous
+                                            </Button>
+                                            <Button
+                                                variant="outline"
+                                                className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/70"
+                                                disabled={loading || !canGoNext}
+                                                onClick={() => void loadSlots(currentPage + 1)}
+                                            >
+                                                Next
+                                            </Button>
+                                        </div>
+                                    </div>
                                 </div>
                             ) : (
                                 <div className="py-6 text-center text-muted-foreground">

--- a/src/lib/booking.ts
+++ b/src/lib/booking.ts
@@ -1,0 +1,41 @@
+import { DoctorSpecialization } from "@prisma/client";
+
+import { formatManilaISODate, getManilaWeekday, startOfManilaDay } from "@/lib/time";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export const DEFAULT_MIN_BOOKING_LEAD_DAYS = 3;
+
+function shouldSkipDay(weekday: number, specialization: DoctorSpecialization | null | undefined) {
+    if (Number.isNaN(weekday)) return true;
+
+    if (weekday === 0) return true; // Always skip Sundays
+
+    if (specialization === DoctorSpecialization.Dentist) {
+        return false; // Dentists may book Saturdays
+    }
+
+    return weekday === 6; // Physicians skip Saturdays
+}
+
+export function computeDoctorEarliestBookingStart(
+    now: Date,
+    specialization: DoctorSpecialization | null | undefined,
+    minLeadDays = DEFAULT_MIN_BOOKING_LEAD_DAYS,
+): Date {
+    let cursor = new Date(now.getTime() + minLeadDays * DAY_IN_MS);
+
+    for (let i = 0; i < 31; i += 1) {
+        const isoDate = formatManilaISODate(cursor);
+        const weekday = getManilaWeekday(isoDate);
+
+        if (!shouldSkipDay(weekday, specialization)) {
+            return startOfManilaDay(isoDate);
+        }
+
+        cursor = new Date(cursor.getTime() + DAY_IN_MS);
+    }
+
+    const fallbackDate = formatManilaISODate(cursor);
+    return startOfManilaDay(fallbackDate);
+}

--- a/src/lib/duty-hours.ts
+++ b/src/lib/duty-hours.ts
@@ -1,0 +1,30 @@
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { manilaNow } from "@/lib/time";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Mark duty hours as archived when they are more than 24 hours past their end time.
+ *
+ * This keeps doctor availability queries lightweight without permanently deleting
+ * historical duty hours.
+ */
+export async function archiveExpiredDutyHours(
+    where: Prisma.DoctorAvailabilityWhereInput = {}
+) {
+    const now = manilaNow();
+    const cutoff = new Date(now.getTime() - DAY_IN_MS);
+
+    const criteria: Prisma.DoctorAvailabilityWhereInput = {
+        archivedAt: null,
+        available_timeend: { lt: cutoff },
+        ...where,
+    };
+
+    await prisma.doctorAvailability.updateMany({
+        where: criteria,
+        data: { archivedAt: now },
+    });
+}


### PR DESCRIPTION
## Summary
- add archiving support for doctor duty hours and filter archived slots out of API responses
- extend duty hour generation to cover an entire year with overlap validation and updated messaging
- ensure availability checks across patient, scholar, and doctor flows respect archived duty hours

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f9e7fc27c88333a927da43e2a5ce43