### PR TITLE
Record walk-in ID numbers and refresh tech stack visuals

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,23 +178,33 @@ model Consultation {
 }
 
 model MedDispense {
-  dispense_id     String          @id @default(dbgenerated("concat('DESP_', (floor((random() * (1000000)::double precision)))::integer)"))
-  med_id          String
-  consultation_id String?
-  scholar_user_id String?
-  walk_in_name    String?
-  walk_in_contact String?
-  walk_in_notes   String?
-  quantity        Int
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @default(now()) @updatedAt
-  dispenseBatches DispenseBatch[]
-  consultation    Consultation?   @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
-  med             MedInventory    @relation(fields: [med_id], references: [med_id], onDelete: Cascade)
-  scholar         Users?          @relation("ScholarDispenses", fields: [scholar_user_id], references: [user_id])
+  dispense_id       String          @id @default(dbgenerated("concat('DESP_', (floor((random() * (1000000)::double precision)))::integer)"))
+  med_id            String
+  consultation_id   String?
+  scholar_user_id   String?
+  walk_in_id_number String?
+  walk_in_contact   String?
+  walk_in_notes     String?
+  quantity          Int
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @default(now()) @updatedAt
+  dispenseBatches   DispenseBatch[]
+  consultation      Consultation?   @relation(fields: [consultation_id], references: [consultation_id], onDelete: Cascade)
+  med               MedInventory    @relation(fields: [med_id], references: [med_id], onDelete: Cascade)
+  scholar           Users?          @relation("ScholarDispenses", fields: [scholar_user_id], references: [user_id])
 
   @@index([consultation_id])
   @@index([scholar_user_id])
+}
+
+model RateLimitBucket {
+  key          String
+  window_start DateTime
+  count        Int       @default(1)
+  updatedAt    DateTime  @default(now()) @updatedAt
+
+  @@id([key, window_start])
+  @@index([window_start])
 }
 
 model DispenseBatch {

--- a/src/app/api/nurse/dispense/route.ts
+++ b/src/app/api/nurse/dispense/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
             med_id,
             consultation_id,
             quantity,
-            walkInName,
+            walkInIdNumber,
             walkInContact,
             walkInNotes,
             scholarUserId,
@@ -41,14 +41,14 @@ export async function POST(req: Request) {
             );
         }
 
