### PR TITLE
Update domain references to hnu-clinic-app.com

### DIFF
--- a/src/app/api/auth/request-reset/route.ts
+++ b/src/app/api/auth/request-reset/route.ts
@@ -131,7 +131,7 @@ async function handler(req: Request) {
           <div style="text-align: center; margin-bottom: 20px;">
             <div style="display: inline-block; background-color: #ffffff; border-radius: 50%; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);">
               <img
-                src="https://hnu-clinic-app.vercel.app/clinic-illustration.png"
+                src="https://www.hnu-clinic-app.com/clinic-illustration.png"
                 alt="HNU Clinic Logo"
                 width="48"
                 height="48"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,7 +74,7 @@ export default function HomePage() {
                                 Manage health records, book visits, and stay connected.
                             </h2>
                             <p className="text-base leading-relaxed text-gray-700 md:text-lg">
-                                Our public homepage at <Link href="https://hnu-clinic-app.vercel.app/" className="font-semibold text-green-700 underline underline-offset-2">hnu-clinic-app.vercel.app</Link> introduces the system students, faculty, and staff use to request appointments, manage records, and coordinate care.
+                                Our public homepage at <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link> introduces the system students, faculty, and staff use to request appointments, manage records, and coordinate care.
                             </p>
                             <p className="text-base leading-relaxed text-gray-700 md:text-lg">
                                 We help patients schedule visits, notify doctors of updates, and keep sensitive information synchronized between care teams—all while upholding the privacy expectations of the HNU community.
@@ -198,7 +198,7 @@ export default function HomePage() {
                             <div className="space-y-4 rounded-2xl border border-green-100 bg-green-50/60 p-6 text-sm text-green-700">
                                 <p className="font-semibold text-green-700">Verified presence</p>
                                 <p>
-                                    This application is presented by HNU Clinic and currently hosted on <Link href="https://hnu-clinic-app.vercel.app/" className="font-semibold underline underline-offset-2">hnu-clinic-app.vercel.app</Link>, where you can review privacy details before signing in.
+                                    This application is presented by HNU Clinic and currently hosted on <Link href="https://www.hnu-clinic-app.com/" className="font-semibold underline underline-offset-2">www.hnu-clinic-app.com</Link>, where you can review privacy details before signing in.
                                 </p>
                                 <p>
                                     Our team typically responds within one business day.

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -16,7 +16,7 @@ export default function PrivacyPage() {
                         </span>
                         <h1 className="text-3xl font-bold text-green-700 md:text-4xl">Privacy Policy</h1>
                         <p className="text-base leading-relaxed text-gray-700 md:text-lg">
-                            This policy explains how the HNU Clinic capstone application collects, uses, and protects information when you visit <Link href="https://hnu-clinic-app.vercel.app/" className="font-semibold text-green-700 underline underline-offset-2">hnu-clinic-app.vercel.app</Link>, request an account, and use the scheduling, records, and notification features offered to the Holy Name University community.
+                            This policy explains how the HNU Clinic capstone application collects, uses, and protects information when you visit <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link>, request an account, and use the scheduling, records, and notification features offered to the Holy Name University community.
                         </p>
                     </div>
 
@@ -85,7 +85,7 @@ export default function PrivacyPage() {
                                 The application encrypts information in transit and at rest. Role-based permissions ensure only authorized clinic personnel can view or update sensitive records, and key actions are logged for auditing.
                             </p>
                             <p>
-                                Hosting is currently provided through Vercel at <Link href="https://hnu-clinic-app.vercel.app/" className="font-medium text-green-700 underline underline-offset-2">hnu-clinic-app.vercel.app</Link>. Access is limited to the HNU Clinic team responsible for this capstone project.
+                                Hosting is currently provided through Vercel at <Link href="https://www.hnu-clinic-app.com/" className="font-medium text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link>. Access is limited to the HNU Clinic team responsible for this capstone project.
                             </p>
                         </section>
 


### PR DESCRIPTION
## Summary
- replace public marketing links to use https://www.hnu-clinic-app.com/
- point transactional email illustration asset at the new domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69032a0290fc83278e3e964a9cf0547a