### PR TITLE
Use walk-in ID numbers for dispenses and update learn more tooling section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@next-auth/prisma-adapter": "^1.0.7",
-        "@prisma/client": "^6.18.0",
+        "@prisma/client": "^6.19.0",
         "@prisma/extension-accelerate": "^2.0.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -84,7 +84,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.4",
-        "prisma": "^6.18.0",
+        "prisma": "^6.19.0",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.18.0.tgz",
-      "integrity": "sha512-jnL2I9gDnPnw4A+4h5SuNn8Gc+1mL1Z79U/3I9eE2gbxJG1oSA+62ByPW4xkeDgwE0fqMzzpAZ7IHxYnLZ4iQA==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.0.tgz",
+      "integrity": "sha512-QXFT+N/bva/QI2qoXmjBzL7D6aliPffIwP+81AdTGq0FXDoLxLkWivGMawG8iM5B9BKfxLIXxfWWAF6wbuJU6g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.18.0.tgz",
-      "integrity": "sha512-rgFzspCpwsE+q3OF/xkp0fI2SJ3PfNe9LLMmuSVbAZ4nN66WfBiKqJKo/hLz3ysxiPQZf8h1SMf2ilqPMeWATQ==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0.tgz",
+      "integrity": "sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1136,30 +1136,30 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.18.0.tgz",
-      "integrity": "sha512-PMVPMmxPj0ps1VY75DIrT430MoOyQx9hmm174k6cmLZpcI95rAPXOQ+pp8ANQkJtNyLVDxnxVJ0QLbrm/ViBcg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.0.tgz",
+      "integrity": "sha512-8hAdGG7JmxrzFcTzXZajlQCidX0XNkMJkpqtfbLV54wC6LSSX6Vni25W/G+nAANwLnZ2TmwkfIuWetA7jJxJFA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.18.0.tgz",
-      "integrity": "sha512-i5RzjGF/ex6AFgqEe2o1IW8iIxJGYVQJVRau13kHPYEL1Ck8Zvwuzamqed/1iIljs5C7L+Opiz5TzSsUebkriA==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.0.tgz",
+      "integrity": "sha512-pMRJ+1S6NVdXoB8QJAPIGpKZevFjxhKt0paCkRDTZiczKb7F4yTgRP8M4JdVkpQwmaD4EoJf6qA+p61godDokw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.18.0",
-        "@prisma/engines-version": "6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f",
-        "@prisma/fetch-engine": "6.18.0",
-        "@prisma/get-platform": "6.18.0"
+        "@prisma/debug": "6.19.0",
+        "@prisma/engines-version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
+        "@prisma/fetch-engine": "6.19.0",
+        "@prisma/get-platform": "6.19.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f.tgz",
-      "integrity": "sha512-T7Af4QsJQnSgWN1zBbX+Cha5t4qjHRxoeoWpK4JugJzG/ipmmDMY5S+O0N1ET6sCBNVkf6lz+Y+ZNO9+wFU8pQ==",
+      "version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773.tgz",
+      "integrity": "sha512-gV7uOBQfAFlWDvPJdQxMT1aSRur3a0EkU/6cfbAC5isV67tKDWUrPauyaHNpB+wN1ebM4A9jn/f4gH+3iHSYSQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
@@ -1175,25 +1175,25 @@
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.18.0.tgz",
-      "integrity": "sha512-TdaBvTtBwP3IoqVYoGIYpD4mWlk0pJpjTJjir/xLeNWlwog7Sl3bD2J0jJ8+5+q/6RBg+acb9drsv5W6lqae7A==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.0.tgz",
+      "integrity": "sha512-OOx2Lda0DGrZ1rodADT06ZGqHzr7HY7LNMaFE2Vp8dp146uJld58sRuasdX0OiwpHgl8SqDTUKHNUyzEq7pDdQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.18.0",
-        "@prisma/engines-version": "6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f",
-        "@prisma/get-platform": "6.18.0"
+        "@prisma/debug": "6.19.0",
+        "@prisma/engines-version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
+        "@prisma/get-platform": "6.19.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.18.0.tgz",
-      "integrity": "sha512-uXNJCJGhxTCXo2B25Ta91Rk1/Nmlqg9p7G9GKh8TPhxvAyXCvMNQoogj4JLEUy+3ku8g59cpyQIKFhqY2xO2bg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.0.tgz",
+      "integrity": "sha512-ym85WDO2yDhC3fIXHWYpG3kVMBA49cL1XD2GCsCF8xbwoy2OkDQY44gEbAt2X46IQ4Apq9H6g0Ex1iFfPqEkHA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.18.0"
+        "@prisma/debug": "6.19.0"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -8117,16 +8117,16 @@
       "license": "MIT"
     },
     "node_modules/prisma": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.18.0.tgz",