-        if (!consultation_id && !walkInName) {
+        if (!consultation_id && !walkInIdNumber) {
             return NextResponse.json(
-                { error: "Provide a consultation_id or walk-in name" },
+                { error: "Provide a consultation_id or walk-in ID number" },
                 { status: 400 }
             );
         }
 
-        if (!consultation_id && walkInName && !scholarUserId) {
+        if (!consultation_id && walkInIdNumber && !scholarUserId) {
             return NextResponse.json(
                 { error: "Walk-in dispenses must include the assisting scholar" },
                 { status: 400 }
@@ -59,14 +59,14 @@ export async function POST(req: Request) {
             med_id,
             consultation_id: consultation_id ?? null,
             quantity: Number(quantity),
-            walkIn: walkInName
+            walkIn: walkInIdNumber
                 ? {
-                    name: walkInName,
+                    idNumber: walkInIdNumber,
                     contact: walkInContact ?? null,
                     notes: walkInNotes ?? null,
                 }
                 : undefined,
-            scholar_user_id: walkInName ? scholarUserId ?? null : null,
+            scholar_user_id: walkInIdNumber ? scholarUserId ?? null : null,
         });
         return NextResponse.json(newDispense);
     } catch (err) {

--- a/src/app/api/scholar/dispense/route.ts
+++ b/src/app/api/scholar/dispense/route.ts
@@ -91,11 +91,11 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { med_id, quantity, walkInName, walkInContact, walkInNotes } = await req.json();
+        const { med_id, quantity, walkInIdNumber, walkInContact, walkInNotes } = await req.json();
 
-        if (!med_id || quantity === undefined || !walkInName) {
+        if (!med_id || quantity === undefined || !walkInIdNumber) {
             return NextResponse.json(
-                { error: "med_id, quantity, and walkInName are required" },
+                { error: "med_id, quantity, and walkInIdNumber are required" },
                 { status: 400 }
             );
         }
@@ -104,7 +104,7 @@ export async function POST(req: Request) {
             med_id,
             quantity: Number(quantity),
             walkIn: {
-                name: walkInName,
+                idNumber: walkInIdNumber,
                 contact: walkInContact ?? null,
                 notes: walkInNotes ?? null,
             },

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -45,7 +45,7 @@ type DispenseRecord = {
         doctor: { username: string } | null;
         nurse: { username: string } | null;
     } | null;
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -463,7 +463,7 @@ export default function DoctorDispensePage() {
                                         <TableHeader className="bg-green-50 text-green-700">
                                             <TableRow>
                                                 <TableHead className="whitespace-nowrap">Clinic</TableHead>
-                                                <TableHead className="whitespace-nowrap">Recipient</TableHead>
+                                                <TableHead className="whitespace-nowrap">Recipient / ID</TableHead>
                                                 <TableHead className="whitespace-nowrap">Visit Type</TableHead>
                                                 <TableHead className="whitespace-nowrap">Medicine</TableHead>
                                                 <TableHead className="whitespace-nowrap">Quantity</TableHead>
@@ -491,8 +491,7 @@ export default function DoctorDispensePage() {
                                                             <div className="flex flex-col gap-1">
                                                                 <span className="font-semibold text-gray-900">
                                                                     {d.consultation?.appointment?.patient?.username ??
-                                                                        d.walk_in_name ??
-                                                                        "—"}
+                                                                        (d.walk_in_id_number ? `ID: ${d.walk_in_id_number}` : "—")}
                                                                 </span>
                                                                 {!d.consultation && (
                                                                     <>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { SiteHeader } from "@/components/marketing/site-header";
+import { LogoLoop } from "@/components/marketing/logo-loop";
 import {
     Users,
     Code2,
@@ -13,6 +14,9 @@ import {
     BellRing,
     Workflow,
     ArrowRight,
+    Cpu,
+    Palette,
+    LockKeyhole,
 } from "lucide-react";
 
 const navigation = [
@@ -66,6 +70,32 @@ const techStack = [
     { name: "NextAuth", logo: "/logos/nextauth.svg" },
     { name: "Zod", logo: "/logos/zod.svg" },
     { name: "Vercel", logo: "/logos/vercel.svg" },
+];
+
+const techLoopRows = [
+    techStack.slice(0, Math.ceil(techStack.length / 2)),
+    [
+        ...techStack.slice(Math.ceil(techStack.length / 2)),
+        ...techStack.slice(0, Math.ceil(techStack.length / 2)),
+    ],
+];
+
+const techHighlights = [
+    {
+        title: "Typed data flows",
+        description: "TypeScript and Prisma enforce a consistent schema from the UI to the database layer.",
+        icon: Cpu,
+    },
+    {
+        title: "Polished interfaces",
+        description: "Tailwind CSS with shadcn/ui makes it easy to ship accessible, branded clinic screens.",
+        icon: Palette,
+    },
+    {
+        title: "Secure by design",
+        description: "NextAuth, granular roles, and rate limiting safeguard every interaction with clinic data.",
+        icon: LockKeyhole,
+    },
 ];
 
 const developers = [
@@ -206,26 +236,42 @@ export default function LearnMorePage() {
                 </section>
 
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
-                    <div className="mx-auto max-w-6xl space-y-10">
+                    <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
                             <Code2 className="mx-auto h-12 w-12 text-green-600" />
                             <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Modern tools that power the experience</h3>
                             <p className="mx-auto max-w-3xl text-gray-600">
-                                Our technology stack combines reliable frameworks and UI libraries to keep the platform scalable and intuitive.
+                                A cohesive toolkit keeps the HNU Clinic portal fast, reliable, and easy to maintain—from typed APIs and automated schema checks to polished interface components and resilient security guards.
                             </p>
                         </div>
 
-                        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                            {techStack.map((tech) => (
-                                <Card key={tech.name} className="rounded-2xl border-green-100 bg-white shadow-sm">
-                                    <CardContent className="flex flex-col items-center gap-4 p-6">
-                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
-                                            <Image src={tech.logo} alt={tech.name} width={48} height={48} className="object-contain" />
-                                        </div>
-                                        <p className="text-sm font-medium text-green-700">{tech.name}</p>
-                                    </CardContent>
-                                </Card>
-                            ))}
+                        <div className="space-y-6">
+                            <LogoLoop logos={techLoopRows[0]} className="rounded-3xl border border-green-100 bg-white/90 shadow-sm" />
+                            <LogoLoop
+                                logos={techLoopRows[1]}
+                                direction="right"
+                                speedSeconds={32}
+                                className="rounded-3xl border border-green-100 bg-white/90 shadow-sm md:translate-x-16"
+                            />
+                        </div>
+
+                        <div className="grid gap-6 md:grid-cols-3">
+                            {techHighlights.map((item) => {
+                                const Icon = item.icon;
+                                return (
+                                    <Card key={item.title} className="rounded-3xl border border-green-100/80 bg-white/95 shadow-sm">
+                                        <CardContent className="flex flex-col gap-4 p-6">
+                                            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-green-100 bg-green-50">
+                                                <Icon className="h-5 w-5 text-green-600" />
+                                            </div>
+                                            <div className="space-y-1">
+                                                <h4 className="text-base font-semibold text-green-700">{item.title}</h4>
+                                                <p className="text-sm leading-relaxed text-gray-600">{item.description}</p>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                );
+                            })}
                         </div>
                     </div>
                 </section>

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -35,7 +35,7 @@ type Dispense = {
         doctor: { username: string } | null;
         nurse: { username: string } | null;
     } | null;
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -200,7 +200,7 @@ export default function NurseDispensePage() {
                                 <TableHeader className="bg-green-50 text-green-700">
                                     <TableRow>
                                         <TableHead className="whitespace-nowrap">Clinic</TableHead>
-                                        <TableHead className="whitespace-nowrap">Recipient</TableHead>
+                                        <TableHead className="whitespace-nowrap">Recipient / ID</TableHead>
                                         <TableHead className="whitespace-nowrap">Visit Type</TableHead>
                                         <TableHead className="whitespace-nowrap">Medicine</TableHead>
                                         <TableHead className="whitespace-nowrap">Quantity</TableHead>
@@ -228,8 +228,7 @@ export default function NurseDispensePage() {
                                                     <div className="flex flex-col gap-1">
                                                         <span className="font-semibold text-gray-900">
                                                             {d.consultation?.appointment?.patient?.username ??
-                                                                d.walk_in_name ??
-                                                                "—"}
+                                                                (d.walk_in_id_number ? `ID: ${d.walk_in_id_number}` : "—")}
                                                         </span>
                                                         {!d.consultation && (
                                                             <>

--- a/src/app/scholar/dispense/page.tsx
+++ b/src/app/scholar/dispense/page.tsx
@@ -38,7 +38,7 @@ type DispenseRecord = {
         item_name: string;
         clinic: { clinic_name: string };
     };
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -92,7 +92,7 @@ export default function ScholarDispensePage() {
     const [loading, setLoading] = useState(false);
     const [submitting, setSubmitting] = useState(false);
     const [form, setForm] = useState({
-        name: "",
+        idNumber: "",
         contact: "",
         notes: "",
         med_id: "",
@@ -155,7 +155,7 @@ export default function ScholarDispensePage() {
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
 
-        if (!form.name.trim() || !form.med_id || !form.quantity) {
+        if (!form.idNumber.trim() || !form.med_id || !form.quantity) {
             toast.error("Please complete the required fields");
             return;
         }
@@ -179,7 +179,7 @@ export default function ScholarDispensePage() {
                 body: JSON.stringify({
                     med_id: form.med_id,
                     quantity,
-                    walkInName: form.name.trim(),
+                    walkInIdNumber: form.idNumber.trim(),
                     walkInContact: form.contact.trim() || null,
                     walkInNotes: form.notes.trim() || null,
                 }),
@@ -199,7 +199,7 @@ export default function ScholarDispensePage() {
                         : medicine
                 )
             );
-            setForm({ name: "", contact: "", notes: "", med_id: "", quantity: "" });
+            setForm({ idNumber: "", contact: "", notes: "", med_id: "", quantity: "" });
             toast.success("Walk-in dispense recorded");
         } catch (error) {
             console.error(error);
@@ -289,11 +289,11 @@ export default function ScholarDispensePage() {
                     <CardContent className="pt-6">
                         <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
                             <div className="space-y-2">
-                                <Label className="font-medium text-green-700">Walk-in name</Label>
+                                <Label className="font-medium text-green-700">Student/Employee ID number</Label>
                                 <Input
-                                    value={form.name}
-                                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
-                                    placeholder="Enter walk-in's name"
+                                    value={form.idNumber}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, idNumber: event.target.value }))}
+                                    placeholder="Enter ID number of the recipient"
                                     required
                                     className="rounded-xl border border-green-100/80 bg-white/80 focus-visible:ring-green-500"
                                 />
@@ -400,7 +400,7 @@ export default function ScholarDispensePage() {
                                     <TableHeader className="bg-green-50 text-green-700">
                                         <TableRow>
                                             <TableHead className="whitespace-nowrap">Clinic</TableHead>
-                                            <TableHead className="whitespace-nowrap">Walk-in</TableHead>
+                                            <TableHead className="whitespace-nowrap">Recipient ID</TableHead>
                                             <TableHead className="whitespace-nowrap">Medicine</TableHead>
                                             <TableHead className="whitespace-nowrap">Quantity</TableHead>
                                             <TableHead className="whitespace-nowrap">Scholar</TableHead>
@@ -421,7 +421,7 @@ export default function ScholarDispensePage() {
                                                 <TableCell>
                                                     <div className="flex flex-col gap-1">
                                                         <span className="font-semibold text-gray-900">
-                                                            {dispense.walk_in_name ?? "—"}
+                                                            {dispense.walk_in_id_number ?? "—"}
                                                         </span>
                                                         {dispense.walk_in_contact ? (
                                                             <span className="text-xs text-muted-foreground">

--- a/src/components/marketing/logo-loop.tsx
+++ b/src/components/marketing/logo-loop.tsx
@@ -1,0 +1,70 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+interface LogoItem {
+    name: string;
+    logo: string;
+}
+
+interface LogoLoopProps {
+    logos: LogoItem[];
+    className?: string;
+    direction?: "left" | "right";
+    speedSeconds?: number;
+}
+
+export function LogoLoop({ logos, className, direction = "left", speedSeconds = 28 }: LogoLoopProps) {
+    const loopItems = [...logos, ...logos];
+
+    return (
+        <div className={cn("logo-loop relative overflow-hidden", className)}>
+            <div
+                aria-hidden
+                className="pointer-events-none absolute inset-y-0 left-0 z-10 w-24 bg-gradient-to-r from-white via-white/90 to-transparent"
+            />
+            <div
+                aria-hidden
+                className="pointer-events-none absolute inset-y-0 right-0 z-10 w-24 bg-gradient-to-l from-white via-white/90 to-transparent"
+            />
+            <div
+                className="logo-loop-track flex w-max gap-10 py-6"
+                data-direction={direction}
+                style={{ animationDuration: `${speedSeconds}s` }}
+            >
+                {loopItems.map((item, index) => (
+                    <div
+                        key={`${item.name}-${index}`}
+                        className="flex items-center gap-3 rounded-2xl border border-green-100/80 bg-white/80 px-4 py-3 shadow-sm backdrop-blur-sm"
+                    >
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full border border-green-100 bg-green-50">
+                            <Image src={item.logo} alt={item.name} width={40} height={40} className="h-10 w-10 object-contain" />
+                        </div>
+                        <span className="text-sm font-medium text-green-700">{item.name}</span>
+                    </div>
+                ))}
+            </div>
+            <style jsx>{`
+                @keyframes logo-loop {
+                    from {
+                        transform: translateX(0);
+                    }
+                    to {
+                        transform: translateX(-50%);
+                    }
+                }
+
+                .logo-loop-track {
+                    animation: logo-loop linear infinite;
+                }
+
+                .logo-loop-track[data-direction="right"] {
+                    animation-direction: reverse;
+                }
+
+                .logo-loop:hover .logo-loop-track {
+                    animation-play-state: paused;
+                }
+            `}</style>
+        </div>
+    );
+}

--- a/src/lib/dispense.ts
+++ b/src/lib/dispense.ts
@@ -79,7 +79,7 @@ export async function recordDispense({
     consultation_id?: string | null;
     quantity: number;
     walkIn?: {
-        name: string;
+        idNumber: string;
         contact?: string | null;
         notes?: string | null;
     };
@@ -89,12 +89,12 @@ export async function recordDispense({
         throw new DispenseError("med_id is required", 400);
     }
 
-    const walkInName = walkIn?.name?.trim();
+    const walkInIdNumber = walkIn?.idNumber?.trim();
     const walkInContact = walkIn?.contact ? walkIn.contact.trim() : null;
     const walkInNotes = walkIn?.notes ? walkIn.notes.trim() : null;
 
     const hasConsultation = Boolean(consultation_id);
-    const hasWalkIn = Boolean(walkInName);
+    const hasWalkIn = Boolean(walkInIdNumber);
 
     if (!hasConsultation && !hasWalkIn) {
         throw new DispenseError("Either consultation_id or walk-in details are required", 400);
@@ -185,7 +185,7 @@ export async function recordDispense({
                 med_id,
                 consultation_id: hasConsultation ? consultation_id : null,
                 scholar_user_id: hasWalkIn ? scholar_user_id ?? null : null,
-                walk_in_name: hasWalkIn ? walkInName : null,
+                walk_in_id_number: hasWalkIn ? walkInIdNumber : null,
                 walk_in_contact: hasWalkIn ? walkInContact : null,
                 walk_in_notes: hasWalkIn ? walkInNotes : null,
                 quantity: qtyNeeded,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -133,81 +133,49 @@ class MemoryRateLimiter implements RateLimiter {
     }
 }
 
-const RATE_LIMIT_TABLE = '"RateLimitBucket"';
-let rateLimitTableReady = false;
-let ensureRateLimitTablePromise: Promise<void> | null = null;
-
-async function ensureRateLimitTable() {
-    if (rateLimitTableReady) {
-        return;
-    }
-
-    if (ensureRateLimitTablePromise) {
-        return ensureRateLimitTablePromise;
-    }
-
-    ensureRateLimitTablePromise = (async () => {
-        await prisma.$executeRawUnsafe(`
-            CREATE TABLE IF NOT EXISTS ${RATE_LIMIT_TABLE} (
-                "key" text NOT NULL,
-                "window_start" timestamptz NOT NULL,
-                "count" integer NOT NULL DEFAULT 1,
-                "updatedAt" timestamptz NOT NULL DEFAULT now(),
-                CONSTRAINT "RateLimitBucket_pkey" PRIMARY KEY ("key", "window_start")
-            )
-        `);
-
-        await prisma.$executeRawUnsafe(`
-            CREATE INDEX IF NOT EXISTS "RateLimitBucket_window_start_idx"
-            ON ${RATE_LIMIT_TABLE} ("window_start")
-        `);
-
-        rateLimitTableReady = true;
-    })();
-
-    try {
-        await ensureRateLimitTablePromise;
-    } catch (error) {
-        ensureRateLimitTablePromise = null;
-        throw error;
-    }
-}
-
 class PrismaRateLimiter implements RateLimiter {
     async consume(key: string, limit: number, windowMs: number): Promise<RateLimitResult> {
-        await ensureRateLimitTable();
-
         const now = new Date();
         const windowStartMs = Math.floor(now.getTime() / windowMs) * windowMs;
         const windowStart = new Date(windowStartMs);
         const windowEndMs = windowStartMs + windowMs;
 
         try {
-            const rows = await prisma.$transaction(
-                async (tx) =>
-                    tx.$queryRaw<{ count: number }[]>`
-                        INSERT INTO "RateLimitBucket" ("key", "window_start", "count")
-                        VALUES (${key}, ${windowStart}, 1)
-                        ON CONFLICT ("key", "window_start")
-                        DO UPDATE SET
-                            "count" = "RateLimitBucket"."count" + 1,
-                            "updatedAt" = now()
-                        RETURNING "count"
-                    `,
-                { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
-            );
+            const bucket = await prisma.rateLimitBucket.upsert({
+                where: {
+                    key_window_start: {
+                        key,
+                        window_start: windowStart,
+                    },
+                },
+                create: {
+                    key,
+                    window_start: windowStart,
+                    count: 1,
+                },
+                update: {
+                    count: { increment: 1 },
+                },
+            });
 
-            const count = Number(rows?.[0]?.count ?? 1);
-            if (count > limit) {
+            if (bucket.count > limit) {
                 return { success: false, retryAfterMs: Math.max(0, windowEndMs - now.getTime()) };
             }
+
+            void prisma.rateLimitBucket
+                .deleteMany({
+                    where: {
+                        window_start: {
+                            lt: new Date(now.getTime() - windowMs * 10),
+                        },
+                    },
+                })
+                .catch((cleanupError) => {
+                    console.warn("[RateLimit] Failed to clean up expired rate limit buckets", cleanupError);
+                });
 
             return { success: true };
         } catch (error) {
-            if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034") {
-                return { success: false, retryAfterMs: Math.max(0, windowEndMs - now.getTime()) };
-            }
-
             throw error;
         }
     }
@@ -231,7 +199,7 @@ function logRateLimitFallback(error: unknown) {
 
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2021") {
         console.warn(
-            "[RateLimit] RateLimitBucket table is unavailable or could not be created. Falling back to in-memory limiter."
+            "[RateLimit] RateLimitBucket table is unavailable. Ensure database migrations are up to date. Falling back to in-memory limiter."
         );
         return;
     }


### PR DESCRIPTION
## Summary
- store walk-in dispenses with student/employee ID numbers across the schema, APIs, and dashboards
- add the RateLimitBucket model and switch the rate limiter to Prisma-backed counters
- refresh the Learn More technology section with a looping logo marquee and updated highlight cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690c979ef4248327b529555f93f63939