### PR TITLE
Refactor doctor consultation client for faster builds

### DIFF
--- a/src/app/doctor/consultation/components/slot-card.tsx
+++ b/src/app/doctor/consultation/components/slot-card.tsx
@@ -1,0 +1,99 @@
+import { memo } from "react";
+import { Pencil } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatTimeRange, toManilaDateString, toManilaTimeString } from "@/lib/time";
+import { cn } from "@/lib/utils";
+
+import type { Availability } from "../types";
+
+type SlotCardProps = {
+    slot: Availability;
+    context: "card" | "inline";
+    onEdit?: (slot: Availability) => void;
+};
+
+function SlotCardComponent({ slot, context, onEdit }: SlotCardProps) {
+    const handleEdit = () => {
+        onEdit?.(slot);
+    };
+
+    return (
+        <div
+            className={cn(
+                "flex flex-col gap-3 rounded-2xl border p-4 text-sm shadow-inner sm:flex-row sm:items-center sm:justify-between",
+                slot.is_on_leave
+                    ? context === "inline"
+                        ? "border-amber-200 bg-amber-50/80 text-amber-900"
+                        : "border-amber-200 bg-amber-50/70 text-amber-900"
+                    : context === "inline"
+                        ? "border-green-100/80 bg-emerald-50/70 text-slate-700"
+                        : "border-green-100/80 bg-emerald-50/40 text-slate-700",
+                context === "inline" && "shadow-sm"
+            )}
+        >
+            <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                    <p
+                        className={cn(
+                            "text-lg font-semibold",
+                            slot.is_on_leave ? "text-amber-800" : "text-green-700"
+                        )}
+                    >
+                        {formatTimeRange(slot.available_timestart, slot.available_timeend)}
+                    </p>
+                    {slot.is_on_leave ? (
+                        <Badge
+                            variant="outline"
+                            className="border-amber-300 bg-amber-100 text-[0.65rem] font-semibold uppercase tracking-wide text-amber-800"
+                        >
+                            On leave
+                        </Badge>
+                    ) : null}
+                </div>
+                <p
+                    className={cn(
+                        "text-sm",
+                        slot.is_on_leave ? "text-amber-700/90" : "text-muted-foreground"
+                    )}
+                >
+                    {slot.clinic.clinic_name}
+                </p>
+                {slot.is_on_leave ? (
+                    <p className="text-xs text-amber-700">
+                        Patients cannot book appointments for this day until you restore availability.
+                    </p>
+                ) : null}
+            </div>
+            <Button
+                size="sm"
+                variant="outline"
+                className={cn(
+                    "w-full gap-2 rounded-xl border-green-200 text-green-700 hover:bg-green-100/70 sm:w-auto",
+                    slot.is_on_leave && "border-amber-300 text-amber-800 hover:bg-amber-100/80",
+                    context === "inline" && "bg-white/90"
+                )}
+                onClick={handleEdit}
+            >
+                <Pencil className="h-4 w-4" /> {slot.is_on_leave ? "Update" : "Edit"}
+            </Button>
+        </div>
+    );
+}
+
+export const SlotCard = memo(SlotCardComponent);
+
+export function buildFormStateFromSlot(slot: Availability) {
+    const slotDate = toManilaDateString(slot.available_date);
+    return {
+        slotDate,
+        formState: {
+            clinic_id: slot.clinic.clinic_id,
+            available_date: slotDate,
+            available_timestart: toManilaTimeString(slot.available_timestart),
+            available_timeend: toManilaTimeString(slot.available_timeend),
+            is_on_leave: slot.is_on_leave,
+        },
+    } as const;
+}

--- a/src/app/doctor/consultation/utils.ts
+++ b/src/app/doctor/consultation/utils.ts
@@ -1,0 +1,95 @@
+import { toManilaDateString } from "@/lib/time";
+
+import type { Availability } from "./types";
+
+export const MANILA_TIME_SUFFIX = "+08:00";
+
+export function toCalendarDate(value: string | null | undefined) {
+    if (!value) return null;
+    const normalized = value.includes("T") ? value : `${value}T12:00:00${MANILA_TIME_SUFFIX}`;
+    const date = new Date(normalized);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatMonthKeyFromDate(date: Date): string {
+    return date.toLocaleDateString("en-CA", {
+        timeZone: "Asia/Manila",
+        year: "numeric",
+        month: "2-digit",
+    });
+}
+
+export function getMonthKeyFromISODate(value: string): string {
+    return value.slice(0, 7);
+}
+
+export function sortSlotsForDay(slots: Availability[]): Availability[] {
+    return [...slots].sort((a, b) => {
+        if (a.is_on_leave && !b.is_on_leave) return -1;
+        if (!a.is_on_leave && b.is_on_leave) return 1;
+        return a.available_timestart.localeCompare(b.available_timestart);
+    });
+}
+
+export function mapSlotsByDate(slots: Availability[]) {
+    const map = new Map<string, Availability[]>();
+    for (const slot of slots) {
+        const dateKey = toManilaDateString(slot.available_date);
+        if (!map.has(dateKey)) {
+            map.set(dateKey, []);
+        }
+        map.get(dateKey)!.push(slot);
+    }
+    return map;
+}
+
+export function summarizeSlots(slots: Availability[]) {
+    let active = 0;
+    let onLeave = 0;
+    const activeDays = new Set<string>();
+    const leaveDays = new Set<string>();
+    const coveredDays = new Set<string>();
+
+    for (const slot of slots) {
+        const dateKey = toManilaDateString(slot.available_date);
+        coveredDays.add(dateKey);
+        if (slot.is_on_leave) {
+            onLeave += 1;
+            leaveDays.add(dateKey);
+        } else {
+            active += 1;
+            activeDays.add(dateKey);
+        }
+    }
+
+    return {
+        active,
+        onLeave,
+        activeDays: activeDays.size,
+        leaveDays: leaveDays.size,
+        coveredDays: coveredDays.size,
+    };
+}
+
+export function buildSortedSlots(slots: Availability[], todayKey: string) {
+    const slotsWithDateKeys = slots.map((slot) => ({
+        slot,
+        dateKey: toManilaDateString(slot.available_date),
+    }));
+
+    const ordered = slotsWithDateKeys
+        .sort((a, b) => {
+            const byDate = a.dateKey.localeCompare(b.dateKey);
+            if (byDate !== 0) {
+                return byDate;
+            }
+            return a.slot.available_timestart.localeCompare(b.slot.available_timestart);
+        })
+        .map((item) => item.slot);
+
+    const upcomingLeaveSlots = ordered
+        .filter((slot) => slot.is_on_leave && toManilaDateString(slot.available_date) >= todayKey)
+        .slice(0, 4);
+
+    return { ordered, upcomingLeaveSlots };
+}


### PR DESCRIPTION
## Summary
- extract the doctor consultation slot card into a memoized component to cut repeated JSX rebuilds
- move calendar helper logic into a shared utility module and reuse it across the page
- streamline the doctor consultation client page to rely on memoized helpers for lighter recompilation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fb8da179ec833394365f11761a07ca