### PR TITLE
Require doctor approval after patient reschedules

### DIFF
--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -322,11 +322,12 @@ export async function PATCH(req: Request) {
                 appointment_date,
                 appointment_timestart,
                 appointment_timeend,
-                status: AppointmentStatus.Moved,
+                status: AppointmentStatus.Pending,
+                remarks: null,
             },
         });
 
-        return NextResponse.json({ message: "Appointment rescheduled" });
+        return NextResponse.json({ message: "Reschedule request submitted" });
     } catch (error) {
         console.error("[PATCH /api/patient/appointments]", error);
         return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -307,7 +307,7 @@ export default function PatientAppointmentsPage() {
                 toast.error(data?.message ?? "Failed to reschedule appointment");
                 return;
             }
-            toast.success("Appointment rescheduled");
+            toast.success("Reschedule request sent for doctor approval");
             closeRescheduleDialog();
             loadAppointments();
         } catch {
@@ -1283,8 +1283,8 @@ export default function PatientAppointmentsPage() {
                         <DialogTitle className="text-lg font-semibold text-green-700">Reschedule appointment</DialogTitle>
                         <DialogDescription>
                             {rescheduleTarget
-                                ? `Select a new slot for your appointment with ${rescheduleTarget.doctor}. ${earliestBookedMessage}`
-                                : "Choose a new schedule for your appointment."}
+                                ? `Select a new slot for your appointment with ${rescheduleTarget.doctor}. We'll send the request to the clinic for approval. ${earliestBookedMessage}`
+                                : "Choose a new schedule for your appointment. We'll submit it for doctor approval."}
                         </DialogDescription>
                     </DialogHeader>
 
@@ -1345,7 +1345,7 @@ export default function PatientAppointmentsPage() {
                             >
                                 {rescheduling ? (
                                     <>
-                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Submitting...
                                     </>
                                 ) : (
                                     "Confirm"


### PR DESCRIPTION
## Summary
- reset rescheduled patient appointments back to pending status for doctor review
- refresh patient-facing messaging to explain the reschedule approval flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fded09bedc8333a9146548e0751981