-      "integrity": "sha512-bXWy3vTk8mnRmT+SLyZBQoC2vtV9Z8u7OHvEu+aULYxwiop/CPiFZ+F56KsNRNf35jw+8wcu8pmLsjxpBxAO9g==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.0.tgz",
+      "integrity": "sha512-F3eX7K+tWpkbhl3l4+VkFtrwJlLXbAM+f9jolgoUZbFcm1DgHZ4cq9AgVEgUym2au5Ad/TDLN8lg83D+M10ycw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@prisma/config": "6.18.0",
-        "@prisma/engines": "6.18.0"
+        "@prisma/config": "6.19.0",
+        "@prisma/engines": "6.19.0"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -9419,11 +9419,14 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@next-auth/prisma-adapter": "^1.0.7",
-    "@prisma/client": "^6.18.0",
+    "@prisma/client": "^6.19.0",
     "@prisma/extension-accelerate": "^2.0.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -85,7 +85,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
-    "prisma": "^6.18.0",
+    "prisma": "^6.19.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,7 +182,7 @@ model MedDispense {
   med_id          String
   consultation_id String?
   scholar_user_id String?
-  walk_in_name    String?
+  walk_in_id_number String?
   walk_in_contact String?
   walk_in_notes   String?
   quantity        Int
@@ -204,6 +204,16 @@ model DispenseBatch {
   quantity_used    Int
   dispense         MedDispense   @relation(fields: [dispense_id], references: [dispense_id], onDelete: Cascade)
   replenishment    Replenishment @relation(fields: [replenishment_id], references: [replenishment_id], onDelete: Cascade)
+}
+
+model RateLimitBucket {
+  key          String
+  window_start DateTime
+  count        Int      @default(1)
+  updatedAt    DateTime @updatedAt
+
+  @@id([key, window_start])
+  @@index([window_start])
 }
 
 model PasswordResetToken {

--- a/src/app/api/nurse/dispense/route.ts
+++ b/src/app/api/nurse/dispense/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
             med_id,
             consultation_id,
             quantity,
-            walkInName,
+            walkInIdNumber,
             walkInContact,
             walkInNotes,
             scholarUserId,
@@ -41,14 +41,14 @@ export async function POST(req: Request) {
             );
         }
 
