### PR TITLE
Keep cancelled appointments without deleting records

### DIFF
--- a/prisma/migrations/20251010120000_keep_cancelled_appointments/migration.sql
+++ b/prisma/migrations/20251010120000_keep_cancelled_appointments/migration.sql
@@ -1,0 +1,5 @@
+-- Drop the previous unique index that prevented keeping cancelled appointments
+DROP INDEX IF EXISTS "Appointment_doctor_user_id_appointment_timestart_appointmen_key";
+
+-- Allow cancelled appointments to retain their original schedule while freeing the slot for new bookings
+CREATE UNIQUE INDEX "Appointment_unique_doctor_time_status" ON "public"."Appointment"("doctor_user_id", "appointment_timestart", "appointment_timeend", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,7 +155,10 @@ model Appointment {
   patient               Users             @relation("PatientAppointments", fields: [patient_user_id], references: [user_id], onDelete: Cascade)
   consultation          Consultation?
 
-  @@unique([doctor_user_id, appointment_timestart, appointment_timeend])
+  @@unique(
+    [doctor_user_id, appointment_timestart, appointment_timeend, status],
+    map: "Appointment_unique_doctor_time_status"
+  )
   @@index([doctor_user_id, appointment_date, status])
   @@index([patient_user_id, appointment_date, status])
 }

--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -371,8 +371,18 @@ export async function DELETE(req: Request) {
             );
         }
 
-        await prisma.appointment.delete({
+        if (appointment.status === AppointmentStatus.Cancelled) {
+            return NextResponse.json(
+                { message: "Appointment already cancelled" },
+                { status: 400 }
+            );
+        }
+
+        await prisma.appointment.update({
             where: { appointment_id },
+            data: {
+                status: AppointmentStatus.Cancelled,
+            },
         });
 
         return NextResponse.json({ message: "Appointment cancelled" });


### PR DESCRIPTION
## Summary
- mark patient and doctor cancellations as status updates instead of deleting the appointment rows
- return the updated appointment payload to the doctor dashboard and keep the entry while reflecting the cancelled status
- relax the unique schedule constraint by including status so cancelled visits no longer block new bookings and add a migration for the change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fca39f93048333a6919986be51d50d