### PR TITLE
Remove redundant ADMIN role access control

### DIFF
--- a/prisma/migrations/20250930053727_added_changes/migration.sql
+++ b/prisma/migrations/20250930053727_added_changes/migration.sql
@@ -8,7 +8,7 @@
 
 */
 -- CreateEnum
-CREATE TYPE "public"."Role" AS ENUM ('NURSE', 'DOCTOR', 'SCHOLAR', 'PATIENT', 'ADMIN');
+CREATE TYPE "public"."Role" AS ENUM ('NURSE', 'DOCTOR', 'SCHOLAR', 'PATIENT');
 
 -- CreateEnum
 CREATE TYPE "public"."AppointmentStatus" AS ENUM ('Pending', 'Approved', 'Moved', 'Cancelled', 'Completed');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,7 +256,6 @@ enum Role {
   DOCTOR
   SCHOLAR
   PATIENT
-  ADMIN
 }
 
 enum AppointmentStatus {

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -70,7 +70,7 @@ async function ensureUniqueEmployeeId(value: string): Promise<string> {
 // ---------------- CREATE USER ----------------
 export async function POST(req: Request) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const payload = await req.json();
         const roleEnum = payload.role as Role;
@@ -213,7 +213,7 @@ export async function POST(req: Request) {
 // ---------------- LIST USERS ----------------
 export async function GET() {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const users = await prisma.users.findMany({
             include: { student: true, employee: true },
@@ -268,7 +268,7 @@ export async function GET() {
 // ---------------- UPDATE USER STATUS (Activate / Deactivate) ----------------
 export async function PUT(req: Request) {
     try {
-        const session = await requireRole([Role.NURSE, Role.ADMIN]);
+        const session = await requireRole([Role.NURSE]);
 
         const { user_id, newStatus } = await req.json();
 

--- a/src/app/api/nurse/clinic/[id]/appointments/route.ts
+++ b/src/app/api/nurse/clinic/[id]/appointments/route.ts
@@ -81,7 +81,7 @@ function resolveMonthRange(monthParam: string | null) {
 
 export async function GET(req: NextRequest, { params }: RouteContext) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { id } = await params;
         if (!id) {

--- a/src/app/api/nurse/clinic/[id]/route.ts
+++ b/src/app/api/nurse/clinic/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
     { params }: ClinicRouteContext
 ) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { id } = await params;
 
@@ -44,7 +44,7 @@ export async function PUT(
     { params }: ClinicRouteContext
 ) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { id } = await params;
 

--- a/src/app/api/nurse/clinic/route.ts
+++ b/src/app/api/nurse/clinic/route.ts
@@ -6,7 +6,7 @@ import { handleAuthError, requireRole } from "@/lib/authorization";
 // GET /api/nurse/clinic
 export async function GET() {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const clinics = await prisma.clinic.findMany();
         return NextResponse.json(clinics);
@@ -21,7 +21,7 @@ export async function GET() {
 // POST /api/nurse/clinic
 export async function POST(req: NextRequest) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { clinic_name, clinic_location, clinic_contactno } = await req.json();
 

--- a/src/app/api/nurse/consultations/route.ts
+++ b/src/app/api/nurse/consultations/route.ts
@@ -6,7 +6,7 @@ import { Role } from "@prisma/client";
 
 export async function POST(req: Request) {
     try {
-        const session = await requireRole([Role.NURSE, Role.ADMIN]);
+        const session = await requireRole([Role.NURSE]);
 
         const body = await req.json();
         const { appointment_id, reason_of_visit, findings, diagnosis } = body;

--- a/src/app/api/nurse/dispense/route.ts
+++ b/src/app/api/nurse/dispense/route.ts
@@ -5,7 +5,7 @@ import { Role } from "@prisma/client";
 
 export async function GET() {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const dispenses = await listDispenses();
         return NextResponse.json(dispenses);
@@ -22,7 +22,7 @@ export async function GET() {
 
 export async function POST(req: Request) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const {
             med_id,

--- a/src/app/api/nurse/inventory/route.ts
+++ b/src/app/api/nurse/inventory/route.ts
@@ -6,7 +6,7 @@ import { handleAuthError, requireRole } from "@/lib/authorization";
 // GET stays the same (no changes)
 export async function GET() {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const now = new Date();
 
@@ -162,7 +162,7 @@ export async function GET() {
 // POST updated to support enums + strength
 export async function POST(req: Request) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const body = await req.json();
         const { clinic_id, item_name, quantity, expiry, category, item_type, strength, unit } = body as {

--- a/src/app/api/nurse/records/[id]/route.ts
+++ b/src/app/api/nurse/records/[id]/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(
     { params }: RecordRouteContext
 ) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { id } = await params;
 

--- a/src/app/api/nurse/records/route.ts
+++ b/src/app/api/nurse/records/route.ts
@@ -6,7 +6,7 @@ import { Role } from "@prisma/client";
 
 export async function GET() {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const records = await fetchPatientRecords();
         return NextResponse.json(records);

--- a/src/app/api/nurse/reports/pdf/route.ts
+++ b/src/app/api/nurse/reports/pdf/route.ts
@@ -443,7 +443,7 @@ export async function GET(req: NextRequest) {
     let browser: Awaited<ReturnType<typeof puppeteer.launch>> | null = null;
 
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { searchParams } = new URL(req.url);
         const yearParam = Number.parseInt(searchParams.get("year") ?? "", 10);

--- a/src/app/api/nurse/reports/route.ts
+++ b/src/app/api/nurse/reports/route.ts
@@ -6,7 +6,7 @@ import { Role } from "@prisma/client";
 
 export async function GET(req: NextRequest) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { searchParams } = new URL(req.url);
 

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -23,7 +23,7 @@ function handleError(error: unknown, message = "Server error") {
 // --------------------
 export async function POST(req: Request) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const body = await req.json();
 
@@ -155,7 +155,7 @@ export async function POST(req: Request) {
 // --------------------
 export async function GET() {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const users = await prisma.users.findMany({
             include: {
@@ -190,7 +190,7 @@ export async function GET() {
 // --------------------
 export async function PATCH(req: Request) {
     try {
-        await requireRole([Role.NURSE, Role.ADMIN]);
+        await requireRole([Role.NURSE]);
 
         const { userId, status } = (await req.json()) as {
             userId: string;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -59,7 +59,6 @@ export async function middleware(req: NextRequest) {
         "/doctor": "DOCTOR",
         "/scholar": "SCHOLAR",
         "/patient": "PATIENT",
-        "/admin": "ADMIN",
     };
 
     for (const prefix in roleGuardMap) {
@@ -85,7 +84,6 @@ export const config = {
         "/doctor/:path*",
         "/scholar/:path*",
         "/patient/:path*",
-        "/admin/:path*",
         "/api/:path*", // secure API routes too
     ],
 };


### PR DESCRIPTION
## Summary
- remove the admin guard and matcher from the middleware configuration
- update nurse API endpoints to require only the nurse role for access
- drop the unused ADMIN enum value from the Prisma schema and migration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69034d593bf4832797d7aa9ebc6132ff