-        if (!consultation_id && !walkInName) {
+        if (!consultation_id && !walkInIdNumber) {
             return NextResponse.json(
-                { error: "Provide a consultation_id or walk-in name" },
+                { error: "Provide a consultation_id or walk-in ID number" },
                 { status: 400 }
             );
         }
 
-        if (!consultation_id && walkInName && !scholarUserId) {
+        if (!consultation_id && walkInIdNumber && !scholarUserId) {
             return NextResponse.json(
                 { error: "Walk-in dispenses must include the assisting scholar" },
                 { status: 400 }
@@ -59,14 +59,14 @@ export async function POST(req: Request) {
             med_id,
             consultation_id: consultation_id ?? null,
             quantity: Number(quantity),
-            walkIn: walkInName
+            walkIn: walkInIdNumber
                 ? {
-                    name: walkInName,
+                    idNumber: walkInIdNumber,
                     contact: walkInContact ?? null,
                     notes: walkInNotes ?? null,
                 }
                 : undefined,
-            scholar_user_id: walkInName ? scholarUserId ?? null : null,
+            scholar_user_id: walkInIdNumber ? scholarUserId ?? null : null,
         });
         return NextResponse.json(newDispense);
     } catch (err) {

--- a/src/app/api/scholar/dispense/route.ts
+++ b/src/app/api/scholar/dispense/route.ts
@@ -91,11 +91,11 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { med_id, quantity, walkInName, walkInContact, walkInNotes } = await req.json();
+        const { med_id, quantity, walkInIdNumber, walkInContact, walkInNotes } = await req.json();
 
-        if (!med_id || quantity === undefined || !walkInName) {
+        if (!med_id || quantity === undefined || !walkInIdNumber) {
             return NextResponse.json(
-                { error: "med_id, quantity, and walkInName are required" },
+                { error: "med_id, quantity, and walkInIdNumber are required" },
                 { status: 400 }
             );
         }
@@ -104,7 +104,7 @@ export async function POST(req: Request) {
             med_id,
             quantity: Number(quantity),
             walkIn: {
-                name: walkInName,
+                idNumber: walkInIdNumber,
                 contact: walkInContact ?? null,
                 notes: walkInNotes ?? null,
             },

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -45,7 +45,7 @@ type DispenseRecord = {
         doctor: { username: string } | null;
         nurse: { username: string } | null;
     } | null;
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -491,8 +491,9 @@ export default function DoctorDispensePage() {
                                                             <div className="flex flex-col gap-1">
                                                                 <span className="font-semibold text-gray-900">
                                                                     {d.consultation?.appointment?.patient?.username ??
-                                                                        d.walk_in_name ??
-                                                                        "—"}
+                                                                        (d.walk_in_id_number
+                                                                            ? `Walk-in ID: ${d.walk_in_id_number}`
+                                                                            : "—")}
                                                                 </span>
                                                                 {!d.consultation && (
                                                                     <>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -5,14 +5,18 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { SiteHeader } from "@/components/marketing/site-header";
+import { LogoLoop } from "@/components/ui/LogoLoop";
 import {
     Users,
-    Code2,
     LayoutDashboard,
     ShieldCheck,
     BellRing,
     Workflow,
     ArrowRight,
+    Cpu,
+    Braces,
+    ServerCog,
+    Lock,
 } from "lucide-react";
 
 const navigation = [
@@ -68,6 +72,33 @@ const techStack = [
     { name: "Vercel", logo: "/logos/vercel.svg" },
 ];
 
+const toolingHighlights = [
+    {
+        title: "Server-first architecture",
+        description:
+            "Next.js App Router and server components keep clinic tools responsive while reducing client overhead.",
+        icon: ServerCog,
+    },
+    {
+        title: "Typed business logic",
+        description:
+            "TypeScript with Zod validation ensures every dispense, consult, and report follows strict data contracts.",
+        icon: Braces,
+    },
+    {
+        title: "Automated guardrails",
+        description:
+            "Integrated workflows handle inventory adjustments, batching, and Prisma-backed rate limits to prevent abuse.",
+        icon: Workflow,
+    },
+    {
+        title: "Secure data pathways",
+        description:
+            "Prisma ORM, protected sessions, and audited access policies protect health information end to end.",
+        icon: Lock,
+    },
+];
+
 const developers = [
     {
         name: "David Matthew Maniwang",
@@ -92,6 +123,12 @@ const developers = [
 ];
 
 export default function LearnMorePage() {
+    const midpoint = Math.ceil(techStack.length / 2);
+    const logoRows = [
+        techStack.slice(0, midpoint),
+        techStack.slice(midpoint),
+    ].filter((row) => row.length > 0);
+
     return (
         <div className="flex min-h-screen flex-col bg-linear-to-b from-green-50 via-white to-green-50">
             <SiteHeader navigation={navigation} />
@@ -206,26 +243,59 @@ export default function LearnMorePage() {
                 </section>
 
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
-                    <div className="mx-auto max-w-6xl space-y-10">
+                    <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
-                            <Code2 className="mx-auto h-12 w-12 text-green-600" />
+                            <Cpu className="mx-auto h-12 w-12 text-green-600" />
                             <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Modern tools that power the experience</h3>
                             <p className="mx-auto max-w-3xl text-gray-600">
-                                Our technology stack combines reliable frameworks and UI libraries to keep the platform scalable and intuitive.
+                                Our technology stack blends fast rendering, strict type-safety, and dependable automation so the clinic can focus on care—not upkeep.
                             </p>
                         </div>
 
-                        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                            {techStack.map((tech) => (
-                                <Card key={tech.name} className="rounded-2xl border-green-100 bg-white shadow-sm">
-                                    <CardContent className="flex flex-col items-center gap-4 p-6">
-                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
-                                            <Image src={tech.logo} alt={tech.name} width={48} height={48} className="object-contain" />
-                                        </div>
-                                        <p className="text-sm font-medium text-green-700">{tech.name}</p>
-                                    </CardContent>
-                                </Card>
-                            ))}
+                        <div className="space-y-10">
+                            <div className="space-y-4">
+                                {logoRows.map((row, index) => (
+                                    <div
+                                        key={`logo-loop-${index}`}
+                                        className="overflow-hidden rounded-3xl border border-green-100/70 bg-white/90 shadow-sm"
+                                    >
+                                        <LogoLoop
+                                            logos={row.map((tech) => ({
+                                                src: tech.logo,
+                                                alt: tech.name,
+                                                title: tech.name,
+                                                width: 128,
+                                                height: 48,
+                                            }))}
+                                            ariaLabel="Clinic technology stack logos"
+                                            speed={index % 2 === 0 ? 90 : 120}
+                                            direction={index % 2 === 0 ? "left" : "right"}
+                                            logoHeight={40}
+                                            gap={48}
+                                            pauseOnHover
+                                            fadeOut
+                                            fadeOutColor="rgba(248, 250, 252, 0.95)"
+                                            className="px-4 py-6"
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+
+                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                                {toolingHighlights.map(({ title, description, icon: Icon }) => (
+                                    <Card key={title} className="rounded-2xl border-green-100 bg-white shadow-sm">
+                                        <CardContent className="space-y-4 p-6 text-left">
+                                            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
+                                                <Icon className="h-6 w-6" />
+                                            </span>
+                                            <div className="space-y-2">
+                                                <p className="text-base font-semibold text-green-700">{title}</p>
+                                                <p className="text-sm text-gray-600 leading-relaxed">{description}</p>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                ))}
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -13,9 +13,6 @@ import {
     BellRing,
     Workflow,
     ArrowRight,
-    Braces,
-    ServerCog,
-    Lock,
     Code2,
 } from "lucide-react";
 
@@ -70,33 +67,6 @@ const techStack = [
     { name: "NextAuth", logo: "/logos/nextauth.svg", href: "https://next-auth.js.org" },
     { name: "Zod", logo: "/logos/zod.svg", href: "https://zod.dev" },
     { name: "Vercel", logo: "/logos/vercel.svg", href: "https://vercel.com" },
-];
-
-const toolingHighlights = [
-    {
-        title: "Server-first architecture",
-        description:
-            "Next.js App Router and server components keep clinic tools responsive while reducing client overhead.",
-        icon: ServerCog,
-    },
-    {
-        title: "Typed business logic",
-        description:
-            "TypeScript with Zod validation ensures every dispense, consult, and report follows strict data contracts.",
-        icon: Braces,
-    },
-    {
-        title: "Automated guardrails",
-        description:
-            "Integrated workflows handle inventory adjustments, batching, and Prisma-backed rate limits to prevent abuse.",
-        icon: Workflow,
-    },
-    {
-        title: "Secure data pathways",
-        description:
-            "Prisma ORM, protected sessions, and audited access policies protect health information end to end.",
-        icon: Lock,
-    },
 ];
 
 const developers = [
@@ -193,7 +163,6 @@ export default function LearnMorePage() {
                         </div>
                     </div>
                 </section>
-
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
                     <div className="mx-auto grid max-w-6xl gap-10 md:grid-cols-[1.1fr_0.9fr] items-center">
                         <div className="space-y-6">
@@ -235,8 +204,7 @@ export default function LearnMorePage() {
                         </Card>
                     </div>
                 </section>
-
-                <section className="bg-white px-6 py-16 md:px-12 md:py-20">
+                <section className="bg-white px-6 py-16 md:px-12 md:py-10">
                     <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
                             <Code2 className="mx-auto h-12 w-12 text-green-600" />
@@ -247,7 +215,7 @@ export default function LearnMorePage() {
                         </div>
 
                         <div className="space-y-10">
-                            <div className="overflow-hidden shadow-sm">
+                            <div className="overflow-hidden">
                                 <LogoLoop
                                     logos={techStack.map((tech) => ({
                                         src: tech.logo,
@@ -258,32 +226,16 @@ export default function LearnMorePage() {
                                         height: 48,
                                     }))}
                                     ariaLabel="Clinic technology stack logos"
-                                    speed={100}
+                                    speed={80}
                                     direction="left"
-                                    logoHeight={40}
-                                    gap={24}
+                                    logoHeight={45}
+                                    gap={20}
                                     pauseOnHover
                                     fadeOut
                                     fadeOutColor="rgba(248, 250, 252, 0.95)"
                                     scaleOnHover
                                     className="px-4 py-6"
                                 />
-                            </div>
-
-                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                                {toolingHighlights.map(({ title, description, icon: Icon }) => (
-                                    <Card key={title} className="rounded-2xl border-green-100 bg-white shadow-sm">
-                                        <CardContent className="space-y-4 p-6 text-left">
-                                            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
-                                                <Icon className="h-6 w-6" />
-                                            </span>
-                                            <div className="space-y-2">
-                                                <p className="text-base font-semibold text-green-700">{title}</p>
-                                                <p className="text-sm text-gray-600 leading-relaxed">{description}</p>
-                                            </div>
-                                        </CardContent>
-                                    </Card>
-                                ))}
                             </div>
                         </div>
                     </div>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -123,12 +123,6 @@ const developers = [
 ];
 
 export default function LearnMorePage() {
-    const midpoint = Math.ceil(techStack.length / 2);
-    const logoRows = [
-        techStack.slice(0, midpoint),
-        techStack.slice(midpoint),
-    ].filter((row) => row.length > 0);
-
     return (
         <div className="flex min-h-screen flex-col bg-linear-to-b from-green-50 via-white to-green-50">
             <SiteHeader navigation={navigation} />

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -247,7 +247,7 @@ export default function LearnMorePage() {
                         </div>
 
                         <div className="space-y-10">
-                            <div className="overflow-hidden rounded-3xl border border-green-100/70 bg-white/90 shadow-sm">
+                            <div className="overflow-hidden shadow-sm">
                                 <LogoLoop
                                     logos={techStack.map((tech) => ({
                                         src: tech.logo,
@@ -258,10 +258,10 @@ export default function LearnMorePage() {
                                         height: 48,
                                     }))}
                                     ariaLabel="Clinic technology stack logos"
-                                    speed={105}
+                                    speed={100}
                                     direction="left"
                                     logoHeight={40}
-                                    gap={48}
+                                    gap={24}
                                     pauseOnHover
                                     fadeOut
                                     fadeOutColor="rgba(248, 250, 252, 0.95)"

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -228,7 +228,7 @@ export default function LearnMorePage() {
                                     ariaLabel="Clinic technology stack logos"
                                     speed={80}
                                     direction="left"
-                                    logoHeight={45}
+                                    logoHeight={50}
                                     gap={20}
                                     pauseOnHover
                                     fadeOut

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -13,10 +13,10 @@ import {
     BellRing,
     Workflow,
     ArrowRight,
-    Cpu,
     Braces,
     ServerCog,
     Lock,
+    Code2,
 } from "lucide-react";
 
 const navigation = [
@@ -62,14 +62,14 @@ const process = [
 ];
 
 const techStack = [
-    { name: "Next.js", logo: "/logos/nextjs.svg" },
-    { name: "TypeScript", logo: "/logos/typescript.svg" },
-    { name: "Tailwind CSS", logo: "/logos/tailwind.svg" },
-    { name: "ShadCN/UI", logo: "/logos/shadcn.svg" },
-    { name: "Lucide Icons", logo: "/logos/lucide.svg" },
-    { name: "NextAuth", logo: "/logos/nextauth.svg" },
-    { name: "Zod", logo: "/logos/zod.svg" },
-    { name: "Vercel", logo: "/logos/vercel.svg" },
+    { name: "Next.js", logo: "/logos/nextjs.svg", href: "https://nextjs.org" },
+    { name: "TypeScript", logo: "/logos/typescript.svg", href: "https://www.typescriptlang.org" },
+    { name: "Tailwind CSS", logo: "/logos/tailwind.svg", href: "https://tailwindcss.com" },
+    { name: "ShadCN/UI", logo: "/logos/shadcn.svg", href: "https://ui.shadcn.com" },
+    { name: "Lucide Icons", logo: "/logos/lucide.svg", href: "https://lucide.dev" },
+    { name: "NextAuth", logo: "/logos/nextauth.svg", href: "https://next-auth.js.org" },
+    { name: "Zod", logo: "/logos/zod.svg", href: "https://zod.dev" },
+    { name: "Vercel", logo: "/logos/vercel.svg", href: "https://vercel.com" },
 ];
 
 const toolingHighlights = [
@@ -245,40 +245,35 @@ export default function LearnMorePage() {
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
                     <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
-                            <Cpu className="mx-auto h-12 w-12 text-green-600" />
+                            <Code2 className="mx-auto h-12 w-12 text-green-600" />
                             <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Modern tools that power the experience</h3>
                             <p className="mx-auto max-w-3xl text-gray-600">
-                                Our technology stack blends fast rendering, strict type-safety, and dependable automation so the clinic can focus on care—not upkeep.
+                                Our technology stack combines reliable frameworks and UI libraries to keep the platform scalable and intuitive.
                             </p>
                         </div>
 
                         <div className="space-y-10">
-                            <div className="space-y-4">
-                                {logoRows.map((row, index) => (
-                                    <div
-                                        key={`logo-loop-${index}`}
-                                        className="overflow-hidden rounded-3xl border border-green-100/70 bg-white/90 shadow-sm"
-                                    >
-                                        <LogoLoop
-                                            logos={row.map((tech) => ({
-                                                src: tech.logo,
-                                                alt: tech.name,
-                                                title: tech.name,
-                                                width: 128,
-                                                height: 48,
-                                            }))}
-                                            ariaLabel="Clinic technology stack logos"
-                                            speed={index % 2 === 0 ? 90 : 120}
-                                            direction={index % 2 === 0 ? "left" : "right"}
-                                            logoHeight={40}
-                                            gap={48}
-                                            pauseOnHover
-                                            fadeOut
-                                            fadeOutColor="rgba(248, 250, 252, 0.95)"
-                                            className="px-4 py-6"
-                                        />
-                                    </div>
-                                ))}
+                            <div className="overflow-hidden rounded-3xl border border-green-100/70 bg-white/90 shadow-sm">
+                                <LogoLoop
+                                    logos={techStack.map((tech) => ({
+                                        src: tech.logo,
+                                        alt: tech.name,
+                                        title: tech.name,
+                                        href: tech.href,
+                                        width: 128,
+                                        height: 48,
+                                    }))}
+                                    ariaLabel="Clinic technology stack logos"
+                                    speed={105}
+                                    direction="left"
+                                    logoHeight={40}
+                                    gap={48}
+                                    pauseOnHover
+                                    fadeOut
+                                    fadeOutColor="rgba(248, 250, 252, 0.95)"
+                                    scaleOnHover
+                                    className="px-4 py-6"
+                                />
                             </div>
 
                             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -35,7 +35,7 @@ type Dispense = {
         doctor: { username: string } | null;
         nurse: { username: string } | null;
     } | null;
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -228,8 +228,9 @@ export default function NurseDispensePage() {
                                                     <div className="flex flex-col gap-1">
                                                         <span className="font-semibold text-gray-900">
                                                             {d.consultation?.appointment?.patient?.username ??
-                                                                d.walk_in_name ??
-                                                                "—"}
+                                                                (d.walk_in_id_number
+                                                                    ? `Walk-in ID: ${d.walk_in_id_number}`
+                                                                    : "—")}
                                                         </span>
                                                         {!d.consultation && (
                                                             <>

--- a/src/app/scholar/dispense/page.tsx
+++ b/src/app/scholar/dispense/page.tsx
@@ -38,7 +38,7 @@ type DispenseRecord = {
         item_name: string;
         clinic: { clinic_name: string };
     };
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -92,7 +92,7 @@ export default function ScholarDispensePage() {
     const [loading, setLoading] = useState(false);
     const [submitting, setSubmitting] = useState(false);
     const [form, setForm] = useState({
-        name: "",
+        idNumber: "",
         contact: "",
         notes: "",
         med_id: "",
@@ -155,7 +155,7 @@ export default function ScholarDispensePage() {
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
 
-        if (!form.name.trim() || !form.med_id || !form.quantity) {
+        if (!form.idNumber.trim() || !form.med_id || !form.quantity) {
             toast.error("Please complete the required fields");
             return;
         }
@@ -179,7 +179,7 @@ export default function ScholarDispensePage() {
                 body: JSON.stringify({
                     med_id: form.med_id,
                     quantity,
-                    walkInName: form.name.trim(),
+                    walkInIdNumber: form.idNumber.trim(),
                     walkInContact: form.contact.trim() || null,
                     walkInNotes: form.notes.trim() || null,
                 }),
@@ -199,7 +199,7 @@ export default function ScholarDispensePage() {
                         : medicine
                 )
             );
-            setForm({ name: "", contact: "", notes: "", med_id: "", quantity: "" });
+            setForm({ idNumber: "", contact: "", notes: "", med_id: "", quantity: "" });
             toast.success("Walk-in dispense recorded");
         } catch (error) {
             console.error(error);
@@ -289,11 +289,11 @@ export default function ScholarDispensePage() {
                     <CardContent className="pt-6">
                         <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
                             <div className="space-y-2">
-                                <Label className="font-medium text-green-700">Walk-in name</Label>
+                                <Label className="font-medium text-green-700">Walk-in ID number</Label>
                                 <Input
-                                    value={form.name}
-                                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
-                                    placeholder="Enter walk-in's name"
+                                    value={form.idNumber}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, idNumber: event.target.value }))}
+                                    placeholder="Enter walk-in's ID number"
                                     required
                                     className="rounded-xl border border-green-100/80 bg-white/80 focus-visible:ring-green-500"
                                 />
@@ -400,7 +400,7 @@ export default function ScholarDispensePage() {
                                     <TableHeader className="bg-green-50 text-green-700">
                                         <TableRow>
                                             <TableHead className="whitespace-nowrap">Clinic</TableHead>
-                                            <TableHead className="whitespace-nowrap">Walk-in</TableHead>
+                                            <TableHead className="whitespace-nowrap">Walk-in ID</TableHead>
                                             <TableHead className="whitespace-nowrap">Medicine</TableHead>
                                             <TableHead className="whitespace-nowrap">Quantity</TableHead>
                                             <TableHead className="whitespace-nowrap">Scholar</TableHead>
@@ -421,7 +421,7 @@ export default function ScholarDispensePage() {
                                                 <TableCell>
                                                     <div className="flex flex-col gap-1">
                                                         <span className="font-semibold text-gray-900">
-                                                            {dispense.walk_in_name ?? "—"}
+                                                            {dispense.walk_in_id_number ?? "—"}
                                                         </span>
                                                         {dispense.walk_in_contact ? (
                                                             <span className="text-xs text-muted-foreground">

--- a/src/components/ui/LogoLoop.tsx
+++ b/src/components/ui/LogoLoop.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import NextImage from 'next/image';
 

--- a/src/components/ui/LogoLoop.tsx
+++ b/src/components/ui/LogoLoop.tsx
@@ -268,8 +268,7 @@ export const LogoLoop = React.memo<LogoLoopProps>(
           <span
             className={cx(
               'inline-flex items-center',
-              'motion-reduce:transition-none',
-              scaleOnHover && 'transition-transform duration-300 ease-in-out group-hover/item:scale-120'
+              'motion-reduce:transition-none'
             )}
             aria-hidden={!!item.href && !item.ariaLabel}
           >
@@ -281,8 +280,7 @@ export const LogoLoop = React.memo<LogoLoopProps>(
               'h-(--logoloop-logoHeight) block object-contain',
               '[-webkit-user-drag:none] pointer-events-none',
               '[image-rendering:-webkit-optimize-contrast]',
-              'motion-reduce:transition-none',
-              scaleOnHover && 'transition-transform duration-300 ease-in-out group-hover/item:scale-120'
+              'motion-reduce:transition-none'
             )}
             src={item.src}
             alt={item.alt ?? ''}
@@ -302,7 +300,9 @@ export const LogoLoop = React.memo<LogoLoopProps>(
             className={cx(
               'inline-flex items-center no-underline rounded',
               'transition-opacity duration-200 ease-linear hover:opacity-80',
-              'focus-visible:outline focus-visible:outline-current focus-visible:outline-offset-2'
+              'focus-visible:outline focus-visible:outline-current focus-visible:outline-offset-2',
+              scaleOnHover &&
+              'transition-transform duration-300 ease-in-out hover:scale-110 focus-visible:scale-105 motion-reduce:transform-none'
             )}
             href={item.href}
             aria-label={itemAriaLabel || 'logo link'}
@@ -312,7 +312,15 @@ export const LogoLoop = React.memo<LogoLoopProps>(
             {content}
           </a>
         ) : (
-          content
+          <span
+            className={cx(
+              'inline-flex items-center',
+              scaleOnHover &&
+              'transition-transform duration-300 ease-in-out hover:scale-110 group-hover/item:scale-110 motion-reduce:transform-none'
+            )}
+          >
+            {content}
+          </span>
         );
 
         return (

--- a/src/components/ui/LogoLoop.tsx
+++ b/src/components/ui/LogoLoop.tsx
@@ -49,7 +49,7 @@ const toCssLength = (value?: number | string): string | undefined =>
 const cx = (...parts: Array<string | false | null | undefined>) => parts.filter(Boolean).join(' ');
 
 const useResizeObserver = (
-  callback: () => void, elements: Array<React.RefObject<Element | null>>, p0: (number | LogoItem[])[]) => {
+  callback: () => void, elements: Array<React.RefObject<Element | null>>) => {
   useEffect(() => {
     if (!window.ResizeObserver) {
       const handleResize = () => callback();
@@ -71,7 +71,7 @@ const useResizeObserver = (
 };
 
 const useImageLoader = (
-  seqRef: React.RefObject<HTMLUListElement | null>, onLoad: () => void, p0: (number | LogoItem[])[],
+  seqRef: React.RefObject<HTMLUListElement | null>, onLoad: () => void,
 ) => {
   useEffect(() => {
     const images = seqRef.current?.querySelectorAll<HTMLImageElement>('img') ?? [];
@@ -224,9 +224,9 @@ export const LogoLoop = React.memo<LogoLoopProps>(
       ariaLabel?: string;
     } => 'node' in item;
 
-    useResizeObserver(updateDimensions, [containerRef, seqRef], [logos, gap, logoHeight]);
+    useResizeObserver(updateDimensions, [containerRef, seqRef]);
 
-    useImageLoader(seqRef, updateDimensions, [logos, gap, logoHeight]);
+    useImageLoader(seqRef, updateDimensions);
 
     useAnimationLoop(trackRef, targetVelocity, seqWidth, isHovered, pauseOnHover);
 

--- a/src/lib/dispense.ts
+++ b/src/lib/dispense.ts
@@ -79,7 +79,7 @@ export async function recordDispense({
     consultation_id?: string | null;
     quantity: number;
     walkIn?: {
-        name: string;
+        idNumber: string;
         contact?: string | null;
         notes?: string | null;
     };
@@ -89,12 +89,12 @@ export async function recordDispense({
         throw new DispenseError("med_id is required", 400);
     }
 
-    const walkInName = walkIn?.name?.trim();
+    const walkInIdNumber = walkIn?.idNumber?.trim();
     const walkInContact = walkIn?.contact ? walkIn.contact.trim() : null;
     const walkInNotes = walkIn?.notes ? walkIn.notes.trim() : null;
 
     const hasConsultation = Boolean(consultation_id);
-    const hasWalkIn = Boolean(walkInName);
+    const hasWalkIn = Boolean(walkInIdNumber);
 
     if (!hasConsultation && !hasWalkIn) {
         throw new DispenseError("Either consultation_id or walk-in details are required", 400);
@@ -185,7 +185,7 @@ export async function recordDispense({
                 med_id,
                 consultation_id: hasConsultation ? consultation_id : null,
                 scholar_user_id: hasWalkIn ? scholar_user_id ?? null : null,
-                walk_in_name: hasWalkIn ? walkInName : null,
+                walk_in_id_number: hasWalkIn ? walkInIdNumber : null,
                 walk_in_contact: hasWalkIn ? walkInContact : null,
                 walk_in_notes: hasWalkIn ? walkInNotes : null,
                 quantity: qtyNeeded,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -133,71 +133,36 @@ class MemoryRateLimiter implements RateLimiter {
     }
 }
 
-const RATE_LIMIT_TABLE = '"RateLimitBucket"';
-let rateLimitTableReady = false;
-let ensureRateLimitTablePromise: Promise<void> | null = null;
-
-async function ensureRateLimitTable() {
-    if (rateLimitTableReady) {
-        return;
-    }
-
-    if (ensureRateLimitTablePromise) {
-        return ensureRateLimitTablePromise;
-    }
-
-    ensureRateLimitTablePromise = (async () => {
-        await prisma.$executeRawUnsafe(`
-            CREATE TABLE IF NOT EXISTS ${RATE_LIMIT_TABLE} (
-                "key" text NOT NULL,
-                "window_start" timestamptz NOT NULL,
-                "count" integer NOT NULL DEFAULT 1,
-                "updatedAt" timestamptz NOT NULL DEFAULT now(),
-                CONSTRAINT "RateLimitBucket_pkey" PRIMARY KEY ("key", "window_start")
-            )
-        `);
-
-        await prisma.$executeRawUnsafe(`
-            CREATE INDEX IF NOT EXISTS "RateLimitBucket_window_start_idx"
-            ON ${RATE_LIMIT_TABLE} ("window_start")
-        `);
-
-        rateLimitTableReady = true;
-    })();
-
-    try {
-        await ensureRateLimitTablePromise;
-    } catch (error) {
-        ensureRateLimitTablePromise = null;
-        throw error;
-    }
-}
-
 class PrismaRateLimiter implements RateLimiter {
     async consume(key: string, limit: number, windowMs: number): Promise<RateLimitResult> {
-        await ensureRateLimitTable();
-
         const now = new Date();
         const windowStartMs = Math.floor(now.getTime() / windowMs) * windowMs;
         const windowStart = new Date(windowStartMs);
         const windowEndMs = windowStartMs + windowMs;
 
         try {
-            const rows = await prisma.$transaction(
+            const bucket = await prisma.$transaction(
                 async (tx) =>
-                    tx.$queryRaw<{ count: number }[]>`
-                        INSERT INTO "RateLimitBucket" ("key", "window_start", "count")
-                        VALUES (${key}, ${windowStart}, 1)
-                        ON CONFLICT ("key", "window_start")
-                        DO UPDATE SET
-                            "count" = "RateLimitBucket"."count" + 1,
-                            "updatedAt" = now()
-                        RETURNING "count"
-                    `,
+                    tx.rateLimitBucket.upsert({
+                        where: { key_window_start: { key, window_start: windowStart } },
+                        update: { count: { increment: 1 } },
+                        create: { key, window_start: windowStart, count: 1 },
+                    }),
                 { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
             );
 
-            const count = Number(rows?.[0]?.count ?? 1);
+            const count = Number(bucket.count ?? 1);
+            if (count === 1) {
+                const cleanupThreshold = new Date(windowStartMs - windowMs * 24);
+                void prisma.rateLimitBucket
+                    .deleteMany({ where: { window_start: { lt: cleanupThreshold } } })
+                    .catch((cleanupError) => {
+                        console.warn(
+                            "[RateLimit] Failed to prune expired rate limit buckets:",
+                            cleanupError
+                        );
+                    });
+            }
             if (count > limit) {
                 return { success: false, retryAfterMs: Math.max(0, windowEndMs - now.getTime()) };
             }


### PR DESCRIPTION
## Summary
- replace the MedDispense walk-in name column with an ID number field and propagate the change through APIs and UI tables
- add a Prisma-managed RateLimitBucket model and update the rate limiter to use Prisma transactions with cleanup
- refresh the Learn More "Modern tools" section with LogoLoop marquees and new tooling highlight cards

## Testing
- npm run lint *(warnings about existing unused parameters in LogoLoop)*

------
https://chatgpt.com/codex/tasks/task_e_690ca5d0232c832791020bf74f8afca1