### PR TITLE
Fix Manila consultation calendar date alignment

### DIFF
--- a/src/app/doctor/consultation/page.client.tsx
+++ b/src/app/doctor/consultation/page.client.tsx
@@ -56,9 +56,21 @@ import {
 
 const MANILA_TIME_SUFFIX = "+08:00";
 
-function toCalendarDate(value: string | null | undefined) {
+function toCalendarDate(value: string | Date | null | undefined) {
     if (!value) return null;
-    const normalized = value.includes("T") ? value : `${value}T12:00:00${MANILA_TIME_SUFFIX}`;
+
+    if (value instanceof Date) {
+        const manilaDate = formatManilaISODate(value);
+        return toCalendarDate(manilaDate);
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const manilaDate = trimmed.includes("T") ? toManilaDateString(trimmed) : trimmed;
+    if (!manilaDate) return null;
+
+    const normalized = `${manilaDate}T12:00:00${MANILA_TIME_SUFFIX}`;
     const date = new Date(normalized);
     return Number.isNaN(date.getTime()) ? null : date;
 }


### PR DESCRIPTION
## Summary
- ensure calendar date conversion normalizes ISO values to Manila-local days before rendering
- support Date inputs when generating calendar-friendly values to keep selections accurate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69041a244ab08327b2b4f99b7ad8b9b9