### PR TITLE
Add rate limiting to unauthenticated API surfaces

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,6 +3,40 @@
 export const runtime = "nodejs";
 import NextAuth from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { formFieldKey, ipKey, withRateLimit } from "@/lib/rate-limit";
 
 const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST };
+
+export const GET = handler;
+export const POST = withRateLimit(
+    [
+        {
+            key: ipKey("auth:credentials:ip"),
+            limit: 10,
+            windowMs: 60_000,
+            message: "Too many login attempts from this IP. Please try again soon.",
+        },
+        {
+            key: async (request) => {
+                const baseKey = await formFieldKey("id", "auth:credentials:id")(request);
+                if (!baseKey) return null;
+                try {
+                    const cloned = request.clone();
+                    const form = await cloned.formData();
+                    const role = form.get("role");
+                    const roleKey = typeof role === "string" && role
+                        ? role.toUpperCase()
+                        : "UNKNOWN";
+                    return `${baseKey}:${roleKey}`;
+                } catch (error) {
+                    console.warn("Failed to read credentials role for rate limiting", error);
+                    return baseKey;
+                }
+            },
+            limit: 5,
+            windowMs: 60_000,
+            message: "Too many attempts for this account. Please wait a minute before retrying.",
+        },
+    ],
+    handler
+);

--- a/src/app/api/auth/request-reset/route.ts
+++ b/src/app/api/auth/request-reset/route.ts
@@ -5,8 +5,9 @@ import { prisma } from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { normalizeResetContact } from "@/lib/password-reset";
 import { generateNumericCode } from "@/lib/security";
+import { ipKey, jsonFieldKey, withRateLimit } from "@/lib/rate-limit";
 
