### PR TITLE
Use walk-in ID numbers for dispenses and update learn more tooling section

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,7 +182,7 @@ model MedDispense {
   med_id          String
   consultation_id String?
   scholar_user_id String?
-  walk_in_name    String?
+  walk_in_id_number String?
   walk_in_contact String?
   walk_in_notes   String?
   quantity        Int
@@ -204,6 +204,16 @@ model DispenseBatch {
   quantity_used    Int
   dispense         MedDispense   @relation(fields: [dispense_id], references: [dispense_id], onDelete: Cascade)
   replenishment    Replenishment @relation(fields: [replenishment_id], references: [replenishment_id], onDelete: Cascade)
+}
+
+model RateLimitBucket {
+  key          String
+  window_start DateTime
+  count        Int      @default(1)
+  updatedAt    DateTime @updatedAt
+
+  @@id([key, window_start])
+  @@index([window_start])
 }
 
 model PasswordResetToken {

--- a/src/app/api/nurse/dispense/route.ts
+++ b/src/app/api/nurse/dispense/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
             med_id,
             consultation_id,
             quantity,
-            walkInName,
+            walkInIdNumber,
             walkInContact,
             walkInNotes,
             scholarUserId,
@@ -41,14 +41,14 @@ export async function POST(req: Request) {
             );
         }
 
-        if (!consultation_id && !walkInName) {
+        if (!consultation_id && !walkInIdNumber) {
             return NextResponse.json(
-                { error: "Provide a consultation_id or walk-in name" },
+                { error: "Provide a consultation_id or walk-in ID number" },
                 { status: 400 }
             );
         }
 
-        if (!consultation_id && walkInName && !scholarUserId) {
+        if (!consultation_id && walkInIdNumber && !scholarUserId) {
             return NextResponse.json(
                 { error: "Walk-in dispenses must include the assisting scholar" },
                 { status: 400 }
@@ -59,14 +59,14 @@ export async function POST(req: Request) {
             med_id,
             consultation_id: consultation_id ?? null,
             quantity: Number(quantity),
-            walkIn: walkInName
+            walkIn: walkInIdNumber
                 ? {
-                    name: walkInName,
+                    idNumber: walkInIdNumber,
                     contact: walkInContact ?? null,
                     notes: walkInNotes ?? null,
                 }
                 : undefined,
-            scholar_user_id: walkInName ? scholarUserId ?? null : null,
+            scholar_user_id: walkInIdNumber ? scholarUserId ?? null : null,
         });
         return NextResponse.json(newDispense);
     } catch (err) {

--- a/src/app/api/scholar/dispense/route.ts
+++ b/src/app/api/scholar/dispense/route.ts
@@ -91,11 +91,11 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
-        const { med_id, quantity, walkInName, walkInContact, walkInNotes } = await req.json();
+        const { med_id, quantity, walkInIdNumber, walkInContact, walkInNotes } = await req.json();
 
-        if (!med_id || quantity === undefined || !walkInName) {
+        if (!med_id || quantity === undefined || !walkInIdNumber) {
             return NextResponse.json(
-                { error: "med_id, quantity, and walkInName are required" },
+                { error: "med_id, quantity, and walkInIdNumber are required" },
                 { status: 400 }
             );
         }
@@ -104,7 +104,7 @@ export async function POST(req: Request) {
             med_id,
             quantity: Number(quantity),
             walkIn: {
-                name: walkInName,
+                idNumber: walkInIdNumber,
                 contact: walkInContact ?? null,
                 notes: walkInNotes ?? null,
             },

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -45,7 +45,7 @@ type DispenseRecord = {
         doctor: { username: string } | null;
         nurse: { username: string } | null;
     } | null;
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -491,8 +491,9 @@ export default function DoctorDispensePage() {
                                                             <div className="flex flex-col gap-1">
                                                                 <span className="font-semibold text-gray-900">
                                                                     {d.consultation?.appointment?.patient?.username ??
-                                                                        d.walk_in_name ??
-                                                                        "—"}
+                                                                        (d.walk_in_id_number
+                                                                            ? `Walk-in ID: ${d.walk_in_id_number}`
+                                                                            : "—")}
                                                                 </span>
                                                                 {!d.consultation && (
                                                                     <>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -5,14 +5,18 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { SiteHeader } from "@/components/marketing/site-header";
+import { LogoLoop } from "@/components/ui/LogoLoop";
 import {
     Users,
-    Code2,
     LayoutDashboard,
     ShieldCheck,
     BellRing,
     Workflow,
     ArrowRight,
+    Cpu,
+    Braces,
+    ServerCog,
+    Lock,
 } from "lucide-react";
 
 const navigation = [
@@ -58,14 +62,41 @@ const process = [
 ];
 
 const techStack = [
-    { name: "Next.js", logo: "/logos/nextjs.svg" },
-    { name: "TypeScript", logo: "/logos/typescript.svg" },
-    { name: "Tailwind CSS", logo: "/logos/tailwind.svg" },
-    { name: "ShadCN/UI", logo: "/logos/shadcn.svg" },
-    { name: "Lucide Icons", logo: "/logos/lucide.svg" },
-    { name: "NextAuth", logo: "/logos/nextauth.svg" },
-    { name: "Zod", logo: "/logos/zod.svg" },
-    { name: "Vercel", logo: "/logos/vercel.svg" },
+    { name: "Next.js", logo: "/logos/nextjs.svg", href: "https://nextjs.org" },
+    { name: "TypeScript", logo: "/logos/typescript.svg", href: "https://www.typescriptlang.org" },
+    { name: "Tailwind CSS", logo: "/logos/tailwind.svg", href: "https://tailwindcss.com" },
+    { name: "ShadCN/UI", logo: "/logos/shadcn.svg", href: "https://ui.shadcn.com" },
+    { name: "Lucide Icons", logo: "/logos/lucide.svg", href: "https://lucide.dev" },
+    { name: "NextAuth", logo: "/logos/nextauth.svg", href: "https://next-auth.js.org" },
+    { name: "Zod", logo: "/logos/zod.svg", href: "https://zod.dev" },
+    { name: "Vercel", logo: "/logos/vercel.svg", href: "https://vercel.com" },
+];
+
+const toolingHighlights = [
+    {
+        title: "Server-first architecture",
+        description:
+            "Next.js App Router and server components keep clinic tools responsive while reducing client overhead.",
+        icon: ServerCog,
+    },
+    {
+        title: "Typed business logic",
+        description:
+            "TypeScript with Zod validation ensures every dispense, consult, and report follows strict data contracts.",
+        icon: Braces,
+    },
+    {
+        title: "Automated guardrails",
+        description:
+            "Integrated workflows handle inventory adjustments, batching, and Prisma-backed rate limits to prevent abuse.",
+        icon: Workflow,
+    },
+    {
+        title: "Secure data pathways",
+        description:
+            "Prisma ORM, protected sessions, and audited access policies protect health information end to end.",
+        icon: Lock,
+    },
 ];
 
 const developers = [
@@ -206,26 +237,54 @@ export default function LearnMorePage() {
                 </section>
 
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
-                    <div className="mx-auto max-w-6xl space-y-10">
+                    <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
-                            <Code2 className="mx-auto h-12 w-12 text-green-600" />
+                            <Cpu className="mx-auto h-12 w-12 text-green-600" />
                             <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Modern tools that power the experience</h3>
                             <p className="mx-auto max-w-3xl text-gray-600">
-                                Our technology stack combines reliable frameworks and UI libraries to keep the platform scalable and intuitive.
+                                Our technology stack blends fast rendering, strict type-safety, and dependable automation so the clinic can focus on care—not upkeep.
                             </p>
                         </div>
 
-                        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                            {techStack.map((tech) => (
-                                <Card key={tech.name} className="rounded-2xl border-green-100 bg-white shadow-sm">
-                                    <CardContent className="flex flex-col items-center gap-4 p-6">
-                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
-                                            <Image src={tech.logo} alt={tech.name} width={48} height={48} className="object-contain" />
-                                        </div>
-                                        <p className="text-sm font-medium text-green-700">{tech.name}</p>
-                                    </CardContent>
-                                </Card>
-                            ))}
+                        <div className="space-y-10">
+                            <div className="overflow-hidden rounded-3xl border border-green-100/70 bg-white/90 shadow-sm">
+                                <LogoLoop
+                                    logos={techStack.map((tech) => ({
+                                        src: tech.logo,
+                                        alt: tech.name,
+                                        title: tech.name,
+                                        href: tech.href,
+                                        width: 128,
+                                        height: 48,
+                                    }))}
+                                    ariaLabel="Clinic technology stack logos"
+                                    speed={105}
+                                    direction="left"
+                                    logoHeight={40}
+                                    gap={48}
+                                    pauseOnHover
+                                    fadeOut
+                                    fadeOutColor="rgba(248, 250, 252, 0.95)"
+                                    scaleOnHover
+                                    className="px-4 py-6"
+                                />
+                            </div>
+
+                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                                {toolingHighlights.map(({ title, description, icon: Icon }) => (
+                                    <Card key={title} className="rounded-2xl border-green-100 bg-white shadow-sm">
+                                        <CardContent className="space-y-4 p-6 text-left">
+                                            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
+                                                <Icon className="h-6 w-6" />
+                                            </span>
+                                            <div className="space-y-2">
+                                                <p className="text-base font-semibold text-green-700">{title}</p>
+                                                <p className="text-sm text-gray-600 leading-relaxed">{description}</p>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                ))}
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -35,7 +35,7 @@ type Dispense = {
         doctor: { username: string } | null;
         nurse: { username: string } | null;
     } | null;
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -228,8 +228,9 @@ export default function NurseDispensePage() {
                                                     <div className="flex flex-col gap-1">
                                                         <span className="font-semibold text-gray-900">
                                                             {d.consultation?.appointment?.patient?.username ??
-                                                                d.walk_in_name ??
-                                                                "—"}
+                                                                (d.walk_in_id_number
+                                                                    ? `Walk-in ID: ${d.walk_in_id_number}`
+                                                                    : "—")}
                                                         </span>
                                                         {!d.consultation && (
                                                             <>

--- a/src/app/scholar/dispense/page.tsx
+++ b/src/app/scholar/dispense/page.tsx
@@ -38,7 +38,7 @@ type DispenseRecord = {
         item_name: string;
         clinic: { clinic_name: string };
     };
-    walk_in_name: string | null;
+    walk_in_id_number: string | null;
     walk_in_contact: string | null;
     walk_in_notes: string | null;
     scholar: {
@@ -92,7 +92,7 @@ export default function ScholarDispensePage() {
     const [loading, setLoading] = useState(false);
     const [submitting, setSubmitting] = useState(false);
     const [form, setForm] = useState({
-        name: "",
+        idNumber: "",
         contact: "",
         notes: "",
         med_id: "",
@@ -155,7 +155,7 @@ export default function ScholarDispensePage() {
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
 
-        if (!form.name.trim() || !form.med_id || !form.quantity) {
+        if (!form.idNumber.trim() || !form.med_id || !form.quantity) {
             toast.error("Please complete the required fields");
             return;
         }
@@ -179,7 +179,7 @@ export default function ScholarDispensePage() {
                 body: JSON.stringify({
                     med_id: form.med_id,
                     quantity,
-                    walkInName: form.name.trim(),
+                    walkInIdNumber: form.idNumber.trim(),
                     walkInContact: form.contact.trim() || null,
                     walkInNotes: form.notes.trim() || null,
                 }),
@@ -199,7 +199,7 @@ export default function ScholarDispensePage() {
                         : medicine
                 )
             );
-            setForm({ name: "", contact: "", notes: "", med_id: "", quantity: "" });
+            setForm({ idNumber: "", contact: "", notes: "", med_id: "", quantity: "" });
             toast.success("Walk-in dispense recorded");
         } catch (error) {
             console.error(error);
@@ -289,11 +289,11 @@ export default function ScholarDispensePage() {
                     <CardContent className="pt-6">
                         <form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
                             <div className="space-y-2">
-                                <Label className="font-medium text-green-700">Walk-in name</Label>
+                                <Label className="font-medium text-green-700">Walk-in ID number</Label>
                                 <Input
-                                    value={form.name}
-                                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
-                                    placeholder="Enter walk-in's name"
+                                    value={form.idNumber}
+                                    onChange={(event) => setForm((prev) => ({ ...prev, idNumber: event.target.value }))}
+                                    placeholder="Enter walk-in's ID number"
                                     required
                                     className="rounded-xl border border-green-100/80 bg-white/80 focus-visible:ring-green-500"
                                 />
@@ -400,7 +400,7 @@ export default function ScholarDispensePage() {
                                     <TableHeader className="bg-green-50 text-green-700">
                                         <TableRow>
                                             <TableHead className="whitespace-nowrap">Clinic</TableHead>
-                                            <TableHead className="whitespace-nowrap">Walk-in</TableHead>
+                                            <TableHead className="whitespace-nowrap">Walk-in ID</TableHead>
                                             <TableHead className="whitespace-nowrap">Medicine</TableHead>
                                             <TableHead className="whitespace-nowrap">Quantity</TableHead>
                                             <TableHead className="whitespace-nowrap">Scholar</TableHead>
@@ -421,7 +421,7 @@ export default function ScholarDispensePage() {
                                                 <TableCell>
                                                     <div className="flex flex-col gap-1">
                                                         <span className="font-semibold text-gray-900">
-                                                            {dispense.walk_in_name ?? "—"}
+                                                            {dispense.walk_in_id_number ?? "—"}
                                                         </span>
                                                         {dispense.walk_in_contact ? (
                                                             <span className="text-xs text-muted-foreground">

--- a/src/components/ui/LogoLoop.tsx
+++ b/src/components/ui/LogoLoop.tsx
@@ -266,8 +266,7 @@ export const LogoLoop = React.memo<LogoLoopProps>(
           <span
             className={cx(
               'inline-flex items-center',
-              'motion-reduce:transition-none',
-              scaleOnHover && 'transition-transform duration-300 ease-in-out group-hover/item:scale-120'
+              'motion-reduce:transition-none'
             )}
             aria-hidden={!!item.href && !item.ariaLabel}
           >
@@ -279,8 +278,7 @@ export const LogoLoop = React.memo<LogoLoopProps>(
               'h-(--logoloop-logoHeight) block object-contain',
               '[-webkit-user-drag:none] pointer-events-none',
               '[image-rendering:-webkit-optimize-contrast]',
-              'motion-reduce:transition-none',
-              scaleOnHover && 'transition-transform duration-300 ease-in-out group-hover/item:scale-120'
+              'motion-reduce:transition-none'
             )}
             src={item.src}
             alt={item.alt ?? ''}
@@ -300,7 +298,9 @@ export const LogoLoop = React.memo<LogoLoopProps>(
             className={cx(
               'inline-flex items-center no-underline rounded',
               'transition-opacity duration-200 ease-linear hover:opacity-80',
-              'focus-visible:outline focus-visible:outline-current focus-visible:outline-offset-2'
+              'focus-visible:outline focus-visible:outline-current focus-visible:outline-offset-2',
+              scaleOnHover &&
+                'transition-transform duration-300 ease-in-out hover:scale-110 focus-visible:scale-105 motion-reduce:transform-none'
             )}
             href={item.href}
             aria-label={itemAriaLabel || 'logo link'}
@@ -310,7 +310,15 @@ export const LogoLoop = React.memo<LogoLoopProps>(
             {content}
           </a>
         ) : (
-          content
+          <span
+            className={cx(
+              'inline-flex items-center',
+              scaleOnHover &&
+                'transition-transform duration-300 ease-in-out hover:scale-110 group-hover/item:scale-110 motion-reduce:transform-none'
+            )}
+          >
+            {content}
+          </span>
         );
 
         return (

--- a/src/lib/dispense.ts
+++ b/src/lib/dispense.ts
@@ -79,7 +79,7 @@ export async function recordDispense({
     consultation_id?: string | null;
     quantity: number;
     walkIn?: {
-        name: string;
+        idNumber: string;
         contact?: string | null;
         notes?: string | null;
     };
@@ -89,12 +89,12 @@ export async function recordDispense({
         throw new DispenseError("med_id is required", 400);
     }
 
-    const walkInName = walkIn?.name?.trim();
+    const walkInIdNumber = walkIn?.idNumber?.trim();
     const walkInContact = walkIn?.contact ? walkIn.contact.trim() : null;
     const walkInNotes = walkIn?.notes ? walkIn.notes.trim() : null;
 
     const hasConsultation = Boolean(consultation_id);
-    const hasWalkIn = Boolean(walkInName);
+    const hasWalkIn = Boolean(walkInIdNumber);
 
     if (!hasConsultation && !hasWalkIn) {
         throw new DispenseError("Either consultation_id or walk-in details are required", 400);
@@ -185,7 +185,7 @@ export async function recordDispense({
                 med_id,
                 consultation_id: hasConsultation ? consultation_id : null,
                 scholar_user_id: hasWalkIn ? scholar_user_id ?? null : null,
-                walk_in_name: hasWalkIn ? walkInName : null,
+                walk_in_id_number: hasWalkIn ? walkInIdNumber : null,
                 walk_in_contact: hasWalkIn ? walkInContact : null,
                 walk_in_notes: hasWalkIn ? walkInNotes : null,
                 quantity: qtyNeeded,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -133,71 +133,36 @@ class MemoryRateLimiter implements RateLimiter {
     }
 }
 
-const RATE_LIMIT_TABLE = '"RateLimitBucket"';
-let rateLimitTableReady = false;
-let ensureRateLimitTablePromise: Promise<void> | null = null;
-
-async function ensureRateLimitTable() {
-    if (rateLimitTableReady) {
-        return;
-    }
-
-    if (ensureRateLimitTablePromise) {
-        return ensureRateLimitTablePromise;
-    }
-
-    ensureRateLimitTablePromise = (async () => {
-        await prisma.$executeRawUnsafe(`
-            CREATE TABLE IF NOT EXISTS ${RATE_LIMIT_TABLE} (
-                "key" text NOT NULL,
-                "window_start" timestamptz NOT NULL,
-                "count" integer NOT NULL DEFAULT 1,
-                "updatedAt" timestamptz NOT NULL DEFAULT now(),
-                CONSTRAINT "RateLimitBucket_pkey" PRIMARY KEY ("key", "window_start")
-            )
-        `);
-
-        await prisma.$executeRawUnsafe(`
-            CREATE INDEX IF NOT EXISTS "RateLimitBucket_window_start_idx"
-            ON ${RATE_LIMIT_TABLE} ("window_start")
-        `);
-
-        rateLimitTableReady = true;
-    })();
-
-    try {
-        await ensureRateLimitTablePromise;
-    } catch (error) {
-        ensureRateLimitTablePromise = null;
-        throw error;
-    }
-}
-
 class PrismaRateLimiter implements RateLimiter {
     async consume(key: string, limit: number, windowMs: number): Promise<RateLimitResult> {
-        await ensureRateLimitTable();
-
         const now = new Date();
         const windowStartMs = Math.floor(now.getTime() / windowMs) * windowMs;
         const windowStart = new Date(windowStartMs);
         const windowEndMs = windowStartMs + windowMs;
 
         try {
-            const rows = await prisma.$transaction(
+            const bucket = await prisma.$transaction(
                 async (tx) =>
-                    tx.$queryRaw<{ count: number }[]>`
-                        INSERT INTO "RateLimitBucket" ("key", "window_start", "count")
-                        VALUES (${key}, ${windowStart}, 1)
-                        ON CONFLICT ("key", "window_start")
-                        DO UPDATE SET
-                            "count" = "RateLimitBucket"."count" + 1,
-                            "updatedAt" = now()
-                        RETURNING "count"
-                    `,
+                    tx.rateLimitBucket.upsert({
+                        where: { key_window_start: { key, window_start: windowStart } },
+                        update: { count: { increment: 1 } },
+                        create: { key, window_start: windowStart, count: 1 },
+                    }),
                 { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
             );
 
-            const count = Number(rows?.[0]?.count ?? 1);
+            const count = Number(bucket.count ?? 1);
+            if (count === 1) {
+                const cleanupThreshold = new Date(windowStartMs - windowMs * 24);
+                void prisma.rateLimitBucket
+                    .deleteMany({ where: { window_start: { lt: cleanupThreshold } } })
+                    .catch((cleanupError) => {
+                        console.warn(
+                            "[RateLimit] Failed to prune expired rate limit buckets:",
+                            cleanupError
+                        );
+                    });
+            }
             if (count > limit) {
                 return { success: false, retryAfterMs: Math.max(0, windowEndMs - now.getTime()) };
             }


### PR DESCRIPTION
## Summary
- replace the MedDispense walk-in name column with an ID number field and propagate the change through APIs and UI tables
- add a Prisma-managed RateLimitBucket model and update the rate limiter to use Prisma transactions with cleanup
- refresh the Learn More "Modern tools" section with a single-row LogoLoop marquee, outbound links, and hover-scaling highlight cards

## Testing
- npm run lint *(warnings about existing unused parameters in LogoLoop)*

------
https://chatgpt.com/codex/tasks/task_e_690ca5d0232c832791020bf74f8afca1