### PR TITLE
Add password strength feedback to password reset flow

### DIFF
--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { normalizeResetContact } from "@/lib/password-reset";
+import { getPasswordStrength } from "@/lib/password-strength";
 
 export async function POST(req: Request) {
     try {
@@ -36,9 +37,11 @@ export async function POST(req: Request) {
             );
         }
 
-        if (trimmedPassword.length < 8) {
+        const strength = getPasswordStrength(trimmedPassword);
+
+        if (strength.label === "Too weak") {
             return NextResponse.json(
-                { error: "New password must be at least 8 characters." },
+                { error: "Create a stronger password before continuing." },
                 { status: 400 }
             );
         }

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -56,6 +56,18 @@ export default function LoginPageClient() {
         () => getPasswordStrength(newPassword),
         [newPassword]
     );
+    const passwordMismatchMessage = useMemo(() => {
+        if (!newPassword || !confirmPassword) return null;
+        if (newPassword === confirmPassword) return null;
+        return "Passwords do not match.";
+    }, [confirmPassword, newPassword]);
+    const canReset = useMemo(() => {
+        const trimmedCode = code.trim();
+        if (!/^\d{6}$/.test(trimmedCode)) return false;
+        if (!newPassword || !confirmPassword) return false;
+        if (newPassword !== confirmPassword) return false;
+        return passwordStrength.label !== "Too weak";
+    }, [code, confirmPassword, newPassword, passwordStrength.label]);
 
     const handleForgotToggle = (open: boolean) => {
         setForgotOpen(open);
@@ -187,18 +199,14 @@ export default function LoginPageClient() {
             return;
         }
 
-        if (passwordValue.length < 8) {
-            setPasswordError("Password must be at least 8 characters.");
-            return;
-        }
-
-        if (!/[A-Za-z]/.test(passwordValue) || !/\d/.test(passwordValue)) {
-            setPasswordError("Include letters and numbers for a stronger password.");
+        const strength = getPasswordStrength(passwordValue);
+        if (strength.label === "Too weak") {
+            setPasswordError("Create a stronger password before continuing.");
             return;
         }
 
         if (passwordValue !== confirmPassword) {
-            setPasswordError("Passwords do not match.");
+            setPasswordError(null);
             return;
         }
 
@@ -587,17 +595,17 @@ export default function LoginPageClient() {
                                             </Button>
                                         </div>
                                         {passwordError && (
-                                            <p className="text-sm text-red-600">{passwordError}</p>
+                                            <p className="text-xs text-muted-foreground">{passwordError}</p>
                                         )}
-                                        <p className="text-xs text-slate-500">
-                                            Password must be at least 8 characters and include both letters and numbers.
-                                        </p>
+                                        {passwordMismatchMessage && (
+                                            <p className="text-xs text-muted-foreground">{passwordMismatchMessage}</p>
+                                        )}
                                     </div>
                                 </div>
                                 <DialogFooter>
                                     <Button
                                         type="submit"
-                                        disabled={resetting}
+                                        disabled={resetting || !canReset}
                                         className="w-full bg-green-600 text-white hover:bg-green-700"
                                     >
                                         {resetting ? (

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dialog";
 import { normalizeResetContact } from "@/lib/password-reset";
 import { Progress } from "@/components/ui/progress";
+import { getPasswordStrength } from "@/lib/password-strength";
 
 export default function LoginPageClient() {
     const [loadingRole, setLoadingRole] = useState<string | null>(null);
@@ -615,52 +616,6 @@ export default function LoginPageClient() {
             </Dialog>
         </div>
     );
-}
-
-type PasswordStrength = {
-    label: "" | "Too weak" | "Medium" | "Strong";
-    value: number;
-    indicatorClass: string;
-    textClass: string;
-};
-
-function getPasswordStrength(password: string): PasswordStrength {
-    const trimmed = password.trim();
-    if (!trimmed) {
-        return { label: "", value: 0, indicatorClass: "bg-primary", textClass: "" };
-    }
-
-    let score = 0;
-    if (trimmed.length >= 8) score += 1;
-    if (trimmed.length >= 12) score += 1;
-    if (/[a-z]/.test(trimmed) && /[A-Z]/.test(trimmed)) score += 1;
-    if (/\d/.test(trimmed)) score += 1;
-    if (/[^A-Za-z0-9]/.test(trimmed)) score += 1;
-
-    if (trimmed.length < 8 || score <= 2) {
-        return {
-            label: "Too weak",
-            value: 25,
-            indicatorClass: "bg-red-500",
-            textClass: "text-red-600",
-        };
-    }
-
-    if (score <= 4) {
-        return {
-            label: "Medium",
-            value: 60,
-            indicatorClass: "bg-amber-500",
-            textClass: "text-amber-600",
-        };
-    }
-
-    return {
-        label: "Strong",
-        value: 100,
-        indicatorClass: "bg-green-500",
-        textClass: "text-green-600",
-    };
 }
 
 function maskContact(value: string) {

--- a/src/components/account/account-password-dialog.tsx
+++ b/src/components/account/account-password-dialog.tsx
@@ -86,12 +86,6 @@ export function AccountPasswordDialog({
         return "Passwords do not match.";
     }, [confirmPassword, newPassword]);
 
-    const combinedErrors = useMemo(() => {
-        const source = errors.length > 0 ? errors : livePasswordErrors;
-        if (!passwordMismatchMessage) return source;
-        return source.filter((error) => error !== passwordMismatchMessage);
-    }, [errors, livePasswordErrors, passwordMismatchMessage]);
-
     const resetState = useCallback(() => {
         setShowCurrent(false);
         setShowNew(false);
@@ -127,12 +121,11 @@ export function AccountPasswordDialog({
             setConfirmPassword(confirmPasswordValue);
 
             const validationErrors = collectPasswordErrors(newPasswordValue);
-            if (newPasswordValue !== confirmPasswordValue) {
-                validationErrors.push("Passwords do not match.");
-            }
+            const hasMismatch = newPasswordValue !== confirmPasswordValue;
 
-            if (validationErrors.length > 0) {
-                setErrors(validationErrors);
+            if (validationErrors.length > 0 || hasMismatch) {
+                setLivePasswordErrors(validationErrors);
+                setErrors([]);
                 setMessage(null);
                 return;
             }
@@ -305,13 +298,21 @@ export function AccountPasswordDialog({
                         ) : null}
                     </div>
 
-                    {combinedErrors.length > 0 && (
-                        <div className="space-y-1 text-sm text-red-600">
-                            {combinedErrors.map((error, index) => (
+                    {livePasswordErrors.length > 0 ? (
+                        <div className="space-y-1 text-xs text-muted-foreground">
+                            {livePasswordErrors.map((error, index) => (
                                 <p key={index}>{error}</p>
                             ))}
                         </div>
-                    )}
+                    ) : null}
+
+                    {errors.length > 0 ? (
+                        <div className="space-y-1 text-sm text-red-600">
+                            {errors.map((error, index) => (
+                                <p key={index}>{error}</p>
+                            ))}
+                        </div>
+                    ) : null}
 
                     {message ? <p className="text-sm text-green-600">{message}</p> : null}
 

--- a/src/components/account/account-password-dialog.tsx
+++ b/src/components/account/account-password-dialog.tsx
@@ -294,7 +294,7 @@ export function AccountPasswordDialog({
                             </Button>
                         </div>
                         {passwordMismatchMessage ? (
-                            <p className="mt-2 text-sm text-red-600">{passwordMismatchMessage}</p>
+                            <p className="mt-2 text-xs text-muted-foreground">{passwordMismatchMessage}</p>
                         ) : null}
                     </div>
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -5,11 +5,16 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+type ProgressProps = React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string
+}
+
 function Progress({
   className,
   value,
+  indicatorClassName,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ProgressProps) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -21,7 +26,10 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn(
+          "bg-primary h-full w-full flex-1 transition-all",
+          indicatorClassName
+        )}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/lib/password-strength.ts
+++ b/src/lib/password-strength.ts
@@ -1,0 +1,45 @@
+export type PasswordStrength = {
+    label: "" | "Too weak" | "Medium" | "Strong";
+    value: number;
+    indicatorClass: string;
+    textClass: string;
+};
+
+export function getPasswordStrength(password: string): PasswordStrength {
+    const trimmed = password.trim();
+    if (!trimmed) {
+        return { label: "", value: 0, indicatorClass: "bg-primary", textClass: "" };
+    }
+
+    let score = 0;
+    if (trimmed.length >= 8) score += 1;
+    if (trimmed.length >= 12) score += 1;
+    if (/[a-z]/.test(trimmed) && /[A-Z]/.test(trimmed)) score += 1;
+    if (/\d/.test(trimmed)) score += 1;
+    if (/[^A-Za-z0-9]/.test(trimmed)) score += 1;
+
+    if (trimmed.length < 8 || score <= 2) {
+        return {
+            label: "Too weak",
+            value: 25,
+            indicatorClass: "bg-red-500",
+            textClass: "text-red-600",
+        };
+    }
+
+    if (score <= 4) {
+        return {
+            label: "Medium",
+            value: 60,
+            indicatorClass: "bg-amber-500",
+            textClass: "text-amber-600",
+        };
+    }
+
+    return {
+        label: "Strong",
+        value: 100,
+        indicatorClass: "bg-green-500",
+        textClass: "text-green-600",
+    };
+}


### PR DESCRIPTION
## Summary
- add a real-time password strength meter and helper text to the reset password dialog
- allow the shared Progress component to accept custom indicator styling for contextual colors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fc2c0377508333889144d378bdace1