### PR TITLE
Remove nodemailer artifacts and document Gmail credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A role-based health record and appointment platform built with Next.js for the H
 - **Tailwind CSS v4** powers responsive styling, complemented by **shadcn/ui** components in `src/components/ui` for consistent theming and Radix-powered interactions.
 - **Lucide React icons** provide the iconography across dashboards and shared components.
 - **NextAuth Credentials provider** (configured in `src/lib/auth.ts`) manages secure role-aware authentication.
+- **Direct Gmail API integration** in `src/lib/email.ts` delivers transactional mail without relying on Nodemailer.
 - **Zod schemas** validate API payloads, hardening endpoints such as `src/app/api/nurse/accounts/password/route.ts`.
 
 ## 🏥 Platform Overview
@@ -70,7 +71,10 @@ prisma/
 | --- | --- |
 | `DATABASE_URL` | PostgreSQL connection string used by Prisma (`prisma/schema.prisma`). |
 | `NEXTAUTH_SECRET` | Signing secret for NextAuth JWT/session cookies (`src/lib/auth.ts`, `src/middleware.ts`). |
-| `EMAIL_USER`, `EMAIL_PASS` | SMTP credentials for contact emails (`src/app/api/contact/route.ts`, `src/lib/email.ts`). |
+| `EMAIL_USER` | Gmail address used as the sender in notifications (`src/lib/email.ts`). |
+| `GMAIL_CLIENT_ID` | OAuth client ID for Gmail API access (`src/lib/email.ts`). |
+| `GMAIL_CLIENT_SECRET` | OAuth client secret paired with the client ID (`src/lib/email.ts`). |
+| `GMAIL_REFRESH_TOKEN` | Long-lived refresh token used to mint Gmail access tokens (`src/lib/email.ts`). |
 | `NEXT_PUBLIC_APP_URL` | Public base URL used by nurse-side server actions (`src/app/nurse/actions.ts`). |
 | `TZ` | Time-zone override (set to `Asia/Manila` in `next.config.ts`). |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7620,17 +7620,6 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/nypm": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",


### PR DESCRIPTION
## Summary
- remove the optional nodemailer entry from the lockfile now that Gmail API handles delivery
- refresh the README to highlight the direct Gmail integration and list the required OAuth environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902caec6e588327a7dc21fd2405c672