### PR TITLE
Revamp account experiences across user roles

### DIFF
--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -659,7 +659,7 @@ export default function DoctorAccountPage() {
                                     <Button
                                         type="button"
                                         variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
                                         onClick={() => void handleManualRefresh()}
                                         disabled={refreshing || profileLoading}
                                     >
@@ -673,7 +673,7 @@ export default function DoctorAccountPage() {
                                     </Button>
                                     <Button
                                         type="submit"
-                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"
                                         disabled={profileLoading}
                                     >
                                         {profileLoading ? (

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -2,13 +2,27 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import {
+    Loader2,
+    ShieldCheck,
+    ShieldAlert,
+    BarChart3,
+    Stethoscope,
+    Phone,
+    UserRound,
+    KeyRound,
+    HeartPulse,
+    LifeBuoy,
+} from "lucide-react";
 
 import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Card } from "@/components/ui/card";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountSection } from "@/components/account/account-section";
+import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
@@ -76,6 +90,7 @@ export default function DoctorAccountPage() {
 
     const [tempDOB, setTempDOB] = useState("");
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
 
 
     // Load Profile
@@ -227,6 +242,98 @@ export default function DoctorAccountPage() {
 
     const bloodTypeOptions = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
 
+    const statusBadge = profile?.status ?? null;
+
+    const completionFields = profile
+        ? [
+              profile.email,
+              profile.contactno,
+              profile.address,
+              profile.emergencyco_name,
+              profile.emergencyco_num,
+              profile.emergencyco_relation,
+          ]
+        : [];
+
+    const completionCount = completionFields.filter((value) => {
+        if (typeof value === "string") {
+            return value.trim().length > 0;
+        }
+        return Boolean(value);
+    }).length;
+
+    const completionPercent = completionFields.length
+        ? Math.round((completionCount / completionFields.length) * 100)
+        : 0;
+
+    const emergencyReady = Boolean(
+        profile?.emergencyco_name?.trim() &&
+            profile?.emergencyco_num?.trim() &&
+            profile?.emergencyco_relation?.trim()
+    );
+
+    const medicalPrepared = Boolean(profile?.bloodtype?.trim());
+    const emergencyReady = Boolean(
+        profile?.emergencyco_name?.trim() &&
+            profile?.emergencyco_num?.trim() &&
+            profile?.emergencyco_relation?.trim()
+    );
+
+    const summaryItems = profile
+        ? [
+              {
+                  icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,
+                  label: "Account status",
+                  value: profile.status,
+                  helper:
+                      profile.status === "Active"
+                          ? "Ready to access clinic systems."
+                          : "Contact the administrator to reactivate your access.",
+                  accent: profile.status === "Active" ? "emerald" : "rose",
+              },
+              {
+                  icon: BarChart3,
+                  label: "Profile completeness",
+                  value: `${completionPercent}% complete`,
+                  helper:
+                      completionPercent >= 100
+                          ? "All key contact details are filled."
+                          : "Add missing contact or emergency details.",
+                  progress: completionPercent,
+                  accent:
+                      completionPercent >= 80
+                          ? "emerald"
+                          : completionPercent >= 50
+                            ? "amber"
+                            : "rose",
+              },
+              {
+                  icon: HeartPulse,
+                  label: "Clinical readiness",
+                  value: medicalPrepared ? profile.bloodtype ?? "" : "Add blood type",
+                  helper: medicalPrepared
+                      ? `${
+                            profile.allergies?.trim() ? `Allergies: ${profile.allergies}` : "No allergies listed"
+                        }. ${
+                            emergencyReady
+                                ? `Emergency contact: ${profile.emergencyco_name || "—"}`
+                                : "Add an emergency contact for urgent coordination."
+                        }`
+                      : "Provide blood type and medical notes to aid urgent care.",
+                  accent: medicalPrepared ? "teal" : "amber",
+              },
+          ]
+        : [];
+
+    const handleManualRefresh = useCallback(async () => {
+        try {
+            setRefreshing(true);
+            await loadProfile();
+        } finally {
+            setRefreshing(false);
+        }
+    }, [loadProfile]);
+
     if (initializing) {
         return <DoctorAccountLoading />;
     }
@@ -235,302 +342,368 @@ export default function DoctorAccountPage() {
         <DoctorLayout
             title="Account Management"
             description="Keep your clinic profile accurate, secure, and ready for seamless coordination."
-        >
-            <div className="mx-auto w-full max-w-4xl space-y-10">
-                {profile && (
-                    <AccountCard
-                        description="Update your personal details, emergency contacts, and credentials to keep clinic records current."
-                        onPasswordSubmit={handlePasswordSubmit}
-                        contentClassName="space-y-6 pt-6"
+            actions={
+                statusBadge ? (
+                    <span
+                        className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${
+                            statusBadge === "Active"
+                                ? "border-emerald-200 bg-emerald-50/80 text-emerald-700"
+                                : "border-rose-200 bg-rose-50/80 text-rose-600"
+                        }`}
                     >
-                        <form onSubmit={handleProfileUpdate} className="space-y-6">
-                            {/* Basic Info */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">User ID</Label>
-                                    <Input value={profile.user_id} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Employee ID</Label>
-                                    <Input value={profile.username} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Role</Label>
-                                    <Input value={profile.role} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Status</Label>
-                                    <Input value={profile.status} disabled />
-                                </div>
-                                {/* Date of Birth */}
-                                <div>
-                                    <Label className="block mb-1 font-medium">Date of Birth</Label>
+                        <span
+                            className={`h-2 w-2 rounded-full ${
+                                statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"
+                            }`}
+                        />
+                        Status: {statusBadge}
+                    </span>
+                ) : null
+            }
+        >
+            <div className="mx-auto w-full max-w-4xl space-y-8">
+                {profileLoading ? (
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-6 text-center shadow-sm backdrop-blur">
+                        <div className="flex flex-col items-center gap-3 text-emerald-700">
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                            <p className="text-sm font-medium">Saving your latest updates…</p>
+                        </div>
+                    </Card>
+                ) : null}
 
-                                    {/* If already set → disable input */}
-                                    {profile.date_of_birth ? (
-                                        <Input
-                                            type="date"
-                                            value={profile.date_of_birth?.slice(0, 10) || ""}
-                                            disabled
-                                        />
-                                    ) : (
-                                        <>
-                                            <Input
-                                                type="date"
-                                                value={tempDOB}
-                                                onChange={(e) => setTempDOB(e.target.value)}
-                                            />
-                                            {tempDOB && (
-                                                <Button
-                                                    type="button"
-                                                    className="mt-2 rounded-xl bg-green-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
-                                                    onClick={() => setShowDOBConfirm(true)}
-                                                >
-                                                    Confirm date
-                                                </Button>
+                {refreshing ? (
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-6 text-center shadow-sm backdrop-blur">
+                        <div className="flex flex-col items-center gap-3 text-emerald-700">
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                            <p className="text-sm font-medium">Refreshing your profile data…</p>
+                        </div>
+                    </Card>
+                ) : null}
+
+                {profile ? (
+                    <div className="space-y-8">
+                        <AccountSummaryGrid items={summaryItems} />
+                        <AccountCard
+                            description="Update your personal details, emergency contacts, and credentials to keep clinic records current."
+                            onPasswordSubmit={handlePasswordSubmit}
+                        >
+                            <form onSubmit={handleProfileUpdate} className="space-y-10">
+                                <AccountSection
+                                    icon={KeyRound}
+                                    title="Account credentials"
+                                    description="Reference details used across clinic systems."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">User ID</Label>
+                                            <Input value={profile.user_id} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Employee ID</Label>
+                                            <Input value={profile.username} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Role</Label>
+                                            <Input value={profile.role} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Status</Label>
+                                            <Input value={profile.status} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Date of birth</Label>
+                                            {profile.date_of_birth ? (
+                                                <Input
+                                                    type="date"
+                                                    value={profile.date_of_birth?.slice(0, 10) || ""}
+                                                    disabled
+                                                />
+                                            ) : (
+                                                <>
+                                                    <Input
+                                                        type="date"
+                                                        value={tempDOB}
+                                                        onChange={(e) => setTempDOB(e.target.value)}
+                                                    />
+                                                    {tempDOB ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setShowDOBConfirm(true)}
+                                                        >
+                                                            Confirm date
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                    <AlertDialog open={showDOBConfirm} onOpenChange={setShowDOBConfirm}>
+                                                        <AlertDialogContent className="max-w-sm sm:max-w-md">
+                                                            <AlertDialogHeader>
+                                                                <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
+                                                                <AlertDialogDescription>
+                                                                    You are about to set your Date of Birth to{' '}
+                                                                    <span className="font-semibold text-emerald-700">{tempDOB}</span>.
+                                                                    <br />
+                                                                    This action can only be done once and cannot be changed later.
+                                                                </AlertDialogDescription>
+                                                            </AlertDialogHeader>
+
+                                                            <AlertDialogFooter className="mt-4">
+                                                                <AlertDialogCancel
+                                                                    onClick={() => {
+                                                                        setTempDOB("");
+                                                                        setShowDOBConfirm(false);
+                                                                    }}
+                                                                >
+                                                                    Cancel
+                                                                </AlertDialogCancel>
+                                                                <AlertDialogAction
+                                                                    className="bg-emerald-600 hover:bg-emerald-700"
+                                                                    onClick={async () => {
+                                                                        const contactValidation = validateAndNormalizeContacts({
+                                                                            email: profile.email,
+                                                                            contactNumber: profile.contactno,
+                                                                            emergencyNumber: profile.emergencyco_num,
+                                                                        });
+
+                                                                        if (!contactValidation.success) {
+                                                                            toast.error(contactValidation.error);
+                                                                            return;
+                                                                        }
+
+                                                                        const updatedProfile = {
+                                                                            ...profile,
+                                                                            email: contactValidation.email,
+                                                                            contactno: contactValidation.contactNumber,
+                                                                            emergencyco_num: contactValidation.emergencyNumber,
+                                                                            date_of_birth: tempDOB,
+                                                                        };
+
+                                                                        setProfile(updatedProfile);
+                                                                        setShowDOBConfirm(false);
+
+                                                                        try {
+                                                                            setProfileLoading(true);
+                                                                            const payload = {
+                                                                                ...updatedProfile,
+                                                                                bloodtype:
+                                                                                    reverseBloodTypeEnumMap[
+                                                                                        updatedProfile?.bloodtype || ""
+                                                                                    ] || null,
+                                                                            };
+
+                                                                            const res = await fetch("/api/doctor/account/me", {
+                                                                                method: "PUT",
+                                                                                headers: { "Content-Type": "application/json" },
+                                                                                body: JSON.stringify({ profile: payload }),
+                                                                            });
+
+                                                                            const data = await res.json();
+                                                                            if (data.error) {
+                                                                                toast.error(data.error);
+                                                                            } else {
+                                                                                toast.success("Date of Birth saved!");
+                                                                                await loadProfile();
+                                                                            }
+                                                                        } catch {
+                                                                            toast.error("Failed to save Date of Birth");
+                                                                        } finally {
+                                                                            setProfileLoading(false);
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    Confirm
+                                                                </AlertDialogAction>
+                                                            </AlertDialogFooter>
+                                                        </AlertDialogContent>
+                                                    </AlertDialog>
+                                                </>
                                             )}
-                                            <p className="text-xs text-gray-500 mt-1">
-                                                You can only set this once. Once saved, it cannot be changed.
-                                            </p>
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                                            {/* Confirmation Dialog */}
-                                            <AlertDialog open={showDOBConfirm} onOpenChange={setShowDOBConfirm}>
-                                                <AlertDialogContent className="max-w-sm sm:max-w-md">
-                                                    <AlertDialogHeader>
-                                                        <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
-                                                        <AlertDialogDescription>
-                                                            You are about to set your Date of Birth to{" "}
-                                                            <span className="font-semibold text-green-700">{tempDOB}</span>.
-                                                            <br />
-                                                            This action can only be done once and cannot be changed later.
-                                                        </AlertDialogDescription>
-                                                    </AlertDialogHeader>
+                                <AccountSection
+                                    icon={UserRound}
+                                    title="Personal information"
+                                    description="Keep your basic profile details current for accurate coordination."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">First name</Label>
+                                            <Input
+                                                value={profile.fname}
+                                                onChange={(e) => setProfile({ ...profile, fname: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Middle name</Label>
+                                            <Input
+                                                value={profile.mname || ""}
+                                                onChange={(e) => setProfile({ ...profile, mname: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Last name</Label>
+                                            <Input
+                                                value={profile.lname}
+                                                onChange={(e) => setProfile({ ...profile, lname: e.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                                                    <AlertDialogFooter className="mt-4">
-                                                        <AlertDialogCancel
-                                                            onClick={() => {
-                                                                setTempDOB("");
-                                                                setShowDOBConfirm(false);
-                                                            }}
-                                                        >
-                                                            Cancel
-                                                        </AlertDialogCancel>
-                                                        <AlertDialogAction
-                                                            className="bg-green-600 hover:bg-green-700"
-                                                            onClick={async () => {
-                                                                const contactValidation = validateAndNormalizeContacts({
-                                                                    email: profile.email,
-                                                                    contactNumber: profile.contactno,
-                                                                    emergencyNumber: profile.emergencyco_num,
-                                                                });
+                                <AccountSection
+                                    icon={Phone}
+                                    title="Contact & address"
+                                    description="Ensure the clinic can reach you for urgent updates."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Email</Label>
+                                            <Input
+                                                type="email"
+                                                placeholder="example@hnu.edu.ph"
+                                                value={profile.email || ""}
+                                                onChange={(e) => setProfile({ ...profile, email: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                type="tel"
+                                                placeholder="09XXXXXXXXX"
+                                                value={profile.contactno || ""}
+                                                onChange={(e) => setProfile({ ...profile, contactno: e.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Address</Label>
+                                        <Input
+                                            value={profile.address || ""}
+                                            onChange={(e) => setProfile({ ...profile, address: e.target.value })}
+                                        />
+                                    </div>
+                                </AccountSection>
 
-                                                                if (!contactValidation.success) {
-                                                                    toast.error(contactValidation.error);
-                                                                    return;
-                                                                }
+                                <AccountSection
+                                    icon={HeartPulse}
+                                    title="Medical background"
+                                    description="Supports faster care during clinical operations."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Blood type</Label>
+                                            <Select
+                                                value={profile.bloodtype || ""}
+                                                onValueChange={(val) => setProfile({ ...profile, bloodtype: val })}
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select blood type" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {bloodTypeOptions.map((type) => (
+                                                        <SelectItem key={type} value={type}>
+                                                            {type}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Allergies</Label>
+                                            <Input
+                                                value={profile.allergies || ""}
+                                                onChange={(e) => setProfile({ ...profile, allergies: e.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
+                                        <Input
+                                            value={profile.medical_cond || ""}
+                                            onChange={(e) => setProfile({ ...profile, medical_cond: e.target.value })}
+                                        />
+                                    </div>
+                                </AccountSection>
 
-                                                                const updatedProfile = {
-                                                                    ...profile,
-                                                                    email: contactValidation.email,
-                                                                    contactno: contactValidation.contactNumber,
-                                                                    emergencyco_num: contactValidation.emergencyNumber,
-                                                                    date_of_birth: tempDOB,
-                                                                };
+                                <AccountSection
+                                    icon={LifeBuoy}
+                                    title="Emergency contact"
+                                    description="Provide someone we can reach when urgent coordination is needed."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact name</Label>
+                                            <Input
+                                                value={profile.emergencyco_name || ""}
+                                                onChange={(e) => setProfile({ ...profile, emergencyco_name: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                value={profile.emergencyco_num || ""}
+                                                onChange={(e) => setProfile({ ...profile, emergencyco_num: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Relationship</Label>
+                                            <Input
+                                                value={profile.emergencyco_relation || ""}
+                                                onChange={(e) => setProfile({ ...profile, emergencyco_relation: e.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                                                                setProfile(updatedProfile);
-                                                                setShowDOBConfirm(false);
-
-                                                                try {
-                                                                    setProfileLoading(true);
-                                                                    const payload = {
-                                                                        ...updatedProfile,
-                                                                        bloodtype:
-                                                                            reverseBloodTypeEnumMap[
-                                                                                updatedProfile?.bloodtype || ""
-                                                                            ] || null,
-                                                                    };
-
-                                                                    const res = await fetch("/api/doctor/account/me", {
-                                                                        method: "PUT",
-                                                                        headers: { "Content-Type": "application/json" },
-                                                                        body: JSON.stringify({ profile: payload }),
-                                                                    });
-
-                                                                    const data = await res.json();
-                                                                    if (data.error) {
-                                                                        toast.error(data.error);
-                                                                    } else {
-                                                                        toast.success("Date of Birth saved!");
-                                                                        await loadProfile(); // refresh profile
-                                                                    }
-                                                                } catch {
-                                                                    toast.error("Failed to save Date of Birth");
-                                                                } finally {
-                                                                    setProfileLoading(false);
-                                                                }
-                                                            }}
-                                                        >
-                                                            Confirm
-                                                        </AlertDialogAction>
-                                                    </AlertDialogFooter>
-                                                </AlertDialogContent>
-                                            </AlertDialog>
-                                        </>
-                                    )}
-                                </div>
-
-                            </div>
-
-                            {/* Personal Info */}
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">First Name</Label>
-                                    <Input
-                                        value={profile.fname}
-                                        onChange={(e) => setProfile({ ...profile, fname: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Middle Name</Label>
-                                    <Input
-                                        value={profile.mname || ""}
-                                        onChange={(e) => setProfile({ ...profile, mname: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Last Name</Label>
-                                    <Input
-                                        value={profile.lname}
-                                        onChange={(e) => setProfile({ ...profile, lname: e.target.value })}
-                                    />
-                                </div>
-                            </div>
-
-                            {/* Contact Info */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Email</Label>
-                                    <Input
-                                        type="email"
-                                        placeholder="example@hnu.edu.ph"
-                                        value={profile.email || ""}
-                                        onChange={(e) => setProfile({ ...profile, email: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Contact No</Label>
-                                    <Input
-                                        type="tel"
-                                        placeholder="09XXXXXXXXX"
-                                        value={profile.contactno || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, contactno: e.target.value })
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            {/* Address & Medical */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Address</Label>
-                                    <Input
-                                        value={profile.address || ""}
-                                        onChange={(e) => setProfile({ ...profile, address: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Allergies</Label>
-                                    <Input
-                                        value={profile.allergies || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, allergies: e.target.value })
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            <div>
-                                <Label className="block mb-1 font-medium">Medical Conditions</Label>
-                                <Input
-                                    value={profile.medical_cond || ""}
-                                    onChange={(e) =>
-                                        setProfile({ ...profile, medical_cond: e.target.value })
-                                    }
-                                />
-                            </div>
-
-                            {/* Blood Type */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Blood Type</Label>
-                                    <Select
-                                        value={profile.bloodtype || ""}
-                                        onValueChange={(val) =>
-                                            setProfile({ ...profile, bloodtype: val })
-                                        }
+                                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        onClick={() => void handleManualRefresh()}
+                                        disabled={refreshing || profileLoading}
                                     >
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select Blood Type" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {bloodTypeOptions.map((type) => (
-                                                <SelectItem key={type} value={type}>
-                                                    {type}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
+                                        {refreshing ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
+                                            </>
+                                        ) : (
+                                            "Refresh profile"
+                                        )}
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        disabled={profileLoading}
+                                    >
+                                        {profileLoading ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Saving…
+                                            </>
+                                        ) : (
+                                            "Save changes"
+                                        )}
+                                    </Button>
                                 </div>
-                            </div>
-
-                            {/* Emergency Contact */}
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Emergency Contact Name</Label>
-                                    <Input
-                                        value={profile.emergencyco_name || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, emergencyco_name: e.target.value })
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">
-                                        Emergency Contact Number
-                                    </Label>
-                                    <Input
-                                        value={profile.emergencyco_num || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, emergencyco_num: e.target.value })
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">
-                                        Emergency Contact Relation
-                                    </Label>
-                                    <Input
-                                        value={profile.emergencyco_relation || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, emergencyco_relation: e.target.value })
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            <Button
-                                type="submit"
-                                className="flex w-full items-center justify-center gap-2 rounded-xl bg-green-600 text-sm font-semibold text-white hover:bg-green-700"
-                                disabled={profileLoading}
-                            >
-                                {profileLoading && <Loader2 className="h-5 w-5 animate-spin" />}
-                                {profileLoading ? "Saving..." : "Save Changes"}
-                            </Button>
-                        </form>
-                    </AccountCard>
+                            </form>
+                        </AccountCard>
+                    </div>
+                ) : (
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-6 text-center shadow-sm backdrop-blur">
+                        <div className="space-y-2">
+                            <Stethoscope className="mx-auto h-6 w-6 text-emerald-600" />
+                            <p className="text-sm text-muted-foreground">
+                                We couldn&apos;t retrieve your account information right now. Try refreshing or contact the clinic administrator.
+                            </p>
+                        </div>
+                    </Card>
                 )}
             </div>
         </DoctorLayout>
     );
+
 }

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -23,6 +23,7 @@ import { Card } from "@/components/ui/card";
 import { AccountCard } from "@/components/account/account-card";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
+import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
@@ -274,7 +275,7 @@ export default function DoctorAccountPage() {
 
     const medicalPrepared = Boolean(profile?.bloodtype?.trim());
 
-    const summaryItems = profile
+    const summaryItems: AccountSummaryItem[] = profile
         ? [
               {
                   icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -273,11 +273,6 @@ export default function DoctorAccountPage() {
     );
 
     const medicalPrepared = Boolean(profile?.bloodtype?.trim());
-    const emergencyReady = Boolean(
-        profile?.emergencyco_name?.trim() &&
-            profile?.emergencyco_num?.trim() &&
-            profile?.emergencyco_relation?.trim()
-    );
 
     const summaryItems = profile
         ? [

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -62,6 +62,7 @@ import {
 import { AccountCard } from "@/components/account/account-card";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
+import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 import { cn } from "@/lib/utils";
@@ -182,7 +183,7 @@ export function NurseAccountsPageClient({
         [users]
     );
 
-    const summaryItems = profile
+    const summaryItems: AccountSummaryItem[] = profile
         ? [
               {
                   icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -2,7 +2,21 @@
 
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
-import { Ban, CheckCircle2, Loader2, Search } from "lucide-react";
+import {
+    Ban,
+    CheckCircle2,
+    Loader2,
+    Search,
+    ShieldCheck,
+    ShieldAlert,
+    BarChart3,
+    ClipboardList,
+    UserRound,
+    Phone,
+    KeyRound,
+    HeartPulse,
+    LifeBuoy,
+} from "lucide-react";
 
 import { NurseLayout } from "@/components/nurse/nurse-layout";
 
@@ -46,6 +60,8 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountSection } from "@/components/account/account-section";
+import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 import { cn } from "@/lib/utils";
@@ -110,6 +126,7 @@ export function NurseAccountsPageClient({
 
     const [profile, setProfile] = useState<NurseAccountProfile | null>(initialProfile);
     const [profileLoading, setProfileLoading] = useState(false);
+    const [refreshingProfile, setRefreshingProfile] = useState(false);
 
     const [profileLoaded, setProfileLoaded] = useState(initialProfileLoaded);
     const [usersLoaded, setUsersLoaded] = useState(initialUsersLoaded);
@@ -133,6 +150,78 @@ export function NurseAccountsPageClient({
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
 
     const initializing = !(profileLoaded && usersLoaded);
+
+    const statusBadge = profile?.status ?? null;
+
+    const completionFields = profile
+        ? [
+              profile.email,
+              profile.contactno,
+              profile.address,
+              profile.bloodtype,
+              profile.emergencyco_name,
+              profile.emergencyco_num,
+              profile.emergencyco_relation,
+          ]
+        : [];
+
+    const completionCount = completionFields.filter((value) => {
+        if (typeof value === "string") {
+            return value.trim().length > 0;
+        }
+        return Boolean(value);
+    }).length;
+
+    const completionPercent = completionFields.length
+        ? Math.round((completionCount / completionFields.length) * 100)
+        : 0;
+
+    const managedAccounts = users.length;
+    const inactiveAccounts = useMemo(
+        () => users.filter((user) => user.status === "Inactive").length,
+        [users]
+    );
+
+    const summaryItems = profile
+        ? [
+              {
+                  icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,
+                  label: "Account status",
+                  value: profile.status,
+                  helper:
+                      profile.status === "Active"
+                          ? "You can administer clinic accounts."
+                          : "Contact an administrator to restore your access.",
+                  accent: profile.status === "Active" ? "emerald" : "rose",
+              },
+              {
+                  icon: BarChart3,
+                  label: "Profile completeness",
+                  value: `${completionPercent}% complete`,
+                  helper:
+                      completionPercent >= 100
+                          ? "All key contact details are filled."
+                          : "Add missing contact or emergency information.",
+                  progress: completionPercent,
+                  accent:
+                      completionPercent >= 80
+                          ? "emerald"
+                          : completionPercent >= 50
+                            ? "amber"
+                            : "rose",
+              },
+              {
+                  icon: ClipboardList,
+                  label: "Accounts overseen",
+                  value: `${managedAccounts} accounts`,
+                  helper:
+                      inactiveAccounts > 0
+                          ? `${inactiveAccounts} inactive accounts need attention.`
+                          : "All accounts are currently active.",
+                  accent: inactiveAccounts > 0 ? "amber" : "teal",
+              },
+          ]
+        : [];
 
 
     // Fetch users (deduplicated but allows same visible ID across different roles)
@@ -177,6 +266,15 @@ export function NurseAccountsPageClient({
             setProfileLoaded(true);
         }
     }, []);
+
+    const handleRefreshProfile = useCallback(async () => {
+        try {
+            setRefreshingProfile(true);
+            await loadProfile();
+        } finally {
+            setRefreshingProfile(false);
+        }
+    }, [loadProfile]);
 
     useEffect(() => {
         if (!profileLoaded) {
@@ -530,299 +628,326 @@ export function NurseAccountsPageClient({
         <NurseLayout
             title="Accounts Management"
             description="Create and manage user accounts, update your profile, and control access from one workspace."
+            actions={
+                statusBadge ? (
+                    <span
+                        className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${
+                            statusBadge === "Active"
+                                ? "border-emerald-200 bg-emerald-50/80 text-emerald-700"
+                                : "border-rose-200 bg-rose-50/80 text-rose-600"
+                        }`}
+                    >
+                        <span
+                            className={`h-2 w-2 rounded-full ${
+                                statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"
+                            }`}
+                        />
+                        Status: {statusBadge}
+                    </span>
+                ) : null
+            }
         >
             <section className="px-4 sm:px-6 py-6 sm:py-8 space-y-10 w-full max-w-6xl mx-auto">
                 {/* My Account */}
-                {profile && (
-                    <AccountCard
-                        title="My Account"
-                        description="Review and update your clinic profile details, emergency contacts, and credentials."
-                        onPasswordSubmit={handlePasswordSubmit}
-                        contentClassName="pt-6"
-                    >
-                        <form onSubmit={handleProfileUpdate} className="space-y-6">
-                            {/* Basic Info */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">User ID</Label>
-                                    <Input value={profile.user_id} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Employee ID</Label>
-                                    <Input value={profile.username} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Role</Label>
-                                    <Input value={profile.role} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Status</Label>
-                                    <Input value={profile.status} disabled />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Date of Birth</Label>
+                {profile ? (
+                    <div className="space-y-8">
+                        <AccountSummaryGrid items={summaryItems} />
+                        <AccountCard
+                            title="My Account"
+                            description="Review and update your clinic profile details, emergency contacts, and credentials."
+                            onPasswordSubmit={handlePasswordSubmit}
+                        >
+                            <form onSubmit={handleProfileUpdate} className="space-y-10">
+                                <AccountSection
+                                    icon={KeyRound}
+                                    title="Account credentials"
+                                    description="Reference identifiers and access status."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">User ID</Label>
+                                            <Input value={profile.user_id} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Employee ID</Label>
+                                            <Input value={profile.username} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Role</Label>
+                                            <Input value={profile.role} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Status</Label>
+                                            <Input value={profile.status} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Date of birth</Label>
+                                            {profile.date_of_birth ? (
+                                                <Input type="date" value={profile.date_of_birth?.slice(0, 10) || ""} disabled />
+                                            ) : (
+                                                <>
+                                                    <Input
+                                                        type="date"
+                                                        value={tempDOB}
+                                                        onChange={(event) => setTempDOB(event.target.value)}
+                                                    />
+                                                    {tempDOB ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setShowDOBConfirm(true)}
+                                                        >
+                                                            Confirm date
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                    <AlertDialog open={showDOBConfirm} onOpenChange={setShowDOBConfirm}>
+                                                        <AlertDialogContent className="max-w-sm sm:max-w-md rounded-3xl border border-emerald-100/80 bg-white/95">
+                                                            <AlertDialogHeader>
+                                                                <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
+                                                                <AlertDialogDescription>
+                                                                    You are about to set your Date of Birth to{' '}
+                                                                    <span className="font-semibold text-emerald-700">{tempDOB}</span>.
+                                                                    <br />
+                                                                    This action can only be done once and cannot be changed later.
+                                                                </AlertDialogDescription>
+                                                            </AlertDialogHeader>
+                                                            <AlertDialogFooter className="mt-4">
+                                                                <AlertDialogCancel
+                                                                    onClick={() => {
+                                                                        setTempDOB("");
+                                                                        setShowDOBConfirm(false);
+                                                                    }}
+                                                                >
+                                                                    Cancel
+                                                                </AlertDialogCancel>
+                                                                <AlertDialogAction
+                                                                    className="bg-emerald-600 hover:bg-emerald-700"
+                                                                    onClick={async () => {
+                                                                        const contactValidation = validateAndNormalizeContacts({
+                                                                            email: profile.email,
+                                                                            contactNumber: profile.contactno,
+                                                                            emergencyNumber: profile.emergencyco_num,
+                                                                        });
 
-                                    {/* If already set → disable input */}
-                                    {profile.date_of_birth ? (
-                                        <Input
-                                            type="date"
-                                            value={profile.date_of_birth?.slice(0, 10) || ""}
-                                            disabled
-                                        />
-                                    ) : (
-                                        <>
-                                            <Input
-                                                type="date"
-                                                value={tempDOB}
-                                                onChange={(e) => setTempDOB(e.target.value)}
-                                            />
-                                            {tempDOB && (
-                                                <Button
-                                                    type="button"
-                                                    className="mt-2 bg-green-600 hover:bg-green-700 text-white text-sm"
-                                                    onClick={() => setShowDOBConfirm(true)}
-                                                >
-                                                    Confirm Date
-                                                </Button>
+                                                                        if (!contactValidation.success) {
+                                                                            toast.error(contactValidation.error);
+                                                                            return;
+                                                                        }
+
+                                                                        const updatedProfile = {
+                                                                            ...profile,
+                                                                            email: contactValidation.email,
+                                                                            contactno: contactValidation.contactNumber,
+                                                                            emergencyco_num: contactValidation.emergencyNumber,
+                                                                            date_of_birth: tempDOB,
+                                                                        };
+
+                                                                        setProfile(updatedProfile);
+                                                                        setShowDOBConfirm(false);
+
+                                                                        try {
+                                                                            setProfileLoading(true);
+                                                                            const payload = {
+                                                                                ...updatedProfile,
+                                                                                bloodtype:
+                                                                                    nurseReverseBloodTypeEnumMap[updatedProfile?.bloodtype || ""] || null,
+                                                                            };
+
+                                                                            const res = await fetch("/api/nurse/accounts/me", {
+                                                                                method: "PUT",
+                                                                                headers: { "Content-Type": "application/json" },
+                                                                                body: JSON.stringify({ profile: payload }),
+                                                                            });
+
+                                                                            const data = await res.json();
+                                                                            if (data.error) {
+                                                                                toast.error(data.error);
+                                                                            } else {
+                                                                                toast.success("Date of Birth saved!");
+                                                                                await loadProfile();
+                                                                            }
+                                                                        } catch {
+                                                                            toast.error("Failed to save Date of Birth");
+                                                                        } finally {
+                                                                            setProfileLoading(false);
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    Confirm
+                                                                </AlertDialogAction>
+                                                            </AlertDialogFooter>
+                                                        </AlertDialogContent>
+                                                    </AlertDialog>
+                                                </>
                                             )}
-                                            <p className="text-xs text-gray-500 mt-1">
-                                                You can only set this once. Once saved, it cannot be changed.
-                                            </p>
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                                            {/* Confirmation Dialog (shown only when user saves) */}
-                                            <AlertDialog open={showDOBConfirm} onOpenChange={setShowDOBConfirm}>
-                                                <AlertDialogContent className="max-w-sm sm:max-w-md">
-                                                    <AlertDialogHeader>
-                                                        <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
-                                                        <AlertDialogDescription>
-                                                            You are about to set your Date of Birth to{" "}
-                                                            <span className="font-semibold text-green-700">{tempDOB}</span>.
-                                                            <br />
-                                                            This action can only be done once and cannot be changed later.
-                                                        </AlertDialogDescription>
-                                                    </AlertDialogHeader>
-                                                    <AlertDialogFooter className="mt-4">
-                                                        <AlertDialogCancel
-                                                            onClick={() => {
-                                                                setTempDOB("");
-                                                                setShowDOBConfirm(false);
-                                                            }}
-                                                        >
-                                                            Cancel
-                                                        </AlertDialogCancel>
-                                                        <AlertDialogAction
-                                                            className="bg-green-600 hover:bg-green-700"
-                                                            onClick={async () => {
-                                                                const contactValidation = validateAndNormalizeContacts({
-                                                                    email: profile.email,
-                                                                    contactNumber: profile.contactno,
-                                                                    emergencyNumber: profile.emergencyco_num,
-                                                                });
+                                <AccountSection
+                                    icon={UserRound}
+                                    title="Personal information"
+                                    description="Keep your name details up to date."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">First name</Label>
+                                            <Input value={profile.fname} onChange={(event) => setProfile({ ...profile, fname: event.target.value })} />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Middle name</Label>
+                                            <Input value={profile.mname || ""} onChange={(event) => setProfile({ ...profile, mname: event.target.value })} />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Last name</Label>
+                                            <Input value={profile.lname} onChange={(event) => setProfile({ ...profile, lname: event.target.value })} />
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                                                                if (!contactValidation.success) {
-                                                                    toast.error(contactValidation.error);
-                                                                    return;
-                                                                }
+                                <AccountSection
+                                    icon={Phone}
+                                    title="Contact & address"
+                                    description="Make sure the clinic can reach you quickly."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Email</Label>
+                                            <Input
+                                                type="email"
+                                                placeholder="example@hnu.edu.ph"
+                                                value={profile.email || ""}
+                                                onChange={(event) => setProfile({ ...profile, email: event.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                type="tel"
+                                                placeholder="09XXXXXXXXX"
+                                                value={profile.contactno || ""}
+                                                onChange={(event) => setProfile({ ...profile, contactno: event.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Address</Label>
+                                        <Input
+                                            value={profile.address || ""}
+                                            onChange={(event) => setProfile({ ...profile, address: event.target.value })}
+                                        />
+                                    </div>
+                                </AccountSection>
 
-                                                                const updatedProfile = {
-                                                                    ...profile,
-                                                                    email: contactValidation.email,
-                                                                    contactno: contactValidation.contactNumber,
-                                                                    emergencyco_num: contactValidation.emergencyNumber,
-                                                                    date_of_birth: tempDOB,
-                                                                };
+                                <AccountSection
+                                    icon={HeartPulse}
+                                    title="Medical background"
+                                    description="Supports emergency preparedness."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Blood type</Label>
+                                            <Select
+                                                value={profile.bloodtype || ""}
+                                                onValueChange={(value) => setProfile({ ...profile, bloodtype: value })}
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select blood type" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {bloodTypeOptions.map((type) => (
+                                                        <SelectItem key={type} value={type}>
+                                                            {type}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Allergies</Label>
+                                            <Input
+                                                value={profile.allergies || ""}
+                                                onChange={(event) => setProfile({ ...profile, allergies: event.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
+                                        <Input
+                                            value={profile.medical_cond || ""}
+                                            onChange={(event) => setProfile({ ...profile, medical_cond: event.target.value })}
+                                        />
+                                    </div>
+                                </AccountSection>
 
-                                                                setProfile(updatedProfile);
-                                                                setShowDOBConfirm(false);
+                                <AccountSection
+                                    icon={LifeBuoy}
+                                    title="Emergency contact"
+                                    description="Provide someone we can reach when urgent coordination is needed."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact name</Label>
+                                            <Input
+                                                value={profile.emergencyco_name || ""}
+                                                onChange={(event) => setProfile({ ...profile, emergencyco_name: event.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                value={profile.emergencyco_num || ""}
+                                                onChange={(event) => setProfile({ ...profile, emergencyco_num: event.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Relationship</Label>
+                                            <Input
+                                                value={profile.emergencyco_relation || ""}
+                                                onChange={(event) => setProfile({ ...profile, emergencyco_relation: event.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                                                                // Immediately save to the DB
-                                                                try {
-                                                                    setProfileLoading(true);
-                                                                    const payload = {
-                                                                        ...updatedProfile,
-                                                                        bloodtype: nurseReverseBloodTypeEnumMap[updatedProfile?.bloodtype || ""] || null,
-                                                                    };
-
-                                                                    const res = await fetch("/api/nurse/accounts/me", {
-                                                                        method: "PUT",
-                                                                        headers: { "Content-Type": "application/json" },
-                                                                        body: JSON.stringify({ profile: payload }),
-                                                                    });
-
-                                                                    const data = await res.json();
-                                                                    if (data.error) {
-                                                                        toast.error(data.error);
-                                                                    } else {
-                                                                        toast.success("Date of Birth saved!");
-                                                                        await loadProfile(); // Refresh with updated DOB
-                                                                    }
-                                                                } catch {
-                                                                    toast.error("Failed to save Date of Birth");
-                                                                } finally {
-                                                                    setProfileLoading(false);
-                                                                }
-                                                            }}
-                                                        >
-                                                            Confirm
-                                                        </AlertDialogAction>
-                                                    </AlertDialogFooter>
-                                                </AlertDialogContent>
-                                            </AlertDialog>
-                                        </>
-                                    )}
-                                </div>
-
-                            </div>
-
-                            {/* Personal Info */}
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">First Name</Label>
-                                    <Input
-                                        value={profile.fname}
-                                        onChange={(e) => setProfile({ ...profile, fname: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Middle Name</Label>
-                                    <Input
-                                        value={profile.mname || ""}
-                                        onChange={(e) => setProfile({ ...profile, mname: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Last Name</Label>
-                                    <Input
-                                        value={profile.lname}
-                                        onChange={(e) => setProfile({ ...profile, lname: e.target.value })}
-                                    />
-                                </div>
-                            </div>
-
-                            {/* Contact Info */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Email</Label>
-                                    <Input
-                                        type="email"
-                                        placeholder="example@hnu.edu.ph"
-                                        value={profile.email || ""}
-                                        onChange={(e) => setProfile({ ...profile, email: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Contact No</Label>
-                                    <Input
-                                        type="tel"
-                                        placeholder="09XXXXXXXXX"
-                                        value={profile.contactno || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, contactno: e.target.value })
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            {/* Address & Medical */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Address</Label>
-                                    <Input
-                                        value={profile.address || ""}
-                                        onChange={(e) => setProfile({ ...profile, address: e.target.value })}
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Allergies</Label>
-                                    <Input
-                                        value={profile.allergies || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, allergies: e.target.value })
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            <div>
-                                <Label className="block mb-1 font-medium">Medical Conditions</Label>
-                                <Input
-                                    value={profile.medical_cond || ""}
-                                    onChange={(e) =>
-                                        setProfile({ ...profile, medical_cond: e.target.value })
-                                    }
-                                />
-                            </div>
-
-                            {/* Blood Type */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Blood Type</Label>
-                                    <Select
-                                        value={profile.bloodtype || ""}
-                                        onValueChange={(val) =>
-                                            setProfile({ ...profile, bloodtype: val })
-                                        }
+                                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        onClick={() => void handleRefreshProfile()}
+                                        disabled={profileLoading || refreshingProfile}
                                     >
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select Blood Type" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {bloodTypeOptions.map((type) => (
-                                                <SelectItem key={type} value={type}>
-                                                    {type}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
+                                        {refreshingProfile ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
+                                            </>
+                                        ) : (
+                                            "Refresh profile"
+                                        )}
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        disabled={profileLoading}
+                                    >
+                                        {profileLoading ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Saving…
+                                            </>
+                                        ) : (
+                                            "Save changes"
+                                        )}
+                                    </Button>
                                 </div>
-                            </div>
+                            </form>
+                        </AccountCard>
+                    </div>
+                ) : null}
 
-                            {/* Emergency Contact */}
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Emergency Contact Name</Label>
-                                    <Input
-                                        value={profile.emergencyco_name || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, emergencyco_name: e.target.value })
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">
-                                        Emergency Contact Number
-                                    </Label>
-                                    <Input
-                                        value={profile.emergencyco_num || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, emergencyco_num: e.target.value })
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">
-                                        Emergency Contact Relation
-                                    </Label>
-                                    <Input
-                                        value={profile.emergencyco_relation || ""}
-                                        onChange={(e) =>
-                                            setProfile({ ...profile, emergencyco_relation: e.target.value })
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            <Button
-                                type="submit"
-                                className="flex w-full items-center justify-center gap-2 rounded-xl bg-green-600 text-sm font-semibold text-white hover:bg-green-700"
-                                disabled={profileLoading}
-                            >
-                                {profileLoading && <Loader2 className="h-5 w-5 animate-spin" />}
-                                {profileLoading ? "Saving..." : "Save Changes"}
-                            </Button>
-                        </form>
-                    </AccountCard>
-                )}
 
                 {/* Create User */}
                 <Card className="rounded-3xl border border-green-100/70 bg-white/80 shadow-sm transition hover:-translate-y-px hover:shadow-md">

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -918,7 +918,7 @@ export function NurseAccountsPageClient({
                                     <Button
                                         type="button"
                                         variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
                                         onClick={() => void handleRefreshProfile()}
                                         disabled={profileLoading || refreshingProfile}
                                     >
@@ -932,7 +932,7 @@ export function NurseAccountsPageClient({
                                     </Button>
                                     <Button
                                         type="submit"
-                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"
                                         disabled={profileLoading}
                                     >
                                         {profileLoading ? (

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -156,14 +156,14 @@ export function NurseAccountsPageClient({
 
     const completionFields = profile
         ? [
-              profile.email,
-              profile.contactno,
-              profile.address,
-              profile.bloodtype,
-              profile.emergencyco_name,
-              profile.emergencyco_num,
-              profile.emergencyco_relation,
-          ]
+            profile.email,
+            profile.contactno,
+            profile.address,
+            profile.bloodtype,
+            profile.emergencyco_name,
+            profile.emergencyco_num,
+            profile.emergencyco_relation,
+        ]
         : [];
 
     const completionCount = completionFields.filter((value) => {
@@ -185,43 +185,43 @@ export function NurseAccountsPageClient({
 
     const summaryItems: AccountSummaryItem[] = profile
         ? [
-              {
-                  icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,
-                  label: "Account status",
-                  value: profile.status,
-                  helper:
-                      profile.status === "Active"
-                          ? "You can administer clinic accounts."
-                          : "Contact an administrator to restore your access.",
-                  accent: profile.status === "Active" ? "emerald" : "rose",
-              },
-              {
-                  icon: BarChart3,
-                  label: "Profile completeness",
-                  value: `${completionPercent}% complete`,
-                  helper:
-                      completionPercent >= 100
-                          ? "All key contact details are filled."
-                          : "Add missing contact or emergency information.",
-                  progress: completionPercent,
-                  accent:
-                      completionPercent >= 80
-                          ? "emerald"
-                          : completionPercent >= 50
+            {
+                icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,
+                label: "Account status",
+                value: profile.status,
+                helper:
+                    profile.status === "Active"
+                        ? "You can manage accounts."
+                        : "Contact an administrator to restore your access.",
+                accent: profile.status === "Active" ? "emerald" : "rose",
+            },
+            {
+                icon: BarChart3,
+                label: "Profile completeness",
+                value: `${completionPercent}% complete`,
+                helper:
+                    completionPercent >= 100
+                        ? "All key contact details are filled."
+                        : "Add missing contact or emergency information.",
+                progress: completionPercent,
+                accent:
+                    completionPercent >= 80
+                        ? "emerald"
+                        : completionPercent >= 50
                             ? "amber"
                             : "rose",
-              },
-              {
-                  icon: ClipboardList,
-                  label: "Accounts overseen",
-                  value: `${managedAccounts} accounts`,
-                  helper:
-                      inactiveAccounts > 0
-                          ? `${inactiveAccounts} inactive accounts need attention.`
-                          : "All accounts are currently active.",
-                  accent: inactiveAccounts > 0 ? "amber" : "teal",
-              },
-          ]
+            },
+            {
+                icon: ClipboardList,
+                label: "Accounts overseen",
+                value: `${managedAccounts} accounts`,
+                helper:
+                    inactiveAccounts > 0
+                        ? `${inactiveAccounts} inactive accounts need attention.`
+                        : "All accounts are currently active.",
+                accent: inactiveAccounts > 0 ? "amber" : "teal",
+            },
+        ]
         : [];
 
 
@@ -632,16 +632,14 @@ export function NurseAccountsPageClient({
             actions={
                 statusBadge ? (
                     <span
-                        className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${
-                            statusBadge === "Active"
+                        className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${statusBadge === "Active"
                                 ? "border-emerald-200 bg-emerald-50/80 text-emerald-700"
                                 : "border-rose-200 bg-rose-50/80 text-rose-600"
-                        }`}
+                            }`}
                     >
                         <span
-                            className={`h-2 w-2 rounded-full ${
-                                statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"
-                            }`}
+                            className={`h-2 w-2 rounded-full ${statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"
+                                }`}
                         />
                         Status: {statusBadge}
                     </span>

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -544,6 +544,18 @@ export function PatientAccountPageClient({
                                                                                 setProfileLoading(true);
                                                                                 const payload = {
                                                                                     ...updatedProfile,
+                                                                                    department:
+                                                                                        profileType === "student"
+                                                                                            ? patientReverseDepartmentEnumMap[
+                                                                                                  updatedProfile.department || ""
+                                                                                              ] || null
+                                                                                            : updatedProfile.department || null,
+                                                                                    year_level:
+                                                                                        profileType === "student"
+                                                                                            ? patientReverseYearLevelEnumMap[
+                                                                                                  updatedProfile.year_level || ""
+                                                                                              ] || null
+                                                                                            : null,
                                                                                     bloodtype:
                                                                                         patientReverseBloodTypeEnumMap[
                                                                                             updatedProfile?.bloodtype || ""

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -821,7 +821,7 @@ export function PatientAccountPageClient({
                                     <Button
                                         type="button"
                                         variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
                                         onClick={() => {
                                             startProfileTransition(() => {
                                                 void loadProfile();
@@ -839,7 +839,7 @@ export function PatientAccountPageClient({
                                     </Button>
                                     <Button
                                         type="submit"
-                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"
                                         disabled={profileLoading}
                                     >
                                         {profileLoading ? (

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -2,7 +2,19 @@
 
 import { useEffect, useState, useCallback, useTransition } from "react";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import {
+    Loader2,
+    ShieldCheck,
+    ShieldAlert,
+    BarChart3,
+    LifeBuoy,
+    GraduationCap,
+    Briefcase,
+    Phone,
+    UserRound,
+    KeyRound,
+    HeartPulse,
+} from "lucide-react";
 
 import PatientLayout from "@/components/patient/patient-layout";
 import { Button } from "@/components/ui/button";
@@ -28,6 +40,8 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountSection } from "@/components/account/account-section";
+import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
@@ -193,6 +207,79 @@ export function PatientAccountPageClient({
 
     const statusBadge = profile?.status ?? null;
 
+    const completionFields = profile
+        ? [
+              profile.email,
+              profile.contactno,
+              profile.address,
+              profile.bloodtype,
+              profile.allergies,
+              profile.medical_cond,
+              profile.emergencyco_name,
+              profile.emergencyco_num,
+              profile.emergencyco_relation,
+          ]
+        : [];
+
+    const completionCount = completionFields.filter((value) => {
+        if (typeof value === "string") {
+            return value.trim().length > 0;
+        }
+        return Boolean(value);
+    }).length;
+
+    const completionPercent = completionFields.length
+        ? Math.round((completionCount / completionFields.length) * 100)
+        : 0;
+
+    const emergencyReady = Boolean(
+        profile?.emergencyco_name?.trim() &&
+            profile?.emergencyco_num?.trim() &&
+            profile?.emergencyco_relation?.trim()
+    );
+
+    const summaryItems = profile
+        ? [
+              {
+                  icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,
+                  label: "Account status",
+                  value: profile.status,
+                  helper:
+                      profile.status === "Active"
+                          ? "Your account can access clinic services."
+                          : "Contact the clinic team to reactivate access.",
+                  accent: profile.status === "Active" ? "emerald" : "rose",
+              },
+              {
+                  icon: BarChart3,
+                  label: "Profile completeness",
+                  value: `${completionPercent}% complete`,
+                  helper:
+                      completionPercent >= 100
+                          ? "All essential profile fields are complete."
+                          : "Add missing contact or medical information.",
+                  progress: completionPercent,
+                  accent:
+                      completionPercent >= 80
+                          ? "emerald"
+                          : completionPercent >= 50
+                            ? "amber"
+                            : "rose",
+              },
+              {
+                  icon: LifeBuoy,
+                  label: "Emergency readiness",
+                  value: emergencyReady ? "Ready" : "Action required",
+                  helper: emergencyReady
+                      ? `${profile.emergencyco_name || "Emergency contact"}${
+                            profile.emergencyco_relation ? ` (${profile.emergencyco_relation})` : ""
+                        } • ${profile.emergencyco_num || "—"}`
+                      : "Provide an emergency contact name, number, and relationship.",
+                  accent: emergencyReady ? "teal" : "amber",
+              },
+          ]
+        : [];
+
     const handleProfileUpdate = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!profile) return;
@@ -308,333 +395,465 @@ export function PatientAccountPageClient({
             description={layoutDescription}
             actions={
                 statusBadge ? (
-                    <span className="hidden rounded-xl border border-green-100 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-green-700 shadow-sm md:inline-flex">
+                    <span
+                        className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${
+                            statusBadge === "Active"
+                                ? "border-emerald-200 bg-emerald-50/80 text-emerald-700"
+                                : "border-rose-200 bg-rose-50/80 text-rose-600"
+                        }`}
+                    >
+                        <span
+                            className={`h-2 w-2 rounded-full ${
+                                statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"
+                            }`}
+                        />
                         Status: {statusBadge}
                     </span>
                 ) : null
             }
         >
-            <div className="space-y-6">
+            <div className="mx-auto w-full max-w-5xl space-y-8">
                 {profileLoading ? (
-                    <Card className="rounded-3xl border-green-100/80 bg-white/90 p-8 text-center shadow-sm">
-                        <div className="flex flex-col items-center gap-3 text-green-700">
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-8 text-center shadow-sm backdrop-blur">
+                        <div className="flex flex-col items-center gap-3 text-emerald-700">
                             <Loader2 className="h-6 w-6 animate-spin" />
-                            <p className="text-sm">Fetching your profile information…</p>
+                            <p className="text-sm font-medium">Refreshing your profile information…</p>
                         </div>
                     </Card>
                 ) : null}
 
                 {!profileLoading && !profile ? (
-                    <Card className="rounded-3xl border-green-100/80 bg-white/90 p-6 text-center shadow-sm">
-                        <p className="text-sm text-muted-foreground">We couldn&apos;t load your account information right now. Please refresh or contact the clinic team.</p>
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-8 text-center shadow-sm backdrop-blur">
+                        <p className="text-sm text-muted-foreground">
+                            We couldn&apos;t load your account information right now. Please refresh or contact the clinic team.
+                        </p>
                     </Card>
                 ) : null}
 
-                {profile && (
-                    <AccountCard
-                        description="Update your personal, academic, and emergency details to keep the clinic team prepared."
-                        onPasswordSubmit={handlePasswordSubmit}
-                        contentClassName="pt-6"
-                    >
-                        <form onSubmit={handleProfileUpdate} className="space-y-6">
-                                {/* Uneditable Fields */}
-                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                    <div><Label className="block mb-1 font-medium">User ID</Label><Input value={profile.user_id} disabled /></div>
-                                    <div>
-                                        <Label className="block mb-1 font-medium">
-                                            {profileType === "student" ? "School ID" : profileType === "employee" ? "Employee ID" : "ID"}
-                                        </Label>
-                                        <Input value={profile.username} disabled />
-                                    </div>
-                                    <div><Label className="block mb-1 font-medium">Role</Label><Input value={profile.role} disabled /></div>
-                                    <div><Label className="block mb-1 font-medium">Status</Label><Input value={profile.status} disabled /></div>
-                                    <div>
-                                        <Label className="block mb-1 font-medium">Date of Birth</Label>
-                    
-                                        {/* If already set → disable input */}
-                                        {profile.date_of_birth ? (
-                                            <Input
-                                                type="date"
-                                                value={profile.date_of_birth?.slice(0, 10) || ""}
-                                                disabled
-                                            />
-                                        ) : (
-                                            <>
+                {profile ? (
+                    <div className="space-y-8">
+                        <AccountSummaryGrid items={summaryItems} />
+                        <AccountCard
+                            description="Update your personal, academic, and emergency details to keep the clinic team prepared."
+                            onPasswordSubmit={handlePasswordSubmit}
+                        >
+                            <form onSubmit={handleProfileUpdate} className="space-y-10">
+                                <AccountSection
+                                    icon={KeyRound}
+                                    title="Account credentials"
+                                    description="Reference-only details used across clinic systems."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">User ID</Label>
+                                            <Input value={profile.user_id} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">
+                                                {profileType === "student"
+                                                    ? "School ID"
+                                                    : profileType === "employee"
+                                                      ? "Employee ID"
+                                                      : "ID"}
+                                            </Label>
+                                            <Input value={profile.username} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Role</Label>
+                                            <Input value={profile.role} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Status</Label>
+                                            <Input value={profile.status} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Date of birth</Label>
+                                            {profile.date_of_birth ? (
                                                 <Input
                                                     type="date"
-                                                    value={tempDOB}
-                                                    onChange={(e) => setTempDOB(e.target.value)}
+                                                    value={profile.date_of_birth?.slice(0, 10) || ""}
+                                                    disabled
                                                 />
-                                                {tempDOB && (
-                                                    <Button
-                                                        type="button"
-                                                        className="mt-2 rounded-xl bg-green-600 px-3 text-sm font-semibold text-white hover:bg-green-700"
-                                                        onClick={() => setShowDOBConfirm(true)}
-                                                    >
-                                                        Confirm Date
-                                                    </Button>
-                                                )}
-                                                <p className="text-xs text-gray-500 mt-1">
-                                                    You can only set this once. Once saved, it cannot be changed.
-                                                </p>
-                    
-                                                {/* Confirmation Dialog (only shows when user confirms) */}
-                                            {showDOBConfirm ? (
-                                                <AlertDialog open onOpenChange={setShowDOBConfirm}>
-                                                    <AlertDialogContent className="max-w-sm sm:max-w-md">
-                                                        <AlertDialogHeader>
-                                                            <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
-                                                            <AlertDialogDescription>
-                                                                You are about to set your Date of Birth to{" "}
-                                                                <span className="font-semibold text-green-700">{tempDOB}</span>.
-                                                                <br />
-                                                                This action can only be done once and cannot be changed later.
-                                                            </AlertDialogDescription>
-                                                        </AlertDialogHeader>
-                                                        <AlertDialogFooter className="mt-4">
-                                                            <AlertDialogCancel
-                                                                onClick={() => {
-                                                                    setTempDOB("");
-                                                                    setShowDOBConfirm(false);
-                                                                }}
-                                                            >
-                                                                Cancel
-                                                            </AlertDialogCancel>
-                                                            <AlertDialogAction
-                                                                className="bg-green-600 hover:bg-green-700"
-                                                                onClick={async () => {
-                                                                    const contactValidation = validateAndNormalizeContacts({
-                                                                        email: profile.email,
-                                                                        contactNumber: profile.contactno,
-                                                                        emergencyNumber: profile.emergencyco_num,
-                                                                    });
+                                            ) : (
+                                                <>
+                                                    <Input
+                                                        type="date"
+                                                        value={tempDOB}
+                                                        onChange={(e) => setTempDOB(e.target.value)}
+                                                    />
+                                                    {tempDOB ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setShowDOBConfirm(true)}
+                                                        >
+                                                            Confirm date
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                    {showDOBConfirm ? (
+                                                        <AlertDialog open onOpenChange={setShowDOBConfirm}>
+                                                            <AlertDialogContent className="max-w-sm sm:max-w-md">
+                                                                <AlertDialogHeader>
+                                                                    <AlertDialogTitle>Confirm Date of Birth</AlertDialogTitle>
+                                                                    <AlertDialogDescription>
+                                                                        You are about to set your Date of Birth to{" "}
+                                                                        <span className="font-semibold text-emerald-700">{tempDOB}</span>.
+                                                                        <br />
+                                                                        This action can only be done once and cannot be changed later.
+                                                                    </AlertDialogDescription>
+                                                                </AlertDialogHeader>
+                                                                <AlertDialogFooter className="mt-4">
+                                                                    <AlertDialogCancel
+                                                                        onClick={() => {
+                                                                            setTempDOB("");
+                                                                            setShowDOBConfirm(false);
+                                                                        }}
+                                                                    >
+                                                                        Cancel
+                                                                    </AlertDialogCancel>
+                                                                    <AlertDialogAction
+                                                                        className="bg-emerald-600 hover:bg-emerald-700"
+                                                                        onClick={async () => {
+                                                                            const contactValidation = validateAndNormalizeContacts({
+                                                                                email: profile.email,
+                                                                                contactNumber: profile.contactno,
+                                                                                emergencyNumber: profile.emergencyco_num,
+                                                                            });
 
-                                                                    if (!contactValidation.success) {
-                                                                        toast.error(contactValidation.error);
-                                                                        return;
-                                                                    }
+                                                                            if (!contactValidation.success) {
+                                                                                toast.error(contactValidation.error);
+                                                                                return;
+                                                                            }
 
-                                                                    const updatedProfile = {
-                                                                        ...profile,
-                                                                        email: contactValidation.email,
-                                                                        contactno: contactValidation.contactNumber,
-                                                                        emergencyco_num: contactValidation.emergencyNumber,
-                                                                        date_of_birth: tempDOB,
-                                                                    };
+                                                                            const updatedProfile = {
+                                                                                ...profile,
+                                                                                email: contactValidation.email,
+                                                                                contactno: contactValidation.contactNumber,
+                                                                                emergencyco_num: contactValidation.emergencyNumber,
+                                                                                date_of_birth: tempDOB,
+                                                                            };
 
-                                                                    setProfile(updatedProfile);
-                                                                    setShowDOBConfirm(false);
+                                                                            setProfile(updatedProfile);
+                                                                            setShowDOBConfirm(false);
 
-                                                                    try {
-                                                                        setProfileLoading(true);
-                                                                        const payload = {
-                                                                            ...updatedProfile,
-                                                                        bloodtype: patientReverseBloodTypeEnumMap[
-                                                                            updatedProfile?.bloodtype || ""
-                                                                        ] || null,
-                                                                        };
+                                                                            try {
+                                                                                setProfileLoading(true);
+                                                                                const payload = {
+                                                                                    ...updatedProfile,
+                                                                                    bloodtype:
+                                                                                        patientReverseBloodTypeEnumMap[
+                                                                                            updatedProfile?.bloodtype || ""
+                                                                                        ] || null,
+                                                                                };
 
-                                                                        const res = await fetch("/api/patient/account/me", {
-                                                                            method: "PUT",
-                                                                            headers: { "Content-Type": "application/json" },
-                                                                            body: JSON.stringify({ profile: payload }),
-                                                                        });
+                                                                                const res = await fetch("/api/patient/account/me", {
+                                                                                    method: "PUT",
+                                                                                    headers: { "Content-Type": "application/json" },
+                                                                                    body: JSON.stringify({ profile: payload }),
+                                                                                });
 
-                                                                        const data = await res.json();
-                                                                        if (data.error) {
-                                                                            toast.error(data.error);
-                                                                        } else {
-                                                                            toast.success("Date of Birth saved!");
-                                                                            await loadProfile();
-                                                                        }
-                                                                    } catch {
-                                                                        toast.error("Failed to save Date of Birth");
-                                                                    } finally {
-                                                                        setProfileLoading(false);
-                                                                    }
-                                                                }}
-                                                            >
-                                                                Confirm
-                                                            </AlertDialogAction>
-                                                        </AlertDialogFooter>
-                                                    </AlertDialogContent>
-                                                </AlertDialog>
-                                            ) : null}
-
-                                            </>
-                                        )}
-                                    </div>
-                    
-                                    <div><Label className="block mb-1 font-medium">Gender</Label><Input value={profile.gender || ""} disabled /></div>
-                                </div>
-                    
-                                {/* Editable Fields */}
-                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                    <div><Label className="block mb-1 font-medium">First Name</Label><Input value={profile.fname} onChange={(e) => setProfile({ ...profile, fname: e.target.value })} /></div>
-                                    <div><Label className="block mb-1 font-medium">Middle Name</Label><Input value={profile.mname || ""} onChange={(e) => setProfile({ ...profile, mname: e.target.value })} /></div>
-                                    <div><Label className="block mb-1 font-medium">Last Name</Label><Input value={profile.lname} onChange={(e) => setProfile({ ...profile, lname: e.target.value })} /></div>
-                                </div>
-                    
-                                {/* Student Academic Info */}
-                                {profileType === "student" && (
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Department</Label>
-                                            <Select
-                                                value={profile.department || ""}
-                                                onValueChange={(val) =>
-                                                    setProfile({
-                                                        ...profile,
-                                                        department: val,
-                                                        program: "",
-                                                        year_level: "",
-                                                    })
-                                                }
-                                            >
-                                                <SelectTrigger><SelectValue placeholder="Select Department" /></SelectTrigger>
-                                                <SelectContent>
-                                                    {departmentOptions.map((dept) => (
-                                                        <SelectItem key={dept} value={dept}>
-                                                            {dept}
-                                                        </SelectItem>
-                                                    ))}
-                                                </SelectContent>
-                                            </Select>
+                                                                                const data = await res.json();
+                                                                                if (data.error) {
+                                                                                    toast.error(data.error);
+                                                                                } else {
+                                                                                    toast.success("Date of Birth saved!");
+                                                                                    await loadProfile();
+                                                                                }
+                                                                            } catch {
+                                                                                toast.error("Failed to save Date of Birth");
+                                                                            } finally {
+                                                                                setProfileLoading(false);
+                                                                            }
+                                                                        }}
+                                                                    >
+                                                                        Confirm
+                                                                    </AlertDialogAction>
+                                                                </AlertDialogFooter>
+                                                            </AlertDialogContent>
+                                                        </AlertDialog>
+                                                    ) : null}
+                                                </>
+                                            )}
                                         </div>
-                    
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Program</Label>
-                                            <Select
-                                                value={profile.program || ""}
-                                                onValueChange={(val) => setProfile({ ...profile, program: val })}
-                                            >
-                                                <SelectTrigger><SelectValue placeholder="Select Program" /></SelectTrigger>
-                                                <SelectContent>
-                                                    {(programOptions[profile.department || ""] || []).map((prog) => (
-                                                        <SelectItem key={prog} value={prog}>
-                                                            {prog}
-                                                        </SelectItem>
-                                                    ))}
-                                                </SelectContent>
-                                            </Select>
-                                        </div>
-                    
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Year Level</Label>
-                                            <Select
-                                                value={profile.year_level || ""}
-                                                onValueChange={(val) => setProfile({ ...profile, year_level: val })}
-                                            >
-                                                <SelectTrigger><SelectValue placeholder="Select Year Level" /></SelectTrigger>
-                                                <SelectContent>
-                                                    {getYearLevelOptions(
-                                                        profile.department || "",
-                                                        profile.program ?? undefined
-                                                    ).map((lvl) => (
-                                                        <SelectItem key={lvl} value={lvl}>
-                                                            {lvl}
-                                                        </SelectItem>
-                                                    ))}
-                                                </SelectContent>
-                                            </Select>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Gender</Label>
+                                            <Input value={profile.gender || ""} disabled />
                                         </div>
                                     </div>
-                                )}
-                    
-                                {/* Employee Info */}
-                                {profileType === "employee" && (
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                        <div>
-                                            <Label className="block mb-1 font-medium">Department / Office</Label>
+                                </AccountSection>
+
+                                <AccountSection
+                                    icon={UserRound}
+                                    title="Personal information"
+                                    description="Keep your basic profile details current for accurate records."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">First name</Label>
                                             <Input
-                                                value={profile.department || ""}
-                                                onChange={(e) => setProfile({ ...profile, department: e.target.value })}
-                                                placeholder="e.g. HR, Accounting, Nursing"
+                                                value={profile.fname}
+                                                onChange={(e) => setProfile({ ...profile, fname: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Middle name</Label>
+                                            <Input
+                                                value={profile.mname || ""}
+                                                onChange={(e) => setProfile({ ...profile, mname: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Last name</Label>
+                                            <Input
+                                                value={profile.lname}
+                                                onChange={(e) => setProfile({ ...profile, lname: e.target.value })}
                                             />
                                         </div>
                                     </div>
-                                )}
-                    
-                                {/* Contact Info */}
-                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                    <div>
-                                        <Label className="block mb-1 font-medium">Email</Label>
-                                        <Input
-                                            type="email"
-                                            placeholder="example@hnu.edu.ph"
-                                            value={profile.email || ""}
-                                            onChange={(e) => setProfile({ ...profile, email: e.target.value })}
-                                        />
-                                    </div>
-                                    <div>
-                                        <Label className="block mb-1 font-medium">Contact No.</Label>
-                                        <Input
-                                            type="tel"
-                                            placeholder="09XXXXXXXXX"
-                                            value={profile.contactno || ""}
-                                            onChange={(e) => setProfile({ ...profile, contactno: e.target.value })}
-                                        />
-                                    </div>
-                                </div>
-                    
-                                <div>
-                                    <Label className="block mb-1 font-medium">Address</Label>
-                                    <Input
-                                        value={profile.address || ""}
-                                        onChange={(e) => setProfile({ ...profile, address: e.target.value })}
-                                    />
-                                </div>
-                    
-                    
-                                {/* Medical Info */}
-                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                    <div>
-                                        <Label className="block mb-1 font-medium">Blood Type</Label>
-                                        <Select
-                                            value={profile.bloodtype || ""}
-                                            onValueChange={(val) => setProfile({ ...profile, bloodtype: val })}
-                                        >
-                                            <SelectTrigger><SelectValue placeholder="Select Blood Type" /></SelectTrigger>
-                                            <SelectContent>
-                                                {bloodTypeOptions.map((type) => (
-                                                    <SelectItem key={type} value={type}>
-                                                        {type}
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                    <div><Label className="block mb-1 font-medium">Allergies</Label><Input value={profile.allergies || ""} onChange={(e) => setProfile({ ...profile, allergies: e.target.value })} /></div>
-                                </div>
-                    
-                                <div>
-                                    <Label className="block mb-1 font-medium">Medical Conditions</Label>
-                                    <Input value={profile.medical_cond || ""} onChange={(e) => setProfile({ ...profile, medical_cond: e.target.value })} />
-                                </div>
-                    
-                                {/* Emergency Contact */}
-                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                    <div><Label className="block mb-1 font-medium">Emergency Contact Name</Label><Input value={profile.emergencyco_name || ""} onChange={(e) => setProfile({ ...profile, emergencyco_name: e.target.value })} /></div>
-                                    <div><Label className="block mb-1 font-medium">Emergency Contact Number</Label><Input value={profile.emergencyco_num || ""} onChange={(e) => setProfile({ ...profile, emergencyco_num: e.target.value })} /></div>
-                                    <div><Label className="block mb-1 font-medium">Emergency Contact Relation</Label><Input value={profile.emergencyco_relation || ""} onChange={(e) => setProfile({ ...profile, emergencyco_relation: e.target.value })} /></div>
-                                </div>
-                    
-                                <Button
-                                    type="submit"
-                                    className="flex w-full items-center justify-center gap-2 rounded-xl bg-green-600 text-sm font-semibold text-white hover:bg-green-700"
-                                    disabled={profileLoading}
+                                </AccountSection>
+
+                                <AccountSection
+                                    icon={Phone}
+                                    title="Contact & address"
+                                    description="Where the clinic can reach you for updates and reminders."
                                 >
-                                    {profileLoading ? (
-                                        <>
-                                            <Loader2 className="h-5 w-5 animate-spin" /> Saving...
-                                        </>
-                                    ) : (
-                                        "Save Changes"
-                                    )}
-                                </Button>
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Email</Label>
+                                            <Input
+                                                type="email"
+                                                placeholder="example@hnu.edu.ph"
+                                                value={profile.email || ""}
+                                                onChange={(e) => setProfile({ ...profile, email: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                type="tel"
+                                                placeholder="09XXXXXXXXX"
+                                                value={profile.contactno || ""}
+                                                onChange={(e) => setProfile({ ...profile, contactno: e.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Address</Label>
+                                        <Input
+                                            value={profile.address || ""}
+                                            onChange={(e) => setProfile({ ...profile, address: e.target.value })}
+                                        />
+                                    </div>
+                                </AccountSection>
+
+                                {profileType === "student" ? (
+                                    <AccountSection
+                                        icon={GraduationCap}
+                                        title="Academic information"
+                                        description="Help the clinic coordinate with your department."
+                                    >
+                                        <div className="grid gap-4 md:grid-cols-2">
+                                            <div className="space-y-2">
+                                                <Label className="text-sm font-medium text-emerald-900">Department</Label>
+                                                <Select
+                                                    value={profile.department || ""}
+                                                    onValueChange={(val) =>
+                                                        setProfile({
+                                                            ...profile,
+                                                            department: val,
+                                                            program: "",
+                                                            year_level: "",
+                                                        })
+                                                    }
+                                                >
+                                                    <SelectTrigger>
+                                                        <SelectValue placeholder="Select department" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {departmentOptions.map((dept) => (
+                                                            <SelectItem key={dept} value={dept}>
+                                                                {dept}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label className="text-sm font-medium text-emerald-900">Program</Label>
+                                                <Select
+                                                    value={profile.program || ""}
+                                                    onValueChange={(val) => setProfile({ ...profile, program: val })}
+                                                >
+                                                    <SelectTrigger>
+                                                        <SelectValue placeholder="Select program" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {(programOptions[profile.department || ""] || []).map((prog) => (
+                                                            <SelectItem key={prog} value={prog}>
+                                                                {prog}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                            <div className="space-y-2">
+                                                <Label className="text-sm font-medium text-emerald-900">Year level</Label>
+                                                <Select
+                                                    value={profile.year_level || ""}
+                                                    onValueChange={(val) => setProfile({ ...profile, year_level: val })}
+                                                >
+                                                    <SelectTrigger>
+                                                        <SelectValue placeholder="Select year level" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {getYearLevelOptions(
+                                                            profile.department || "",
+                                                            profile.program ?? undefined
+                                                        ).map((lvl) => (
+                                                            <SelectItem key={lvl} value={lvl}>
+                                                                {lvl}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                        </div>
+                                    </AccountSection>
+                                ) : null}
+
+                                {profileType === "employee" ? (
+                                    <AccountSection
+                                        icon={Briefcase}
+                                        title="Employment information"
+                                        description="Share your latest office or department details."
+                                    >
+                                        <div className="grid gap-4 md:grid-cols-2">
+                                            <div className="space-y-2">
+                                                <Label className="text-sm font-medium text-emerald-900">Department / Office</Label>
+                                                <Input
+                                                    value={profile.department || ""}
+                                                    onChange={(e) => setProfile({ ...profile, department: e.target.value })}
+                                                    placeholder="e.g. HR, Accounting, Nursing"
+                                                />
+                                            </div>
+                                        </div>
+                                    </AccountSection>
+                                ) : null}
+
+                                <AccountSection
+                                    icon={HeartPulse}
+                                    title="Medical background"
+                                    description="Supports faster care during clinic visits."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Blood type</Label>
+                                            <Select
+                                                value={profile.bloodtype || ""}
+                                                onValueChange={(val) => setProfile({ ...profile, bloodtype: val })}
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select blood type" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {bloodTypeOptions.map((type) => (
+                                                        <SelectItem key={type} value={type}>
+                                                            {type}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Allergies</Label>
+                                            <Input
+                                                value={profile.allergies || ""}
+                                                onChange={(e) => setProfile({ ...profile, allergies: e.target.value })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
+                                        <Input
+                                            value={profile.medical_cond || ""}
+                                            onChange={(e) => setProfile({ ...profile, medical_cond: e.target.value })}
+                                        />
+                                    </div>
+                                </AccountSection>
+
+                                <AccountSection
+                                    icon={LifeBuoy}
+                                    title="Emergency contact"
+                                    description="Provide someone we can reach in urgent situations."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact name</Label>
+                                            <Input
+                                                value={profile.emergencyco_name || ""}
+                                                onChange={(e) => setProfile({ ...profile, emergencyco_name: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                value={profile.emergencyco_num || ""}
+                                                onChange={(e) => setProfile({ ...profile, emergencyco_num: e.target.value })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Relationship</Label>
+                                            <Input
+                                                value={profile.emergencyco_relation || ""}
+                                                onChange={(e) =>
+                                                    setProfile({ ...profile, emergencyco_relation: e.target.value })
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                </AccountSection>
+
+                                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        onClick={() => {
+                                            startProfileTransition(() => {
+                                                void loadProfile();
+                                            });
+                                        }}
+                                        disabled={profileLoading || isRefreshingProfile}
+                                    >
+                                        {isRefreshingProfile ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
+                                            </>
+                                        ) : (
+                                            "Refresh profile"
+                                        )}
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        disabled={profileLoading}
+                                    >
+                                        {profileLoading ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Saving…
+                                            </>
+                                        ) : (
+                                            "Save changes"
+                                        )}
+                                    </Button>
+                                </div>
                             </form>
-                    </AccountCard>
-                )}
+                        </AccountCard>
+                    </div>
+                ) : null}
             </div>
         </PatientLayout>
     );

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -42,6 +42,7 @@ import {
 import { AccountCard } from "@/components/account/account-card";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
+import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 
@@ -238,7 +239,7 @@ export function PatientAccountPageClient({
             profile?.emergencyco_relation?.trim()
     );
 
-    const summaryItems = profile
+    const summaryItems: AccountSummaryItem[] = profile
         ? [
               {
                   icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -19,6 +19,7 @@ import ScholarLayout from "@/components/scholar/scholar-layout";
 import { AccountCard } from "@/components/account/account-card";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
+import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -299,7 +300,7 @@ export default function ScholarAccountPage() {
             : "Add an emergency contact for urgent support."
         : null;
 
-    const summaryItems = profile
+    const summaryItems: AccountSummaryItem[] = profile
         ? [
               {
                   icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -2,13 +2,26 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import {
+    Loader2,
+    ShieldCheck,
+    ShieldAlert,
+    BarChart3,
+    GraduationCap,
+    Phone,
+    UserRound,
+    KeyRound,
+    HeartPulse,
+    LifeBuoy,
+} from "lucide-react";
 
 import ScholarLayout from "@/components/scholar/scholar-layout";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountSection } from "@/components/account/account-section";
+import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -245,6 +258,87 @@ export default function ScholarAccountPage() {
         [profile?.department]
     );
 
+    const statusBadge = profile?.status ?? null;
+
+    const completionFields = profile
+        ? [
+              profile.email,
+              profile.contactno,
+              profile.address,
+              profile.bloodtype,
+              profile.emergencyco_name,
+              profile.emergencyco_num,
+              profile.emergencyco_relation,
+          ]
+        : [];
+
+    const completionCount = completionFields.filter((value) => {
+        if (typeof value === "string") {
+            return value.trim().length > 0;
+        }
+        return Boolean(value);
+    }).length;
+
+    const completionPercent = completionFields.length
+        ? Math.round((completionCount / completionFields.length) * 100)
+        : 0;
+
+    const emergencyReady = Boolean(
+        profile?.emergencyco_name?.trim() &&
+            profile?.emergencyco_num?.trim() &&
+            profile?.emergencyco_relation?.trim()
+    );
+
+    const academicReady = Boolean(
+        profile?.department?.trim() && profile?.program?.trim() && profile?.year_level?.trim()
+    );
+
+    const emergencySummary = profile
+        ? emergencyReady
+            ? `Emergency contact: ${profile.emergencyco_name || "—"}`
+            : "Add an emergency contact for urgent support."
+        : null;
+
+    const summaryItems = profile
+        ? [
+              {
+                  icon: profile.status === "Active" ? ShieldCheck : ShieldAlert,
+                  label: "Account status",
+                  value: profile.status,
+                  helper:
+                      profile.status === "Active"
+                          ? "You have full access to clinic services."
+                          : "Contact the clinic team to reactivate your access.",
+                  accent: profile.status === "Active" ? "emerald" : "rose",
+              },
+              {
+                  icon: BarChart3,
+                  label: "Profile completeness",
+                  value: `${completionPercent}% complete`,
+                  helper:
+                      completionPercent >= 100
+                          ? emergencySummary || "All essential contact details are provided."
+                          : "Add missing contact or emergency information.",
+                  progress: completionPercent,
+                  accent:
+                      completionPercent >= 80
+                          ? "emerald"
+                          : completionPercent >= 50
+                            ? "amber"
+                            : "rose",
+              },
+              {
+                  icon: GraduationCap,
+                  label: "Academic placement",
+                  value: academicReady ? profile.program ?? "" : "Select program",
+                  helper: academicReady
+                      ? `${profile.department ?? ""}${profile.year_level ? ` • ${profile.year_level}` : ""}`
+                      : "Choose your department, program, and year level.",
+                  accent: academicReady ? "indigo" : "amber",
+              },
+          ]
+        : [];
+
     const loadProfile = useCallback(async () => {
         try {
             setProfileLoading(true);
@@ -414,343 +508,422 @@ export default function ScholarAccountPage() {
         <ScholarLayout
             title="Account Management"
             description="Review your personal information, keep emergency contacts current, and manage your clinic credentials."
-        >
-            <section className="space-y-6">
-                {profileLoading ? (
-                    <Card className="rounded-3xl border border-green-100/70 bg-white/80 shadow-sm">
-                        <CardContent className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-                            <Loader2 className="h-5 w-5 animate-spin text-green-600" />
-                            Loading profile...
-                        </CardContent>
-                    </Card>
-                ) : profile ? (
-                    <AccountCard
-                        title="Scholar profile"
-                        description="Keep your details accurate so the clinic team can reach you quickly."
-                        onPasswordSubmit={handlePasswordSubmit}
-                        onPasswordSuccess={(message) => toast.success(message)}
+            actions={
+                statusBadge ? (
+                    <span
+                        className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${
+                            statusBadge === "Active"
+                                ? "border-emerald-200 bg-emerald-50/80 text-emerald-700"
+                                : "border-rose-200 bg-rose-50/80 text-rose-600"
+                        }`}
                     >
-                        <form className="space-y-6" onSubmit={handleProfileSubmit}>
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <div>
-                                    <Label className="mb-1 block font-medium">User ID</Label>
-                                    <Input value={profile.user_id} disabled />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Scholar ID</Label>
-                                    <Input value={profile.username} disabled />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Role</Label>
-                                    <Input value={profile.role} disabled />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Status</Label>
-                                    <Input value={profile.status} disabled />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Date of birth</Label>
-                                    {profile.date_of_birth ? (
-                                        <Input type="date" value={profile.date_of_birth.slice(0, 10)} disabled />
-                                    ) : (
-                                        <>
+                        <span
+                            className={`h-2 w-2 rounded-full ${
+                                statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"
+                            }`}
+                        />
+                        Status: {statusBadge}
+                    </span>
+                ) : null
+            }
+        >
+            <div className="mx-auto w-full max-w-5xl space-y-8">
+                {profileLoading ? (
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-8 text-center shadow-sm backdrop-blur">
+                        <div className="flex flex-col items-center gap-3 text-emerald-700">
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                            <p className="text-sm font-medium">Loading your scholar profile…</p>
+                        </div>
+                    </Card>
+                ) : null}
+
+                {profile ? (
+                    <div className="space-y-8">
+                        <AccountSummaryGrid items={summaryItems} />
+                        <AccountCard
+                            title="Scholar profile"
+                            description="Keep your details accurate so the clinic team can reach you quickly."
+                            onPasswordSubmit={handlePasswordSubmit}
+                            onPasswordSuccess={(message) => toast.success(message)}
+                        >
+                            <form className="space-y-10" onSubmit={handleProfileSubmit}>
+                                <AccountSection
+                                    icon={KeyRound}
+                                    title="Account credentials"
+                                    description="Reference-only identifiers used across clinic services."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">User ID</Label>
+                                            <Input value={profile.user_id} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Scholar ID</Label>
+                                            <Input value={profile.username} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Role</Label>
+                                            <Input value={profile.role} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Status</Label>
+                                            <Input value={profile.status} disabled />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Date of birth</Label>
+                                            {profile.date_of_birth ? (
+                                                <Input type="date" value={profile.date_of_birth.slice(0, 10)} disabled />
+                                            ) : (
+                                                <>
+                                                    <Input
+                                                        type="date"
+                                                        value={tempDOB}
+                                                        onChange={(event) => setTempDOB(event.target.value)}
+                                                    />
+                                                    {tempDOB ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setDobConfirmOpen(true)}
+                                                        >
+                                                            Confirm date
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                </>
+                                            )}
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Gender</Label>
+                                            <Input value={profile.gender ?? ""} disabled />
+                                        </div>
+                                    </div>
+                                </AccountSection>
+
+                                <AccountSection
+                                    icon={UserRound}
+                                    title="Personal information"
+                                    description="Update your core personal details."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">First name</Label>
                                             <Input
-                                                type="date"
-                                                value={tempDOB}
-                                                onChange={(event) => setTempDOB(event.target.value)}
+                                                value={profile.fname}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, fname: event.target.value } : prev
+                                                    )
+                                                }
                                             />
-                                            {tempDOB ? (
-                                                <Button
-                                                    type="button"
-                                                    className="mt-2 rounded-xl bg-green-600 text-sm font-semibold text-white hover:bg-green-700"
-                                                    onClick={() => setDobConfirmOpen(true)}
-                                                >
-                                                    Confirm date
-                                                </Button>
-                                            ) : null}
-                                            <p className="mt-1 text-xs text-muted-foreground">
-                                                You can only set this once. Once saved, it cannot be changed.
-                                            </p>
-                                        </>
-                                    )}
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Gender</Label>
-                                    <Input value={profile.gender ?? ""} disabled />
-                                </div>
-                            </div>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Middle name</Label>
+                                            <Input
+                                                value={profile.mname ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, mname: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Last name</Label>
+                                            <Input
+                                                value={profile.lname}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, lname: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                            <div className="grid gap-4 md:grid-cols-3">
-                                <div>
-                                    <Label className="mb-1 block font-medium">First name</Label>
-                                    <Input
-                                        value={profile.fname}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, fname: event.target.value } : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Middle name</Label>
-                                    <Input
-                                        value={profile.mname ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, mname: event.target.value } : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Last name</Label>
-                                    <Input
-                                        value={profile.lname}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, lname: event.target.value } : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                            </div>
+                                <AccountSection
+                                    icon={GraduationCap}
+                                    title="Academic details"
+                                    description="Ensure your department and year level are accurate."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Department</Label>
+                                            <Select
+                                                value={profile.department ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile((prev) =>
+                                                        prev
+                                                            ? {
+                                                                  ...prev,
+                                                                  department: value,
+                                                                  program: "",
+                                                                  year_level: "",
+                                                              }
+                                                            : prev
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select department" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {departmentOptions.map((department) => (
+                                                        <SelectItem key={department} value={department}>
+                                                            {department}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Program</Label>
+                                            <Select
+                                                value={profile.program ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, program: value } : prev
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select program" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {availablePrograms.map((program) => (
+                                                        <SelectItem key={program} value={program}>
+                                                            {program}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Year level</Label>
+                                            <Select
+                                                value={profile.year_level ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, year_level: value } : prev
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select year level" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {yearLevelOptions.map((level) => (
+                                                        <SelectItem key={level} value={level}>
+                                                            {level}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                    </div>
+                                </AccountSection>
 
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <div>
-                                    <Label className="mb-1 block font-medium">Department</Label>
-                                    <Select
-                                        value={profile.department ?? ""}
-                                        onValueChange={(value) =>
-                                            setProfile((prev) =>
-                                                prev
-                                                    ? {
-                                                        ...prev,
-                                                        department: value,
-                                                        program: "",
-                                                        year_level: "",
-                                                    }
-                                                    : prev
-                                            )
-                                        }
+                                <AccountSection
+                                    icon={Phone}
+                                    title="Contact & address"
+                                    description="Provide reliable contact information for clinic coordination."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Email</Label>
+                                            <Input
+                                                type="email"
+                                                placeholder="example@hnu.edu.ph"
+                                                value={profile.email ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, email: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                type="tel"
+                                                placeholder="09XXXXXXXXX"
+                                                value={profile.contactno ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, contactno: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Address</Label>
+                                        <Input
+                                            value={profile.address ?? ""}
+                                            onChange={(event) =>
+                                                setProfile((prev) =>
+                                                    prev ? { ...prev, address: event.target.value } : prev
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                </AccountSection>
+
+                                <AccountSection
+                                    icon={HeartPulse}
+                                    title="Medical background"
+                                    description="Helps the clinic respond quickly in emergencies."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-2">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Blood type</Label>
+                                            <Select
+                                                value={profile.bloodtype ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, bloodtype: value } : prev
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="Select blood type" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {bloodTypeOptions.map((type) => (
+                                                        <SelectItem key={type} value={type}>
+                                                            {type}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Allergies</Label>
+                                            <Input
+                                                value={profile.allergies ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, allergies: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
+                                        <Input
+                                            value={profile.medical_cond ?? ""}
+                                            onChange={(event) =>
+                                                setProfile((prev) =>
+                                                    prev ? { ...prev, medical_cond: event.target.value } : prev
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                </AccountSection>
+
+                                <AccountSection
+                                    icon={LifeBuoy}
+                                    title="Emergency contact"
+                                    description="Provide someone we can reach in urgent situations."
+                                >
+                                    <div className="grid gap-4 md:grid-cols-3">
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact name</Label>
+                                            <Input
+                                                value={profile.emergencyco_name ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, emergencyco_name: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Contact number</Label>
+                                            <Input
+                                                value={profile.emergencyco_num ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, emergencyco_num: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label className="text-sm font-medium text-emerald-900">Relationship</Label>
+                                            <Input
+                                                value={profile.emergencyco_relation ?? ""}
+                                                onChange={(event) =>
+                                                    setProfile((prev) =>
+                                                        prev ? { ...prev, emergencyco_relation: event.target.value } : prev
+                                                    )
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                </AccountSection>
+
+                                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        onClick={() => void loadProfile()}
+                                        disabled={profileLoading || updating || dobSaving}
                                     >
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select department" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {departmentOptions.map((department) => (
-                                                <SelectItem key={department} value={department}>
-                                                    {department}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Program</Label>
-                                    <Select
-                                        value={profile.program ?? ""}
-                                        onValueChange={(value) =>
-                                            setProfile((prev) => (prev ? { ...prev, program: value } : prev))
-                                        }
-                                        disabled={availablePrograms.length === 0}
+                                        {profileLoading ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
+                                            </>
+                                        ) : (
+                                            "Refresh profile"
+                                        )}
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        disabled={updating || dobSaving}
                                     >
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select program" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {availablePrograms.map((program) => (
-                                                <SelectItem key={program} value={program}>
-                                                    {program}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
+                                        {updating || dobSaving ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Saving…
+                                            </>
+                                        ) : (
+                                            "Save changes"
+                                        )}
+                                    </Button>
                                 </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Year level</Label>
-                                    <Select
-                                        value={profile.year_level ?? ""}
-                                        onValueChange={(value) =>
-                                            setProfile((prev) => (prev ? { ...prev, year_level: value } : prev))
-                                        }
-                                    >
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select year level" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {yearLevelOptions.map((level) => (
-                                                <SelectItem key={level} value={level}>
-                                                    {level}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                            </div>
-
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <div>
-                                    <Label className="mb-1 block font-medium">Email</Label>
-                                    <Input
-                                        type="email"
-                                        value={profile.email ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, email: event.target.value } : prev
-                                            )
-                                        }
-                                        placeholder="example@hnu.edu.ph"
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Contact number</Label>
-                                    <Input
-                                        value={profile.contactno ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, contactno: event.target.value } : prev
-                                            )
-                                        }
-                                        placeholder="09XXXXXXXXX"
-                                    />
-                                </div>
-                            </div>
-
-                            <div>
-                                <Label className="mb-1 block font-medium">Address</Label>
-                                <Input
-                                    value={profile.address ?? ""}
-                                    onChange={(event) =>
-                                        setProfile((prev) =>
-                                            prev ? { ...prev, address: event.target.value } : prev
-                                        )
-                                    }
-                                />
-                            </div>
-
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <div>
-                                    <Label className="mb-1 block font-medium">Blood type</Label>
-                                    <Select
-                                        value={profile.bloodtype ?? ""}
-                                        onValueChange={(value) =>
-                                            setProfile((prev) => (prev ? { ...prev, bloodtype: value } : prev))
-                                        }
-                                    >
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select blood type" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {bloodTypeOptions.map((type) => (
-                                                <SelectItem key={type} value={type}>
-                                                    {type}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Allergies</Label>
-                                    <Input
-                                        value={profile.allergies ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, allergies: event.target.value } : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            <div>
-                                <Label className="mb-1 block font-medium">Medical conditions</Label>
-                                <Input
-                                    value={profile.medical_cond ?? ""}
-                                    onChange={(event) =>
-                                        setProfile((prev) =>
-                                            prev ? { ...prev, medical_cond: event.target.value } : prev
-                                        )
-                                    }
-                                />
-                            </div>
-
-                            <div className="grid gap-4 md:grid-cols-3">
-                                <div>
-                                    <Label className="mb-1 block font-medium">Emergency contact name</Label>
-                                    <Input
-                                        value={profile.emergencyco_name ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, emergencyco_name: event.target.value } : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Emergency contact number</Label>
-                                    <Input
-                                        value={profile.emergencyco_num ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev ? { ...prev, emergencyco_num: event.target.value } : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                                <div>
-                                    <Label className="mb-1 block font-medium">Emergency contact relation</Label>
-                                    <Input
-                                        value={profile.emergencyco_relation ?? ""}
-                                        onChange={(event) =>
-                                            setProfile((prev) =>
-                                                prev
-                                                    ? { ...prev, emergencyco_relation: event.target.value }
-                                                    : prev
-                                            )
-                                        }
-                                    />
-                                </div>
-                            </div>
-
-                            <Button
-                                type="submit"
-                                className="w-full rounded-xl bg-green-600 text-sm font-semibold text-white hover:bg-green-700"
-                                disabled={updating}
-                            >
-                                {updating ? (
-                                    <span className="flex items-center justify-center gap-2">
-                                        <Loader2 className="h-4 w-4 animate-spin" /> Saving changes...
-                                    </span>
-                                ) : (
-                                    "Save changes"
-                                )}
-                            </Button>
-                        </form>
-                    </AccountCard>
+                            </form>
+                        </AccountCard>
+                    </div>
                 ) : (
-                    <Card className="rounded-3xl border border-red-100/70 bg-white/80 shadow-sm">
-                        <CardContent className="space-y-4 py-16 text-center text-sm text-muted-foreground">
-                            <p>We couldn&apos;t load your scholar profile right now.</p>
+                    <Card className="rounded-[28px] border border-rose-100/70 bg-white/95 px-6 py-8 text-center shadow-sm backdrop-blur">
+                        <div className="space-y-4">
+                            <p className="text-sm text-muted-foreground">We couldn&apos;t load your scholar profile right now.</p>
                             <Button
                                 variant="outline"
-                                className="rounded-xl border-green-200 text-green-700 hover:bg-green-100/60"
+                                className="mx-auto w-full max-w-[200px] rounded-2xl border-emerald-200 text-emerald-700 hover:bg-emerald-50"
                                 onClick={() => void loadProfile()}
+                                disabled={profileLoading}
                             >
                                 Try again
                             </Button>
-                        </CardContent>
+                        </div>
                     </Card>
                 )}
-            </section>
+            </div>
 
             <AlertDialog open={dobConfirmOpen} onOpenChange={setDobConfirmOpen}>
-                <AlertDialogContent className="max-w-sm rounded-3xl border border-green-100/80 bg-white/95">
+                <AlertDialogContent className="max-w-sm rounded-3xl border border-emerald-100/80 bg-white/95">
                     <AlertDialogHeader>
                         <AlertDialogTitle>Confirm date of birth</AlertDialogTitle>
                         <AlertDialogDescription>
                             You are about to set your date of birth to
-                            <span className="font-semibold text-green-700"> {tempDOB}</span>.
+                            <span className="font-semibold text-emerald-700"> {tempDOB}</span>.
                             This action can only be done once and cannot be changed later.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
@@ -764,13 +937,13 @@ export default function ScholarAccountPage() {
                             Cancel
                         </AlertDialogCancel>
                         <AlertDialogAction
-                            className="bg-green-600 hover:bg-green-700"
+                            className="bg-emerald-600 hover:bg-emerald-700"
                             onClick={() => void confirmDateOfBirth()}
                             disabled={dobSaving}
                         >
                             {dobSaving ? (
                                 <span className="flex items-center gap-2">
-                                    <Loader2 className="h-4 w-4 animate-spin" /> Saving...
+                                    <Loader2 className="h-4 w-4 animate-spin" /> Saving…
                                 </span>
                             ) : (
                                 "Confirm"
@@ -781,4 +954,5 @@ export default function ScholarAccountPage() {
             </AlertDialog>
         </ScholarLayout>
     );
+
 }

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -647,10 +647,10 @@ export default function ScholarAccountPage() {
 
                                 <AccountSection
                                     icon={GraduationCap}
-                                    title="Academic details"
-                                    description="Ensure your department and year level are accurate."
+                                    title="Academic information"
+                                    description="Help the clinic coordinate with your department."
                                 >
-                                    <div className="grid gap-4 md:grid-cols-3">
+                                    <div className="grid gap-4 md:grid-cols-2">
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Department</Label>
                                             <Select

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -872,7 +872,7 @@ export default function ScholarAccountPage() {
                                     <Button
                                         type="button"
                                         variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-emerald-200 bg-white/95 px-5 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:bg-emerald-50 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
                                         onClick={() => void loadProfile()}
                                         disabled={profileLoading || updating || dobSaving}
                                     >
@@ -886,7 +886,7 @@ export default function ScholarAccountPage() {
                                     </Button>
                                     <Button
                                         type="submit"
-                                        className="flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
+                                        className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"
                                         disabled={updating || dobSaving}
                                     >
                                         {updating || dobSaving ? (

--- a/src/components/account/account-card.tsx
+++ b/src/components/account/account-card.tsx
@@ -46,26 +46,40 @@ export function AccountCard({
     triggerAriaLabel,
 }: AccountCardProps) {
     return (
-        <Card className={cn("rounded-3xl border border-green-100/80 bg-white/90 shadow-sm", className)}>
+        <Card
+            className={cn(
+                "relative overflow-hidden rounded-[32px] border border-green-100/70 bg-white/95 shadow-xl backdrop-blur",
+                className
+            )}
+        >
+            <div aria-hidden className="pointer-events-none absolute inset-0">
+                <div className="absolute -left-20 top-10 h-56 w-56 rounded-full bg-emerald-100/40 blur-3xl" />
+                <div className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-green-200/40 blur-3xl" />
+                <div className="absolute bottom-0 left-1/2 h-24 w-24 -translate-x-1/2 rounded-full bg-emerald-50/60 blur-2xl" />
+            </div>
             <CardHeader
                 className={cn(
-                    "flex flex-col gap-3 border-b border-green-100/70 pb-4 md:flex-row md:items-center md:justify-between",
+                    "relative flex flex-col gap-4 border-b border-white/10 bg-gradient-to-r from-emerald-600 via-green-600 to-emerald-500 px-6 py-6 text-white md:flex-row md:items-center md:justify-between",
                     headerClassName
                 )}
             >
                 <div className="space-y-1">
-                    <CardTitle className="text-2xl font-bold text-green-600">{title}</CardTitle>
+                    <CardTitle className="text-3xl font-semibold tracking-tight text-white drop-shadow-sm">
+                        {title}
+                    </CardTitle>
                     {description ? (
-                        <p className="text-sm text-muted-foreground">{description}</p>
+                        <p className="text-sm text-emerald-50/90 md:max-w-xl">{description}</p>
                     ) : null}
                 </div>
                 <AccountPasswordDialog
                     onSubmit={onPasswordSubmit}
                     onSuccess={onPasswordSuccess}
                     triggerAriaLabel={triggerAriaLabel}
+                    triggerClassName="rounded-2xl border-white/40 bg-white/20 text-white shadow-sm transition hover:bg-white/30 hover:text-white"
+                    dialogTitle="Update account password"
                 />
             </CardHeader>
-            <CardContent className={cn("pt-6", contentClassName)}>{children}</CardContent>
+            <CardContent className={cn("relative space-y-8 px-6 py-8", contentClassName)}>{children}</CardContent>
         </Card>
     );
 }

--- a/src/components/account/account-password-dialog.tsx
+++ b/src/components/account/account-password-dialog.tsx
@@ -186,7 +186,7 @@ export function AccountPasswordDialog({
                         triggerClassName
                     )}
                 >
-                    <Cog className="h-5 w-5 text-green-600" />
+                    <Cog className="h-5 w-5 text-white" />
                 </Button>
             </DialogTrigger>
 

--- a/src/components/account/account-section.tsx
+++ b/src/components/account/account-section.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface AccountSectionProps {
+    icon: LucideIcon;
+    title: string;
+    description?: ReactNode;
+    children: ReactNode;
+    className?: string;
+    contentClassName?: string;
+}
+
+export function AccountSection({
+    icon: Icon,
+    title,
+    description,
+    children,
+    className,
+    contentClassName,
+}: AccountSectionProps) {
+    return (
+        <section
+            className={cn(
+                "overflow-hidden rounded-3xl border border-green-100/70 bg-white/95 shadow-sm backdrop-blur",
+                className
+            )}
+        >
+            <header className="flex items-start gap-4 border-b border-green-100/70 px-6 py-5">
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-green-50 text-green-600 shadow-inner">
+                    <Icon className="h-5 w-5" />
+                </span>
+                <div className="space-y-1">
+                    <h3 className="text-base font-semibold text-green-700">{title}</h3>
+                    {description ? (
+                        <p className="text-sm text-muted-foreground">{description}</p>
+                    ) : null}
+                </div>
+            </header>
+            <div className={cn("space-y-4 px-6 py-6", contentClassName)}>{children}</div>
+        </section>
+    );
+}
+
+export default AccountSection;

--- a/src/components/account/account-summary.tsx
+++ b/src/components/account/account-summary.tsx
@@ -90,7 +90,7 @@ export function AccountSummaryGrid({ items, className }: AccountSummaryGridProps
                             aria-hidden
                             className={cn(
                                 "pointer-events-none absolute inset-0 opacity-60 blur-sm",
-                                "bg-gradient-to-br",
+                                "bg-linear-to-br",
                                 accent.gradient
                             )}
                         />

--- a/src/components/account/account-summary.tsx
+++ b/src/components/account/account-summary.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+type AccountSummaryAccent = "emerald" | "teal" | "amber" | "indigo" | "rose";
+
+const ACCENT_STYLES: Record<
+    AccountSummaryAccent,
+    {
+        card: string;
+        icon: string;
+        gradient: string;
+        progress: string;
+    }
+> = {
+    emerald: {
+        card: "border-emerald-100/70",
+        icon: "bg-emerald-100 text-emerald-600",
+        gradient: "from-emerald-50 via-transparent to-emerald-100/60",
+        progress: "bg-emerald-500",
+    },
+    teal: {
+        card: "border-teal-100/70",
+        icon: "bg-teal-100 text-teal-600",
+        gradient: "from-teal-50 via-transparent to-teal-100/60",
+        progress: "bg-teal-500",
+    },
+    amber: {
+        card: "border-amber-100/70",
+        icon: "bg-amber-100 text-amber-600",
+        gradient: "from-amber-50 via-transparent to-amber-100/60",
+        progress: "bg-amber-500",
+    },
+    indigo: {
+        card: "border-indigo-100/70",
+        icon: "bg-indigo-100 text-indigo-600",
+        gradient: "from-indigo-50 via-transparent to-indigo-100/60",
+        progress: "bg-indigo-500",
+    },
+    rose: {
+        card: "border-rose-100/70",
+        icon: "bg-rose-100 text-rose-600",
+        gradient: "from-rose-50 via-transparent to-rose-100/60",
+        progress: "bg-rose-500",
+    },
+};
+
+export type AccountSummaryItem = {
+    icon: LucideIcon;
+    label: string;
+    value: ReactNode;
+    helper?: ReactNode;
+    progress?: number;
+    accent?: AccountSummaryAccent;
+};
+
+export interface AccountSummaryGridProps {
+    items: AccountSummaryItem[];
+    className?: string;
+}
+
+export function AccountSummaryGrid({ items, className }: AccountSummaryGridProps) {
+    if (!items.length) {
+        return null;
+    }
+
+    return (
+        <div className={cn("grid gap-4 md:grid-cols-3", className)}>
+            {items.map((item, index) => {
+                const Icon = item.icon;
+                const accent = ACCENT_STYLES[item.accent ?? "emerald"];
+                const progressValue =
+                    typeof item.progress === "number"
+                        ? Math.min(100, Math.max(0, Number.isFinite(item.progress) ? item.progress : 0))
+                        : undefined;
+
+                return (
+                    <div
+                        key={`${item.label}-${index}`}
+                        className={cn(
+                            "relative overflow-hidden rounded-3xl border bg-white/90 shadow-sm backdrop-blur",
+                            accent.card
+                        )}
+                    >
+                        <div
+                            aria-hidden
+                            className={cn(
+                                "pointer-events-none absolute inset-0 opacity-60 blur-sm",
+                                "bg-gradient-to-br",
+                                accent.gradient
+                            )}
+                        />
+                        <div className="relative flex h-full flex-col gap-3 px-5 py-5">
+                            <div className="flex items-center justify-between">
+                                <span
+                                    className={cn(
+                                        "flex h-11 w-11 items-center justify-center rounded-2xl text-sm font-medium shadow-sm",
+                                        accent.icon
+                                    )}
+                                >
+                                    <Icon className="h-5 w-5" />
+                                </span>
+                                <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                                    {item.label}
+                                </span>
+                            </div>
+
+                            <div className="text-lg font-semibold text-slate-900">
+                                {typeof item.value === "string" ? <span>{item.value}</span> : item.value}
+                            </div>
+
+                            {progressValue !== undefined ? (
+                                <Progress
+                                    value={progressValue}
+                                    className="h-2"
+                                    indicatorClassName={accent.progress}
+                                    aria-label={`${item.label} progress`}
+                                />
+                            ) : null}
+
+                            {item.helper ? (
+                                <div className="text-sm text-muted-foreground">
+                                    {typeof item.helper === "string" ? <p>{item.helper}</p> : item.helper}
+                                </div>
+                            ) : null}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+export default AccountSummaryGrid;


### PR DESCRIPTION
## Summary
- introduce reusable AccountSummaryGrid and AccountSection components for modernized account dashboards
- refresh patient, doctor, scholar, and nurse account pages to use the new layout and contextual summaries
- restyle the AccountCard wrapper with gradient header and security dialog polish

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ff58a939d883339e841547f4beb627