### PR TITLE
Create rate limiter table at runtime

### DIFF
--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -159,7 +159,7 @@ export async function PUT(req: Request) {
                     delete data.email;
                 }
             } else if (trimmedEmail.toLowerCase() !== existingEmail.toLowerCase()) {
-                const rate = consumeRateLimit(
+                const rate = await consumeRateLimit(
                     `email-verify:${session.user.id}`,
                     3,
                     60 * 60_000

--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -167,7 +167,7 @@ async function postHandler(req: Request) {
 
         const doctorId = doctor.user_id;
 
-        const hourlyLimit = consumeRateLimit(
+        const hourlyLimit = await consumeRateLimit(
             `doctor:consultation:generate:hour:${doctorId}`,
             2,
             60 * 60_000
@@ -178,7 +178,7 @@ async function postHandler(req: Request) {
                 hourlyLimit
             );
 
-        const dailyLimit = consumeRateLimit(
+        const dailyLimit = await consumeRateLimit(
             `doctor:consultation:generate:day:${doctorId}`,
             6,
             24 * 60 * 60_000

--- a/src/app/api/nurse/accounts/me/route.ts
+++ b/src/app/api/nurse/accounts/me/route.ts
@@ -170,7 +170,7 @@ export async function PUT(req: Request) {
                     delete data.email;
                 }
             } else if (trimmedEmail.toLowerCase() !== existingEmail.toLowerCase()) {
-                const rate = consumeRateLimit(
+                const rate = await consumeRateLimit(
                     `email-verify:${session.user.id}`,
                     3,
                     60 * 60_000

--- a/src/app/api/nurse/reports/pdf/route.ts
+++ b/src/app/api/nurse/reports/pdf/route.ts
@@ -461,7 +461,7 @@ async function getHandler(request: RateLimitedRequest) {
         const session = await requireRole([Role.NURSE]);
         const nurseId = session.user.id as string;
 
-        const burstLimit = consumeRateLimit(
+        const burstLimit = await consumeRateLimit(
             `nurse:reports:pdf:burst:${nurseId}`,
             5,
             60_000
@@ -472,7 +472,7 @@ async function getHandler(request: RateLimitedRequest) {
                 burstLimit
             );
 
-        const hourlyLimit = consumeRateLimit(
+        const hourlyLimit = await consumeRateLimit(
             `nurse:reports:pdf:hour:${nurseId}`,
             15,
             60 * 60_000

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -293,7 +293,7 @@ export async function PUT(req: Request) {
                         delete data.email;
                     }
                 } else if (trimmedEmail.toLowerCase() !== existingEmail.toLowerCase()) {
-                    const rate = consumeRateLimit(
+                    const rate = await consumeRateLimit(
                         `email-verify:${session.user.id}`,
                         3,
                         60 * 60_000
@@ -380,7 +380,7 @@ export async function PUT(req: Request) {
                         delete data.email;
                     }
                 } else if (trimmedEmail.toLowerCase() !== existingEmail.toLowerCase()) {
-                    const rate = consumeRateLimit(
+                    const rate = await consumeRateLimit(
                         `email-verify:${session.user.id}`,
                         3,
                         60 * 60_000

--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -3,14 +3,13 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import {
-    rangesOverlap,
     buildManilaDate,
     startOfManilaDay,
     endOfManilaDay,
     manilaNow,
     formatManilaISODate,
 } from "@/lib/time";
-import { AppointmentStatus, Role, ServiceType } from "@prisma/client";
+import { AppointmentStatus, Prisma, Role, ServiceType } from "@prisma/client";
 import { archiveExpiredDutyHours } from "@/lib/duty-hours";
 import {
     computeDoctorEarliestBookingStart,
@@ -22,6 +21,26 @@ import {
     type RateLimitResult,
     withRateLimit,
 } from "@/lib/rate-limit";
+
+class AppointmentConflictError extends Error {
+    constructor(message = "Time slot already booked") {
+        super(message);
+        this.name = "AppointmentConflictError";
+    }
+}
+
+const ACTIVE_APPOINTMENT_STATUSES = [
+    AppointmentStatus.Pending,
+    AppointmentStatus.Approved,
+    AppointmentStatus.Moved,
+];
+
+function isPrismaOverlapError(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+    return (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        (error.code === "P2002" || error.code === "P2034" || error.code === "P2036")
+    );
+}
 
 function rateLimitResponse(message: string, result: RateLimitResult) {
     const response = NextResponse.json({ message }, { status: 429 });
@@ -102,7 +121,7 @@ async function postHandler(req: Request) {
 
         const patient_user_id = session.user.id as string;
 
-        const burstLimit = consumeRateLimit(
+        const burstLimit = await consumeRateLimit(
             `patient:appointments:create:burst:${patient_user_id}`,
             5,
             60_000
@@ -113,7 +132,7 @@ async function postHandler(req: Request) {
                 burstLimit
             );
 
-        const dailyLimit = consumeRateLimit(
+        const dailyLimit = await consumeRateLimit(
             `patient:appointments:create:day:${patient_user_id}`,
             12,
             24 * 60 * 60_000
@@ -189,40 +208,46 @@ async function postHandler(req: Request) {
                 { status: 400 }
             );
 
-        // Check overlapping appointments
-        const existing = await prisma.appointment.findMany({
-            where: {
-                doctor_user_id,
-                appointment_timestart: { gte: dayStart, lte: dayEnd },
-                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved] },
-            },
-        });
+        let created: Awaited<ReturnType<typeof prisma.appointment.create>>;
+        try {
+            created = await prisma.$transaction(
+                async (tx) => {
+                    const conflict = await tx.appointment.findFirst({
+                        where: {
+                            doctor_user_id,
+                            status: { in: ACTIVE_APPOINTMENT_STATUSES },
+                            appointment_timestart: { lt: appointment_timeend },
+                            appointment_timeend: { gt: appointment_timestart },
+                        },
+                        select: { appointment_id: true },
+                    });
 
-        const conflict = existing.some((e) =>
-            rangesOverlap(
-                appointment_timestart,
-                appointment_timeend,
-                e.appointment_timestart,
-                e.appointment_timeend
-            )
-        );
+                    if (conflict) {
+                        throw new AppointmentConflictError();
+                    }
 
-        if (conflict)
-            return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+                    return tx.appointment.create({
+                        data: {
+                            patient_user_id,
+                            clinic_id,
+                            doctor_user_id,
+                            appointment_date,
+                            appointment_timestart,
+                            appointment_timeend,
+                            service_type: service_type as ServiceType,
+                            status: AppointmentStatus.Pending,
+                        },
+                    });
+                },
+                { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+            );
+        } catch (error) {
+            if (error instanceof AppointmentConflictError || isPrismaOverlapError(error)) {
+                return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+            }
 
-        // Create the appointment
-        const created = await prisma.appointment.create({
-            data: {
-                patient_user_id,
-                clinic_id,
-                doctor_user_id,
-                appointment_date,
-                appointment_timestart,
-                appointment_timeend,
-                service_type: service_type as ServiceType,
-                status: AppointmentStatus.Pending,
-            },
-        });
+            throw error;
+        }
 
         return NextResponse.json({
             appointment_id: created.appointment_id,
@@ -252,7 +277,7 @@ async function patchHandler(req: Request) {
 
         const patient_user_id = session.user.id as string;
 
-        const burstLimit = consumeRateLimit(
+        const burstLimit = await consumeRateLimit(
             `patient:appointments:reschedule:burst:${patient_user_id}`,
             5,
             60_000
@@ -263,7 +288,7 @@ async function patchHandler(req: Request) {
                 burstLimit
             );
 
-        const dailyLimit = consumeRateLimit(
+        const dailyLimit = await consumeRateLimit(
             `patient:appointments:reschedule:day:${patient_user_id}`,
             12,
             24 * 60 * 60_000
@@ -364,38 +389,44 @@ async function patchHandler(req: Request) {
             );
         }
 
-        const existing = await prisma.appointment.findMany({
-            where: {
-                doctor_user_id: appointment.doctor_user_id,
-                appointment_timestart: { gte: dayStart, lte: dayEnd },
-                status: { in: [AppointmentStatus.Pending, AppointmentStatus.Approved, AppointmentStatus.Moved] },
-                appointment_id: { not: appointment_id },
-            },
-        });
+        try {
+            await prisma.$transaction(
+                async (tx) => {
+                    const conflict = await tx.appointment.findFirst({
+                        where: {
+                            doctor_user_id: appointment.doctor_user_id,
+                            appointment_id: { not: appointment_id },
+                            status: { in: ACTIVE_APPOINTMENT_STATUSES },
+                            appointment_timestart: { lt: appointment_timeend },
+                            appointment_timeend: { gt: appointment_timestart },
+                        },
+                        select: { appointment_id: true },
+                    });
 
-        const conflict = existing.some((e) =>
-            rangesOverlap(
-                appointment_timestart,
-                appointment_timeend,
-                e.appointment_timestart,
-                e.appointment_timeend
-            )
-        );
+                    if (conflict) {
+                        throw new AppointmentConflictError();
+                    }
 
-        if (conflict) {
-            return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+                    await tx.appointment.update({
+                        where: { appointment_id },
+                        data: {
+                            appointment_date,
+                            appointment_timestart,
+                            appointment_timeend,
+                            status: AppointmentStatus.Pending,
+                            remarks: null,
+                        },
+                    });
+                },
+                { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+            );
+        } catch (error) {
+            if (error instanceof AppointmentConflictError || isPrismaOverlapError(error)) {
+                return NextResponse.json({ message: "Time slot already booked" }, { status: 409 });
+            }
+
+            throw error;
         }
-
-        await prisma.appointment.update({
-            where: { appointment_id },
-            data: {
-                appointment_date,
-                appointment_timestart,
-                appointment_timeend,
-                status: AppointmentStatus.Pending,
-                remarks: null,
-            },
-        });
 
         return NextResponse.json({ message: "Reschedule request submitted" });
     } catch (error) {
@@ -422,7 +453,7 @@ async function deleteHandler(req: Request) {
 
         const patient_user_id = session.user.id as string;
 
-        const burstLimit = consumeRateLimit(
+        const burstLimit = await consumeRateLimit(
             `patient:appointments:cancel:burst:${patient_user_id}`,
             5,
             60_000
@@ -433,7 +464,7 @@ async function deleteHandler(req: Request) {
                 burstLimit
             );
 
-        const dailyLimit = consumeRateLimit(
+        const dailyLimit = await consumeRateLimit(
             `patient:appointments:cancel:day:${patient_user_id}`,
             12,
             24 * 60 * 60_000

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -215,7 +215,7 @@ export async function PUT(req: Request) {
                     delete data.email;
                 }
             } else if (trimmedEmail.toLowerCase() !== existingEmail.toLowerCase()) {
-                const rate = consumeRateLimit(
+                const rate = await consumeRateLimit(
                     `email-verify:${session.user.id}`,
                     3,
                     60 * 60_000

--- a/src/app/api/scholar/appointments/route.ts
+++ b/src/app/api/scholar/appointments/route.ts
@@ -10,7 +10,6 @@ import {
     endOfManilaDay,
     formatManilaISODate,
     manilaNow,
-    rangesOverlap,
     startOfManilaDay,
 } from "@/lib/time";
 import {
@@ -95,6 +94,20 @@ const ACTIVE_STATUSES: AppointmentStatus[] = [
     AppointmentStatus.Approved,
     AppointmentStatus.Moved,
 ];
+
+class AppointmentConflictError extends Error {
+    constructor(message = "Time slot already booked") {
+        super(message);
+        this.name = "AppointmentConflictError";
+    }
+}
+
+function isPrismaOverlapError(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+    return (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        (error.code === "P2002" || error.code === "P2034" || error.code === "P2036")
+    );
+}
 
 export async function GET(req: Request) {
     try {
@@ -230,7 +243,7 @@ async function postHandler(req: Request) {
         }
 
         const scholarId = session.user.id;
-        const burstLimit = consumeRateLimit(
+        const burstLimit = await consumeRateLimit(
             `scholar:appointments:create:burst:${scholarId}`,
             8,
             60_000
@@ -241,7 +254,7 @@ async function postHandler(req: Request) {
                 burstLimit
             );
 
-        const dailyLimit = consumeRateLimit(
+        const dailyLimit = await consumeRateLimit(
             `scholar:appointments:create:day:${scholarId}`,
             40,
             24 * 60 * 60_000
@@ -343,51 +356,52 @@ async function postHandler(req: Request) {
             );
         }
 
-        const conflicts = await prisma.appointment.findMany({
-            where: {
-                doctor_user_id,
-                appointment_timestart: { gte: dayStart, lte: dayEnd },
-                status: {
-                    in: [AppointmentStatus.Pending, AppointmentStatus.Approved, AppointmentStatus.Moved],
+        let created: { appointment_id: string; status: AppointmentStatus };
+        try {
+            created = await prisma.$transaction(
+                async (tx) => {
+                    const conflict = await tx.appointment.findFirst({
+                        where: {
+                            doctor_user_id,
+                            status: { in: ACTIVE_STATUSES },
+                            appointment_timestart: { lt: appointment_timeend },
+                            appointment_timeend: { gt: appointment_timestart },
+                        },
+                        select: { appointment_id: true },
+                    });
+
+                    if (conflict) {
+                        throw new AppointmentConflictError();
+                    }
+
+                    return tx.appointment.create({
+                        data: {
+                            patient_user_id,
+                            clinic_id,
+                            doctor_user_id,
+                            created_by_user_id: session.user.id,
+                            appointment_date,
+                            appointment_timestart,
+                            appointment_timeend,
+                            remarks: remarks.length > 0 ? remarks : null,
+                            service_type: service_type as ServiceType,
+                            status: AppointmentStatus.Pending,
+                        },
+                        select: {
+                            appointment_id: true,
+                            status: true,
+                        },
+                    });
                 },
-            },
-            select: {
-                appointment_timestart: true,
-                appointment_timeend: true,
-            },
-        });
+                { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+            );
+        } catch (error) {
+            if (error instanceof AppointmentConflictError || isPrismaOverlapError(error)) {
+                return NextResponse.json({ error: "Time slot already booked" }, { status: 409 });
+            }
 
-        const hasConflict = conflicts.some((existing) =>
-            rangesOverlap(
-                appointment_timestart,
-                appointment_timeend,
-                existing.appointment_timestart,
-                existing.appointment_timeend
-            )
-        );
-
-        if (hasConflict) {
-            return NextResponse.json({ error: "Time slot already booked" }, { status: 409 });
+            throw error;
         }
-
-        const created = await prisma.appointment.create({
-            data: {
-                patient_user_id,
-                clinic_id,
-                doctor_user_id,
-                created_by_user_id: session.user.id,
-                appointment_date,
-                appointment_timestart,
-                appointment_timeend,
-                remarks: remarks.length > 0 ? remarks : null,
-                service_type: service_type as ServiceType,
-                status: AppointmentStatus.Pending,
-            },
-            select: {
-                appointment_id: true,
-                status: true,
-            },
-        });
 
         return NextResponse.json(created, { status: 201 });
     } catch (err) {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,10 +1,16 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 
 export type RateLimitedRequest = Request | NextRequest;
 
 export interface RateLimitResult {
     success: boolean;
     retryAfterMs?: number;
+}
+
+interface RateLimiter {
+    consume(key: string, limit: number, windowMs: number): Promise<RateLimitResult>;
 }
 
 interface Bucket {
@@ -17,11 +23,11 @@ interface ExpirationEntry {
     expiresAt: number;
 }
 
-class MemoryRateLimiter {
+class MemoryRateLimiter implements RateLimiter {
     private buckets: Map<string, Bucket> = new Map();
     private expirations: ExpirationEntry[] = [];
 
-    consume(key: string, limit: number, windowMs: number): RateLimitResult {
+    async consume(key: string, limit: number, windowMs: number): Promise<RateLimitResult> {
         const now = Date.now();
         this.cleanup(now);
         const bucket = this.buckets.get(key);
@@ -127,6 +133,86 @@ class MemoryRateLimiter {
     }
 }
 
+const RATE_LIMIT_TABLE = '"RateLimitBucket"';
+let rateLimitTableReady = false;
+let ensureRateLimitTablePromise: Promise<void> | null = null;
+
+async function ensureRateLimitTable() {
+    if (rateLimitTableReady) {
+        return;
+    }
+
+    if (ensureRateLimitTablePromise) {
+        return ensureRateLimitTablePromise;
+    }
+
+    ensureRateLimitTablePromise = (async () => {
+        await prisma.$executeRawUnsafe(`
+            CREATE TABLE IF NOT EXISTS ${RATE_LIMIT_TABLE} (
+                "key" text NOT NULL,
+                "window_start" timestamptz NOT NULL,
+                "count" integer NOT NULL DEFAULT 1,
+                "updatedAt" timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT "RateLimitBucket_pkey" PRIMARY KEY ("key", "window_start")
+            )
+        `);
+
+        await prisma.$executeRawUnsafe(`
+            CREATE INDEX IF NOT EXISTS "RateLimitBucket_window_start_idx"
+            ON ${RATE_LIMIT_TABLE} ("window_start")
+        `);
+
+        rateLimitTableReady = true;
+    })();
+
+    try {
+        await ensureRateLimitTablePromise;
+    } catch (error) {
+        ensureRateLimitTablePromise = null;
+        throw error;
+    }
+}
+
+class PrismaRateLimiter implements RateLimiter {
+    async consume(key: string, limit: number, windowMs: number): Promise<RateLimitResult> {
+        await ensureRateLimitTable();
+
+        const now = new Date();
+        const windowStartMs = Math.floor(now.getTime() / windowMs) * windowMs;
+        const windowStart = new Date(windowStartMs);
+        const windowEndMs = windowStartMs + windowMs;
+
+        try {
+            const rows = await prisma.$transaction(
+                async (tx) =>
+                    tx.$queryRaw<{ count: number }[]>`
+                        INSERT INTO "RateLimitBucket" ("key", "window_start", "count")
+                        VALUES (${key}, ${windowStart}, 1)
+                        ON CONFLICT ("key", "window_start")
+                        DO UPDATE SET
+                            "count" = "RateLimitBucket"."count" + 1,
+                            "updatedAt" = now()
+                        RETURNING "count"
+                    `,
+                { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+            );
+
+            const count = Number(rows?.[0]?.count ?? 1);
+            if (count > limit) {
+                return { success: false, retryAfterMs: Math.max(0, windowEndMs - now.getTime()) };
+            }
+
+            return { success: true };
+        } catch (error) {
+            if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034") {
+                return { success: false, retryAfterMs: Math.max(0, windowEndMs - now.getTime()) };
+            }
+
+            throw error;
+        }
+    }
+}
+
 const globalKey = Symbol.for("hnu.rateLimiter");
 const globalObject = globalThis as typeof globalThis & { [globalKey]?: MemoryRateLimiter };
 
@@ -134,14 +220,43 @@ if (!globalObject[globalKey]) {
     globalObject[globalKey] = new MemoryRateLimiter();
 }
 
-const limiter = globalObject[globalKey];
+const memoryLimiter = globalObject[globalKey];
+const databaseLimiter = new PrismaRateLimiter();
+let useMemoryFallback = process.env.RATE_LIMIT_DRIVER === "memory";
+let fallbackLogged = false;
 
-export function consumeRateLimit(
+function logRateLimitFallback(error: unknown) {
+    if (fallbackLogged) return;
+    fallbackLogged = true;
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2021") {
+        console.warn(
+            "[RateLimit] RateLimitBucket table is unavailable or could not be created. Falling back to in-memory limiter."
+        );
+        return;
+    }
+
+    console.error(
+        "[RateLimit] Failed to use database-backed limiter. Falling back to in-memory limiter.",
+        error
+    );
+}
+
+export async function consumeRateLimit(
     key: string,
     limit: number,
     windowMs: number
-): RateLimitResult {
-    return limiter.consume(key, limit, windowMs);
+): Promise<RateLimitResult> {
+    if (!useMemoryFallback) {
+        try {
+            return await databaseLimiter.consume(key, limit, windowMs);
+        } catch (error) {
+            logRateLimitFallback(error);
+            useMemoryFallback = true;
+        }
+    }
+
+    return memoryLimiter.consume(key, limit, windowMs);
 }
 
 export interface RateLimitRule {
@@ -167,7 +282,7 @@ export function withRateLimit<Args extends unknown[]>(
             const key = await (rule.key ?? defaultKey)(request);
             if (!key) continue;
 
-            const result = limiter.consume(key, rule.limit, rule.windowMs);
+            const result = await consumeRateLimit(key, rule.limit, rule.windowMs);
             if (!result.success) {
                 const retryAfterSeconds = result.retryAfterMs
                     ? Math.ceil(result.retryAfterMs / 1000)


### PR DESCRIPTION
## Summary
- remove the Prisma `RateLimitBucket` model so schema updates are unnecessary
- have the rate limiter create and index the `RateLimitBucket` table at runtime before using it, updating timestamps on reuse
- keep graceful fallback to the in-memory limiter when the shared table cannot be accessed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690744b684bc8327882e2b9a62069bc4