-export async function POST(req: Request) {
+async function handler(req: Request) {
     try {
         const { contact } = await req.json();
 
@@ -163,3 +164,21 @@ export async function POST(req: Request) {
         );
     }
 }
+
+export const POST = withRateLimit(
+    [
+        {
+            key: ipKey("auth:request-reset:ip"),
+            limit: 5,
+            windowMs: 10 * 60_000,
+            message: "Too many reset requests from this IP. Please wait before trying again.",
+        },
+        {
+            key: jsonFieldKey("contact", "auth:request-reset:contact"),
+            limit: 3,
+            windowMs: 15 * 60_000,
+            message: "A reset code was already sent recently. Please check your inbox or try later.",
+        },
+    ],
+    handler
+);

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -6,8 +6,9 @@ import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { normalizeResetContact } from "@/lib/password-reset";
 import { getPasswordStrength } from "@/lib/password-strength";
+import { ipKey, jsonFieldKey, withRateLimit } from "@/lib/rate-limit";
 
-export async function POST(req: Request) {
+async function handler(req: Request) {
     try {
         const { contact, code, newPassword } = await req.json();
 
@@ -110,3 +111,21 @@ export async function POST(req: Request) {
         );
     }
 }
+
+export const POST = withRateLimit(
+    [
+        {
+            key: ipKey("auth:reset-password:ip"),
+            limit: 10,
+            windowMs: 5 * 60_000,
+            message: "Too many password reset attempts from this IP. Please try again later.",
+        },
+        {
+            key: jsonFieldKey("contact", "auth:reset-password:contact"),
+            limit: 5,
+            windowMs: 5 * 60_000,
+            message: "Too many verification attempts for this contact. Please wait before retrying.",
+        },
+    ],
+    handler
+);

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { sendEmail } from "@/lib/email";
+import { ipKey, jsonFieldKey, withRateLimit } from "@/lib/rate-limit";
 
 interface ContactFormData {
   name: string;
@@ -8,7 +9,7 @@ interface ContactFormData {
   message: string;
 }
 
-export async function POST(req: Request) {
+async function handler(req: Request) {
   try {
     const { name, email, message } = (await req.json()) as ContactFormData;
 
@@ -83,3 +84,21 @@ export async function POST(req: Request) {
     );
   }
 }
+
+export const POST = withRateLimit(
+    [
+        {
+            key: ipKey("contact:ip"),
+            limit: 5,
+            windowMs: 60_000,
+            message: "Too many messages from this IP. Please try again later.",
+        },
+        {
+            key: jsonFieldKey("email", "contact:email"),
+            limit: 3,
+            windowMs: 10 * 60_000,
+            message: "We already received a few messages from this email recently. Please wait before sending another.",
+        },
+    ],
+    handler
+);

--- a/src/app/api/meta/doctor-availability/route.ts
+++ b/src/app/api/meta/doctor-availability/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { withDb } from "@/lib/withDb";
 import { archiveExpiredDutyHours } from "@/lib/duty-hours";
 import { startOfManilaDay, endOfManilaDay } from "@/lib/time";
+import { getClientIp, withRateLimit } from "@/lib/rate-limit";
 
 /**
  * GET /api/meta/doctor-availability
@@ -13,7 +14,7 @@ import { startOfManilaDay, endOfManilaDay } from "@/lib/time";
  *
  * Returns: Array of available time slots (15 mins each)
  */
-export async function GET(req: Request) {
+async function handler(req: Request) {
     try {
         const { searchParams } = new URL(req.url);
         const clinic_id = searchParams.get("clinic_id");
@@ -113,3 +114,19 @@ export async function GET(req: Request) {
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
     }
 }
+
+export const GET = withRateLimit(
+    {
+        key: (request) => {
+            const ip = getClientIp(request);
+            if (!ip) return null;
+            const { searchParams } = new URL(request.url);
+            const doctor = searchParams.get("doctor_user_id") ?? "any";
+            return `meta:doctor-availability:${ip}:${doctor}`;
+        },
+        limit: 20,
+        windowMs: 60_000,
+        message: "Too many availability checks. Please wait before trying again.",
+    },
+    handler
+);

--- a/src/app/api/meta/doctors/route.ts
+++ b/src/app/api/meta/doctors/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { AccountStatus, Role } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { withDb } from "@/lib/withDb";
+import { getClientIp, withRateLimit } from "@/lib/rate-limit";
 
 /**
  * GET /api/meta/doctors?clinic_id=...&service_type=...
  * Returns doctors available for a given clinic and filtered by service type.
  */
-export async function GET(req: Request) {
+async function handler(req: Request) {
     try {
         const { searchParams } = new URL(req.url);
         const clinic_id = searchParams.get("clinic_id");
@@ -77,3 +78,19 @@ export async function GET(req: Request) {
         );
     }
 }
+
+export const GET = withRateLimit(
+    {
+        key: (request) => {
+            const ip = getClientIp(request);
+            if (!ip) return null;
+            const { searchParams } = new URL(request.url);
+            const clinic = searchParams.get("clinic_id") ?? "any";
+            return `meta:doctors:${ip}:${clinic}`;
+        },
+        limit: 30,
+        windowMs: 60_000,
+        message: "Too many doctor directory requests. Please try again later.",
+    },
+    handler
+);

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
+import { ipKey, withRateLimit } from "@/lib/rate-limit";
 
 // define minimal relation types manually
 type UserRelation = {
@@ -21,7 +22,7 @@ type StudentWithUser = {
     lname: string;
 } & UserRelation;
 
-export async function POST(req: Request) {
+async function handler(req: Request) {
     try {
         const { role, employee_id, school_id, patient_id, password } =
             await req.json();
@@ -78,3 +79,37 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Server error" }, { status: 500 });
     }
 }
+
+export const POST = withRateLimit(
+    [
+        {
+            key: ipKey("users:login:ip"),
+            limit: 10,
+            windowMs: 60_000,
+            message: "Too many login attempts from this IP. Please try again shortly.",
+        },
+        {
+            key: async (request) => {
+                if (request.method !== "POST") return null;
+                try {
+                    const body = await request.clone().json();
+                    const roleValue = typeof body?.role === "string" ? body.role : "UNKNOWN";
+                    const candidateId =
+                        (typeof body?.employee_id === "string" && body.employee_id) ||
+                        (typeof body?.school_id === "string" && body.school_id) ||
+                        (typeof body?.patient_id === "string" && body.patient_id) ||
+                        null;
+                    if (!candidateId) return null;
+                    return `users:login:account:${roleValue.toUpperCase()}:${candidateId.toLowerCase()}`;
+                } catch (error) {
+                    console.warn("Failed to derive login identifier for rate limiting", error);
+                    return null;
+                }
+            },
+            limit: 5,
+            windowMs: 60_000,
+            message: "Too many attempts for this account. Please wait before retrying.",
+        },
+    ],
+    handler
+);

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -840,9 +840,9 @@ export default function PatientAppointmentsPage() {
                                                                 : slots.length
                                                                     ? "Select a time"
                                                                     : "No slots available"
-                                        }
-                                    />
-                                </SelectTrigger>
+                                            }
+                                        />
+                                    </SelectTrigger>
                                     <SelectContent>
                                         {slots.map((slot) => (
                                             <SelectItem key={`${slot.start}-${slot.end}`} value={slot.start}>
@@ -874,7 +874,7 @@ export default function PatientAppointmentsPage() {
                         </form>
                     </AppointmentPanel>
 
-                    <Card className="rounded-3xl border-green-100/80 bg-gradient-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-md">
+                    <Card className="rounded-3xl border-green-100/80 bg-linear-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-md">
                         <CardHeader>
                             <CardTitle className="text-lg">Important reminders</CardTitle>
                         </CardHeader>
@@ -1163,7 +1163,7 @@ export default function PatientAppointmentsPage() {
                                 <TableHeader>
                                     <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
                                         <TableHead className="min-w-[180px]">Clinic</TableHead>
-                                        <TableHead className="min-w-[160px]">Doctor</TableHead>
+                                        <TableHead className="min-w-40">Doctor</TableHead>
                                         <TableHead className="min-w-[120px]">Date</TableHead>
                                         <TableHead className="min-w-[120px]">Time</TableHead>
                                         <TableHead className="min-w-[120px]">Status</TableHead>

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -12,10 +12,14 @@ interface Bucket {
     expiresAt: number;
 }
 
+interface ExpirationEntry {
+    key: string;
+    expiresAt: number;
+}
+
 class MemoryRateLimiter {
     private buckets: Map<string, Bucket> = new Map();
-    private lastCleanup = 0;
-    private readonly cleanupIntervalMs = 60_000; // 1 minute
+    private expirations: ExpirationEntry[] = [];
 
     consume(key: string, limit: number, windowMs: number): RateLimitResult {
         const now = Date.now();
@@ -23,7 +27,9 @@ class MemoryRateLimiter {
         const bucket = this.buckets.get(key);
 
         if (!bucket || bucket.expiresAt <= now) {
-            this.buckets.set(key, { count: 1, expiresAt: now + windowMs });
+            const expiresAt = now + windowMs;
+            this.buckets.set(key, { count: 1, expiresAt });
+            this.scheduleExpiration({ key, expiresAt });
             return { success: true };
         }
 
@@ -36,16 +42,88 @@ class MemoryRateLimiter {
     }
 
     private cleanup(now: number) {
-        if (now - this.lastCleanup < this.cleanupIntervalMs) {
-            return;
-        }
+        while (this.expirations.length > 0) {
+            const next = this.expirations[0];
+            if (next.expiresAt > now) {
+                break;
+            }
 
-        this.lastCleanup = now;
-        for (const [key, bucket] of this.buckets) {
-            if (bucket.expiresAt <= now) {
-                this.buckets.delete(key);
+            const expired = this.popExpiration();
+            const bucket = this.buckets.get(expired.key);
+            if (!bucket) {
+                continue;
+            }
+
+            if (bucket.expiresAt <= now && bucket.expiresAt === expired.expiresAt) {
+                this.buckets.delete(expired.key);
             }
         }
+    }
+
+    private scheduleExpiration(entry: ExpirationEntry) {
+        this.expirations.push(entry);
+        this.heapBubbleUp(this.expirations.length - 1);
+    }
+
+    private popExpiration(): ExpirationEntry {
+        const first = this.expirations[0]!;
+        const last = this.expirations.pop()!;
+
+        if (this.expirations.length === 0) {
+            return first;
+        }
+
+        this.expirations[0] = last;
+        this.heapSinkDown(0);
+        return first;
+    }
+
+    private heapBubbleUp(index: number) {
+        const entry = this.expirations[index];
+
+        while (index > 0) {
+            const parentIndex = Math.floor((index - 1) / 2);
+            const parent = this.expirations[parentIndex];
+            if (parent.expiresAt <= entry.expiresAt) {
+                break;
+            }
+
+            this.expirations[index] = parent;
+            index = parentIndex;
+        }
+
+        this.expirations[index] = entry;
+    }
+
+    private heapSinkDown(index: number) {
+        const length = this.expirations.length;
+        const entry = this.expirations[index];
+
+        while (true) {
+            const leftIndex = index * 2 + 1;
+            if (leftIndex >= length) {
+                break;
+            }
+
+            let smallestIndex = leftIndex;
+            const rightIndex = leftIndex + 1;
+
+            if (
+                rightIndex < length &&
+                this.expirations[rightIndex].expiresAt < this.expirations[leftIndex].expiresAt
+            ) {
+                smallestIndex = rightIndex;
+            }
+
+            if (this.expirations[smallestIndex].expiresAt >= entry.expiresAt) {
+                break;
+            }
+
+            this.expirations[index] = this.expirations[smallestIndex];
+            index = smallestIndex;
+        }
+
+        this.expirations[index] = entry;
     }
 }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -90,7 +90,7 @@ export function withRateLimit<Args extends unknown[]>(
 }
 
 export function getClientIp(request: RateLimitedRequest): string | null {
-    const nextReq = request as NextRequest;
+    const nextReq = request as NextRequest & { ip?: string | null };
     if (typeof nextReq.ip === "string" && nextReq.ip.length > 0) {
         return nextReq.ip;
     }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -14,9 +14,12 @@ interface Bucket {
 
 class MemoryRateLimiter {
     private buckets: Map<string, Bucket> = new Map();
+    private lastCleanup = 0;
+    private readonly cleanupIntervalMs = 60_000; // 1 minute
 
     consume(key: string, limit: number, windowMs: number): RateLimitResult {
         const now = Date.now();
+        this.cleanup(now);
         const bucket = this.buckets.get(key);
 
         if (!bucket || bucket.expiresAt <= now) {
@@ -30,6 +33,19 @@ class MemoryRateLimiter {
         }
 
         return { success: false, retryAfterMs: Math.max(0, bucket.expiresAt - now) };
+    }
+
+    private cleanup(now: number) {
+        if (now - this.lastCleanup < this.cleanupIntervalMs) {
+            return;
+        }
+
+        this.lastCleanup = now;
+        for (const [key, bucket] of this.buckets) {
+            if (bucket.expiresAt <= now) {
+                this.buckets.delete(key);
+            }
+        }
     }
 }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,147 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export type RateLimitedRequest = Request | NextRequest;
+
+interface RateLimitResult {
+    success: boolean;
+    retryAfterMs?: number;
+}
+
+interface Bucket {
+    count: number;
+    expiresAt: number;
+}
+
+class MemoryRateLimiter {
+    private buckets: Map<string, Bucket> = new Map();
+
+    consume(key: string, limit: number, windowMs: number): RateLimitResult {
+        const now = Date.now();
+        const bucket = this.buckets.get(key);
+
+        if (!bucket || bucket.expiresAt <= now) {
+            this.buckets.set(key, { count: 1, expiresAt: now + windowMs });
+            return { success: true };
+        }
+
+        if (bucket.count < limit) {
+            bucket.count += 1;
+            return { success: true };
+        }
+
+        return { success: false, retryAfterMs: Math.max(0, bucket.expiresAt - now) };
+    }
+}
+
+const globalKey = Symbol.for("hnu.rateLimiter");
+const globalObject = globalThis as typeof globalThis & { [globalKey]?: MemoryRateLimiter };
+
+if (!globalObject[globalKey]) {
+    globalObject[globalKey] = new MemoryRateLimiter();
+}
+
+const limiter = globalObject[globalKey];
+
+export interface RateLimitRule {
+    key?: (request: RateLimitedRequest) => Promise<string | null> | string | null;
+    limit: number;
+    windowMs: number;
+    message?: string;
+}
+
+function defaultKey(request: RateLimitedRequest): string | null {
+    const ip = getClientIp(request);
+    return ip ? `ip:${ip}` : null;
+}
+
+export function withRateLimit<Args extends unknown[]>(
+    rules: RateLimitRule[] | RateLimitRule,
+    handler: (request: RateLimitedRequest, ...args: Args) => Promise<Response> | Response
+): (request: RateLimitedRequest, ...args: Args) => Promise<Response> {
+    const normalizedRules = Array.isArray(rules) ? rules : [rules];
+
+    return async (request: RateLimitedRequest, ...args: Args) => {
+        for (const rule of normalizedRules) {
+            const key = await (rule.key ?? defaultKey)(request);
+            if (!key) continue;
+
+            const result = limiter.consume(key, rule.limit, rule.windowMs);
+            if (!result.success) {
+                const retryAfterSeconds = result.retryAfterMs
+                    ? Math.ceil(result.retryAfterMs / 1000)
+                    : undefined;
+                const response = NextResponse.json(
+                    {
+                        error: rule.message ?? "Too many requests. Please try again later.",
+                    },
+                    { status: 429 }
+                );
+
+                if (retryAfterSeconds) {
+                    response.headers.set("Retry-After", retryAfterSeconds.toString());
+                }
+
+                return response;
+            }
+        }
+
+        return handler(request, ...args);
+    };
+}
+
+export function getClientIp(request: RateLimitedRequest): string | null {
+    const nextReq = request as NextRequest;
+    if (typeof nextReq.ip === "string" && nextReq.ip.length > 0) {
+        return nextReq.ip;
+    }
+
+    const header = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip");
+    if (!header) return null;
+    return header.split(",")[0]?.trim() || null;
+}
+
+export function ipKey(prefix: string): (request: RateLimitedRequest) => string | null {
+    return (request) => {
+        const ip = getClientIp(request);
+        return ip ? `${prefix}:${ip}` : null;
+    };
+}
+
+export function formFieldKey(
+    field: string,
+    prefix: string
+): (request: RateLimitedRequest) => Promise<string | null> {
+    return async (request) => {
+        if (request.method !== "POST") return null;
+        const cloned = request.clone();
+        try {
+            const form = await cloned.formData();
+            const value = form.get(field);
+            if (typeof value !== "string" || value.length === 0) return null;
+            return `${prefix}:${value.toLowerCase()}`;
+        } catch (error) {
+            console.warn(`Failed to parse form data for field ${field}:`, error);
+            return null;
+        }
+    };
+}
+
+export function jsonFieldKey(
+    field: string,
+    prefix: string
+): (request: RateLimitedRequest) => Promise<string | null> {
+    return async (request) => {
+        if (request.method !== "POST") return null;
+        const cloned = request.clone();
+        try {
+            const body = await cloned.json();
+            const value = body?.[field];
+            if (typeof value !== "string" || value.length === 0) return null;
+            return `${prefix}:${value.toLowerCase()}`;
+        } catch (error) {
+            console.warn(`Failed to parse JSON body for field ${field}:`, error);
+            return null;
+        }
+    };
+}
+


### PR DESCRIPTION
## Summary
- add a shared in-memory rate limiter utility for API route handlers
- throttle credential login, legacy login, password reset, and contact form endpoints
- cap anonymous doctor metadata queries to curb scraping and repeated mutations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fde38bcc9883338810dd315a4a6a8a