### PR TITLE
Switch email sender configuration to GMAIL_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ prisma/
 | --- | --- |
 | `DATABASE_URL` | PostgreSQL connection string used by Prisma (`prisma/schema.prisma`). |
 | `NEXTAUTH_SECRET` | Signing secret for NextAuth JWT/session cookies (`src/lib/auth.ts`, `src/middleware.ts`). |
-| `EMAIL_USER` | Gmail address used as the sender in notifications (`src/lib/email.ts`). |
+| `GMAIL_USER` | Gmail address used as the sender in notifications (`src/lib/email.ts`). |
 | `GMAIL_CLIENT_ID` | OAuth client ID for Gmail API access (`src/lib/email.ts`). |
 | `GMAIL_CLIENT_SECRET` | OAuth client secret paired with the client ID (`src/lib/email.ts`). |
 | `GMAIL_REFRESH_TOKEN` | Long-lived refresh token used to mint Gmail access tokens (`src/lib/email.ts`). |

--- a/src/app/api/auth/request-reset/route.ts
+++ b/src/app/api/auth/request-reset/route.ts
@@ -189,7 +189,21 @@ This message was automatically sent from the HNU Clinic Capstone Project website
                 );
             }
 
-            throw new Error("Failed to send reset email. Please try again later.");
+            const missingSender =
+                emailError instanceof Error &&
+                emailError.message.includes("Missing GMAIL_USER in environment");
+
+            if (missingSender) {
+                return NextResponse.json(
+                    { error: "Email service is not configured." },
+                    { status: 500 },
+                );
+            }
+
+            return NextResponse.json(
+                { error: "Failed to send reset email. Please try again later." },
+                { status: 500 },
+            );
         }
 
         return NextResponse.json({
@@ -204,13 +218,6 @@ This message was automatically sent from the HNU Clinic Capstone Project website
         if (message === "Unable to generate reset code. Please try again.") {
             return NextResponse.json(
                 { error: "Unable to generate reset code. Please try again." },
-                { status: 500 }
-            );
-        }
-
-        if (message === "Failed to send reset email. Please try again later.") {
-            return NextResponse.json(
-                { error: "Failed to send reset email. Please try again later." },
                 { status: 500 }
             );
         }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -47,7 +47,7 @@ async function handler(req: Request) {
       </div>
     `;
 
-    const inbox = process.env.EMAIL_USER;
+    const inbox = process.env.GMAIL_USER;
     if (!inbox) {
       return NextResponse.json(
         { error: "Email service is not configured." },

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -252,7 +252,7 @@ export async function sendEmail({
     replyTo,
     text,
 }: SendEmailOptions): Promise<void> {
-    const emailUser = getRequiredEnv("EMAIL_USER");
+    const emailUser = getRequiredEnv("GMAIL_USER");
     const fromHeader = formatAddress(emailUser, fromName);
     const toHeader = formatAddress(to);
     const replyToHeader = replyTo ? formatAddress(replyTo) : undefined;


### PR DESCRIPTION
## Summary
- replace usage of the EMAIL_USER environment variable with GMAIL_USER in the Gmail helper and contact API route
- update documentation to list GMAIL_USER as the required sender address configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903542149a88327af0ee4ae616ccae4