### PR TITLE
Add rate limiting to public auth endpoints

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,6 +3,15 @@
 export const runtime = "nodejs";
 import NextAuth from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { withRateLimit, getClientIp } from "@/lib/rate-limit";
 
-const handler = NextAuth(authOptions);
+const baseHandler = NextAuth(authOptions);
+
+const handler = withRateLimit(baseHandler, {
+    limit: 60,
+    windowMs: 60 * 1000,
+    message: "Too many authentication requests from this IP. Please wait and try again.",
+    keyGenerator: (req) => `auth:route:${getClientIp(req)}`,
+});
+
 export { handler as GET, handler as POST };

--- a/src/app/api/auth/request-reset/route.ts
+++ b/src/app/api/auth/request-reset/route.ts
@@ -5,25 +5,61 @@ import { prisma } from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { normalizeResetContact } from "@/lib/password-reset";
 import { generateNumericCode } from "@/lib/security";
+import {
+    assertRateLimit,
+    RateLimitError,
+    getClientIp,
+    applyRateLimitHeaders,
+    RateLimitResult,
+} from "@/lib/rate-limit";
 
 export async function POST(req: Request) {
+    let headerSource: RateLimitResult | null = null;
     try {
+        const clientIp = getClientIp(req);
+        const ipResult = assertRateLimit({
+            key: `auth:reset-request:ip:${clientIp}`,
+            limit: 5,
+            windowMs: 15 * 60 * 1000,
+            message: "Too many password reset requests from this IP. Please try again later.",
+        });
+        headerSource = ipResult;
+
         const { contact } = await req.json();
 
         if (typeof contact !== "string") {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Contact email is required." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         const normalized = normalizeResetContact(contact);
 
         if (!normalized) {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Enter a valid email address." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
+        }
+
+        const contactResult = assertRateLimit({
+            key: `auth:reset-request:contact:${normalized.normalized}`,
+            limit: 3,
+            windowMs: 60 * 60 * 1000,
+            message:
+                "Too many password reset requests for this contact. Please wait before requesting another code.",
+        });
+
+        if (
+            !headerSource ||
+            contactResult.remaining < headerSource.remaining ||
+            (contactResult.remaining === headerSource.remaining &&
+                contactResult.reset < headerSource.reset)
+        ) {
+            headerSource = contactResult;
         }
 
         // Find user by email
@@ -59,10 +95,11 @@ export async function POST(req: Request) {
         });
 
         if (!user) {
-            return NextResponse.json({
+            const response = NextResponse.json({
                 success: true,
                 message: "If an account exists for that email, a reset code has been sent.",
             });
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         // Display name
@@ -138,28 +175,38 @@ export async function POST(req: Request) {
             fromName: "HNU Clinic",
         });
 
-        return NextResponse.json({
+        const response = NextResponse.json({
             success: true,
             message: "If an account exists for that email, a reset code has been sent.",
         });
+        return applyRateLimitHeaders(response, headerSource);
     } catch (error: unknown) {
         console.error("REQUEST-RESET ERROR DETAILS:", error);
         const message =
             error instanceof Error ? error.message : "Unknown error occurred";
 
-        if (message === "Reset already requested recently.") {
+        if (error instanceof RateLimitError) {
             return NextResponse.json(
+                { error: error.message },
+                { status: error.status, headers: error.headers },
+            );
+        }
+
+        if (message === "Reset already requested recently.") {
+            const response = NextResponse.json(
                 {
                     error:
                         "A reset code was already sent recently. Please try again later.",
                 },
                 { status: 429 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
-        return NextResponse.json(
+        const response = NextResponse.json(
             { error: "Internal server error.", details: message },
             { status: 500 }
         );
+        return applyRateLimitHeaders(response, headerSource);
     }
 }

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -6,44 +6,83 @@ import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { normalizeResetContact } from "@/lib/password-reset";
 import { getPasswordStrength } from "@/lib/password-strength";
+import {
+    assertRateLimit,
+    RateLimitError,
+    getClientIp,
+    applyRateLimitHeaders,
+    RateLimitResult,
+} from "@/lib/rate-limit";
 
 export async function POST(req: Request) {
+    let headerSource: RateLimitResult | null = null;
     try {
+        const clientIp = getClientIp(req);
+        const ipResult = assertRateLimit({
+            key: `auth:reset-verify:ip:${clientIp}`,
+            limit: 10,
+            windowMs: 10 * 60 * 1000,
+            message:
+                "Too many password reset attempts from this IP. Please wait before trying again.",
+        });
+        headerSource = ipResult;
+
         const { contact, code, newPassword } = await req.json();
 
         if (typeof contact !== "string" || typeof code !== "string" || typeof newPassword !== "string") {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Missing contact, code, or new password." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         const normalized = normalizeResetContact(contact);
 
         if (!normalized) {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Enter a valid email address." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         const sanitizedCode = code.trim();
         const trimmedPassword = newPassword.trim();
 
+        const contactResult = assertRateLimit({
+            key: `auth:reset-verify:contact:${normalized.normalized}`,
+            limit: 5,
+            windowMs: 15 * 60 * 1000,
+            message:
+                "Too many attempts for this reset code. Please request a new password reset email.",
+        });
+
+        if (
+            !headerSource ||
+            contactResult.remaining < headerSource.remaining ||
+            (contactResult.remaining === headerSource.remaining &&
+                contactResult.reset < headerSource.reset)
+        ) {
+            headerSource = contactResult;
+        }
+
         if (!/^\d{6}$/.test(sanitizedCode)) {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Enter the 6-digit verification code." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         const strength = getPasswordStrength(trimmedPassword);
 
         if (strength.label === "Too weak") {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Create a stronger password before continuing." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         // Find a valid (unexpired) token for this contact + code
@@ -57,10 +96,11 @@ export async function POST(req: Request) {
         });
 
         if (!resetRecord) {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "Invalid or expired code." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         // Get the user from the token's userId
@@ -69,16 +109,18 @@ export async function POST(req: Request) {
         });
 
         if (!user) {
-            return NextResponse.json({ error: "Account not found." }, { status: 404 });
+            const response = NextResponse.json({ error: "Account not found." }, { status: 404 });
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         const passwordMatches = await bcrypt.compare(trimmedPassword, user.password);
 
         if (passwordMatches) {
-            return NextResponse.json(
+            const response = NextResponse.json(
                 { error: "New password must be different from the current password." },
                 { status: 400 }
             );
+            return applyRateLimitHeaders(response, headerSource);
         }
 
         // Hash the new password
@@ -95,18 +137,26 @@ export async function POST(req: Request) {
             where: { userId: user.user_id },
         });
 
-        return NextResponse.json({
+        const response = NextResponse.json({
             success: true,
             message: "Password reset successful.",
         });
+        return applyRateLimitHeaders(response, headerSource);
     } catch (error) {
         console.error(
             "RESET-PASSWORD ERROR:",
             error instanceof Error ? error.message : error
         );
-        return NextResponse.json(
+        if (error instanceof RateLimitError) {
+            return NextResponse.json(
+                { error: error.message },
+                { status: error.status, headers: error.headers },
+            );
+        }
+        const response = NextResponse.json(
             { error: "Internal server error." },
             { status: 500 }
         );
+        return applyRateLimitHeaders(response, headerSource);
     }
 }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 
 import { sendEmail } from "@/lib/email";
+import {
+  assertRateLimit,
+  RateLimitError,
+  getClientIp,
+  applyRateLimitHeaders,
+  RateLimitResult,
+} from "@/lib/rate-limit";
 
 interface ContactFormData {
   name: string;
@@ -9,15 +16,43 @@ interface ContactFormData {
 }
 
 export async function POST(req: Request) {
+  let headerSource: RateLimitResult | null = null;
   try {
+    const clientIp = getClientIp(req);
+    const ipResult = assertRateLimit({
+      key: `contact:ip:${clientIp}`,
+      limit: 3,
+      windowMs: 5 * 60 * 1000,
+      message: "Too many messages from this IP. Please wait a few minutes before trying again.",
+    });
+    headerSource = ipResult;
+
     const { name, email, message } = (await req.json()) as ContactFormData;
 
     // Validate inputs
     if (!name || !email || !message) {
-      return NextResponse.json(
+      const response = NextResponse.json(
         { error: "All fields are required. Please fill out the form completely." },
         { status: 400 }
       );
+      return applyRateLimitHeaders(response, headerSource);
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const emailResult = assertRateLimit({
+      key: `contact:email:${normalizedEmail}`,
+      limit: 5,
+      windowMs: 60 * 60 * 1000,
+      message: "Too many messages from this email address. Please try again later.",
+    });
+
+    if (
+      !headerSource ||
+      emailResult.remaining < headerSource.remaining ||
+      (emailResult.remaining === headerSource.remaining && emailResult.reset < headerSource.reset)
+    ) {
+      headerSource = emailResult;
     }
 
     // Themed HTML email
@@ -46,13 +81,14 @@ export async function POST(req: Request) {
       </div>
     `;
 
-    const inbox = process.env.EMAIL_USER;
-    if (!inbox) {
-      return NextResponse.json(
-        { error: "Email service is not configured." },
-        { status: 500 }
-      );
-    }
+  const inbox = process.env.EMAIL_USER;
+  if (!inbox) {
+    const response = NextResponse.json(
+      { error: "Email service is not configured." },
+      { status: 500 }
+    );
+    return applyRateLimitHeaders(response, headerSource);
+  }
 
     await sendEmail({
       to: inbox,
@@ -63,23 +99,32 @@ export async function POST(req: Request) {
       text: `Name: ${name}\nEmail: ${email}\nMessage:\n${message}`,
     });
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       message: "Message sent successfully! Thank you for contacting HNU Clinic.",
     });
+    return applyRateLimitHeaders(response, headerSource);
   } catch (error) {
     // Type-safe error handling
     if (error instanceof Error) {
+      if (error instanceof RateLimitError) {
+        return NextResponse.json(
+          { error: error.message },
+          { status: error.status, headers: error.headers }
+        );
+      }
       console.error("Email error:", error.message);
-      return NextResponse.json(
+      const response = NextResponse.json(
         { error: `Failed to send message: ${error.message}` },
         { status: 500 }
       );
+      return applyRateLimitHeaders(response, headerSource);
     }
 
     console.error("Unknown error occurred while sending email.");
-    return NextResponse.json(
+    const response = NextResponse.json(
       { error: "An unexpected error occurred. Please try again later." },
       { status: 500 }
     );
+    return applyRateLimitHeaders(response, headerSource);
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,7 @@ import bcrypt from "bcryptjs"; // non-blocking, faster in serverless
 import { prisma } from "@/lib/prisma";
 import { Role, AccountStatus } from "@prisma/client";
 import { withDb } from "@/lib/withDb";
+import { getClientIp, hitRateLimit } from "@/lib/rate-limit";
 
 /** Extend next-auth types used by the application. */
 declare module "next-auth" {
@@ -59,8 +60,21 @@ export const authOptions: NextAuthOptions = {
                 role: { label: "Role", type: "text" },
             },
             // Validate user-provided credentials against stored records.
-            async authorize(credentials): Promise<AppUser | null> {
+            async authorize(credentials, req): Promise<AppUser | null> {
                 if (!credentials) throw new Error("Missing credentials.");
+
+                const clientIp = req ? getClientIp(req) : "unknown";
+                const ipResult = hitRateLimit({
+                    key: `auth:login:ip:${clientIp}`,
+                    limit: 10,
+                    windowMs: 60 * 1000,
+                });
+
+                if (!ipResult.ok) {
+                    throw new Error(
+                        "Too many login attempts from this IP. Please wait a minute before trying again.",
+                    );
+                }
 
                 const id = String(credentials.id || "").trim();
                 const password = String(credentials.password || "");
@@ -69,6 +83,20 @@ export const authOptions: NextAuthOptions = {
                     throw new Error("Invalid role provided.");
                 }
                 const role = roleStr as Role;
+
+                if (id) {
+                    const identifierResult = hitRateLimit({
+                        key: `auth:login:user:${role}:${id.toLowerCase()}`,
+                        limit: 5,
+                        windowMs: 5 * 60 * 1000,
+                    });
+
+                    if (!identifierResult.ok) {
+                        throw new Error(
+                            "Too many login attempts for this account. Please try again later or reset your password.",
+                        );
+                    }
+                }
 
                 // Find user (indexed query)
                 const user = await withDb(() =>

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,156 @@
+// src/lib/rate-limit.ts
+import { NextResponse } from "next/server";
+
+interface BucketState {
+    count: number;
+    resetAt: number;
+}
+
+interface ConsumeOptions {
+    key: string;
+    limit: number;
+    windowMs: number;
+}
+
+export interface RateLimitResult {
+    ok: boolean;
+    limit: number;
+    remaining: number;
+    reset: number;
+}
+
+const buckets = new Map<string, BucketState>();
+
+function consume({ key, limit, windowMs }: ConsumeOptions): RateLimitResult {
+    const now = Date.now();
+    const existing = buckets.get(key);
+
+    if (!existing || existing.resetAt <= now) {
+        const resetAt = now + windowMs;
+        buckets.set(key, { count: 1, resetAt });
+        return {
+            ok: true,
+            limit,
+            remaining: Math.max(0, limit - 1),
+            reset: resetAt,
+        };
+    }
+
+    if (existing.count >= limit) {
+        return {
+            ok: false,
+            limit,
+            remaining: 0,
+            reset: existing.resetAt,
+        };
+    }
+
+    existing.count += 1;
+    return {
+        ok: true,
+        limit,
+        remaining: Math.max(0, limit - existing.count),
+        reset: existing.resetAt,
+    };
+}
+
+export function createRateLimitHeaders(result: RateLimitResult): Record<string, string> {
+    const retryAfterSeconds = Math.max(0, Math.ceil((result.reset - Date.now()) / 1000));
+    return {
+        "Retry-After": String(retryAfterSeconds),
+        "X-RateLimit-Limit": String(result.limit),
+        "X-RateLimit-Remaining": String(Math.max(0, result.remaining)),
+        "X-RateLimit-Reset": String(Math.floor(result.reset / 1000)),
+    };
+}
+
+export function applyRateLimitHeaders(
+    response: Response,
+    result?: RateLimitResult | null,
+): Response {
+    if (!result) return response;
+    const headers = createRateLimitHeaders(result);
+    Object.entries(headers).forEach(([header, value]) => {
+        response.headers.set(header, value);
+    });
+    return response;
+}
+
+export class RateLimitError extends Error {
+    public readonly status = 429;
+    public readonly headers: Record<string, string>;
+
+    constructor(message: string, result: RateLimitResult) {
+        super(message);
+        this.name = "RateLimitError";
+        this.headers = createRateLimitHeaders(result);
+    }
+}
+
+interface AssertOptions extends ConsumeOptions {
+    message?: string;
+}
+
+export function assertRateLimit({ key, limit, windowMs, message }: AssertOptions): RateLimitResult {
+    const result = consume({ key, limit, windowMs });
+    if (!result.ok) {
+        throw new RateLimitError(
+            message ?? "Too many requests. Please try again later.",
+            result,
+        );
+    }
+    return result;
+}
+
+type RequestLike = Pick<Request, "headers"> | { headers: Headers };
+
+export function getClientIp(req: RequestLike): string {
+    const headers = req.headers;
+    const forwarded = headers.get("x-forwarded-for");
+    if (forwarded) {
+        const [first] = forwarded.split(",");
+        if (first?.trim()) return first.trim();
+    }
+
+    const realIp = headers.get("x-real-ip") || headers.get("cf-connecting-ip");
+    if (realIp) return realIp;
+
+    return "unknown";
+}
+
+interface WithRateLimitConfig extends Omit<AssertOptions, "key"> {
+    keyGenerator?: (req: Request, ctx: unknown) => string;
+    message?: string;
+}
+
+type RouteHandler = (req: Request, ctx: unknown) => Response | Promise<Response>;
+
+export function withRateLimit(
+    handler: RouteHandler,
+    { keyGenerator, limit, windowMs, message }: WithRateLimitConfig,
+): RouteHandler {
+    return async (req: Request, ctx: unknown) => {
+        const key = keyGenerator ? keyGenerator(req, ctx) : `rl:${getClientIp(req)}`;
+        try {
+            const result = assertRateLimit({ key, limit, windowMs, message });
+            const response = await handler(req, ctx);
+            if (!response.headers.has("X-RateLimit-Limit")) {
+                applyRateLimitHeaders(response, result);
+            }
+            return response;
+        } catch (error) {
+            if (error instanceof RateLimitError) {
+                const res = NextResponse.json(
+                    { error: error.message },
+                    { status: error.status, headers: error.headers },
+                );
+                return res;
+            }
+            throw error;
+        }
+    };
+}
+
+export function hitRateLimit(options: ConsumeOptions): RateLimitResult {
+    return consume(options);
+}


### PR DESCRIPTION
## Summary
- add a reusable rate limiting utility for API routes and shared helpers
- guard NextAuth credential login, password reset requests, and verification flows with IP/contact limits
- throttle the public contact form and surface standard rate limit headers on responses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fddca6988c83338caa7365c5e41c2c