### PR TITLE
Improve department dropdown layout for long names

### DIFF
--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -682,8 +682,11 @@ export function PatientAccountPageClient({
                                                         })
                                                     }
                                                 >
-                                                    <SelectTrigger>
-                                                        <SelectValue placeholder="Select department" />
+                                                    <SelectTrigger className="w-full whitespace-normal text-left leading-snug">
+                                                        <SelectValue
+                                                            className="line-clamp-none whitespace-normal text-left"
+                                                            placeholder="Select department"
+                                                        />
                                                     </SelectTrigger>
                                                     <SelectContent>
                                                         {departmentOptions.map((dept) => (


### PR DESCRIPTION
## Summary
- allow the student department select trigger to span the full field width
- enable wrapping on the selected value so long department names no longer overlap the trigger icon

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ff71d6101c8333a543dad0bd44917e