### PR TITLE
Improve middleware guards and session handling

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { SessionProvider, useSession, signOut } from "next-auth/react";
 import { Toaster, toast } from "sonner";
 
@@ -9,13 +10,20 @@ import { Toaster, toast } from "sonner";
  */
 function SessionWatcher() {
     const { data: session } = useSession();
+    const router = useRouter();
 
     useEffect(() => {
         if (session?.user?.status === "Inactive") {
             toast.error("Your account has been deactivated. Logging out...");
-            signOut({ callbackUrl: "/login" });
+            void signOut({ redirect: false, callbackUrl: "/login?error=inactive" })
+                .then((data) => {
+                    if (data?.url) router.replace(data.url);
+                })
+                .catch(() => {
+                    router.replace("/login?error=inactive");
+                });
         }
-    }, [session]);
+    }, [router, session]);
 
     return null;
 }

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ReactNode, useMemo, useState } from "react";
+import { ReactNode, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
 import { LogOut, Menu, type LucideIcon } from "lucide-react";
 
@@ -60,10 +60,18 @@ export function PanelLayout({
     isNavItemActive,
 }: PanelLayoutProps) {
     const pathname = usePathname();
-    const { data: session } = useSession();
+    const router = useRouter();
+    const hasRedirectedRef = useRef(false);
+    const { data: session, status } = useSession({
+        required: true,
+        onUnauthenticated() {
+            if (hasRedirectedRef.current) return;
+            hasRedirectedRef.current = true;
+            router.replace("/login");
+        },
+    });
     const [isLoggingOut, setIsLoggingOut] = useState(false);
     const [mobileOpen, setMobileOpen] = useState(false);
-
     const fullName = session?.user?.name ?? defaultName;
 
     const avatarFallback = useMemo(() => {
@@ -72,10 +80,25 @@ export function PanelLayout({
         return initials || fallbackInitials;
     }, [fullName, fallbackInitials]);
 
+    if (status === "loading") {
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-linear-to-br from-green-50 via-white to-green-100 p-6" aria-busy>
+                <p className="text-sm font-medium text-muted-foreground">Verifying your session…</p>
+            </div>
+        );
+    }
+
     async function handleLogout() {
         try {
             setIsLoggingOut(true);
-            await signOut({ callbackUrl: "/login?logout=success" });
+            setMobileOpen(false);
+            const data = await signOut({ redirect: false, callbackUrl: "/login?logout=success" });
+            hasRedirectedRef.current = true;
+            if (data?.url) {
+                router.replace(data.url);
+            } else {
+                router.replace("/login?logout=success");
+            }
         } finally {
             setIsLoggingOut(false);
         }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,53 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
-import { AccountStatus } from "@prisma/client";
+
+const PUBLIC_PATH_PREFIXES = new Set([
+    "/login",
+    "/forgot-password",
+    "/reset-password",
+    "/verify-reset",
+    "/api/auth",
+    "/api/contact",
+    "/api/account/email/verify",
+]);
+
+const ROLE_GUARDS = [
+    { prefix: "/nurse", role: "NURSE" },
+    { prefix: "/doctor", role: "DOCTOR" },
+    { prefix: "/scholar", role: "SCHOLAR" },
+    { prefix: "/patient", role: "PATIENT" },
+] as const;
+
+type GuardRole = (typeof ROLE_GUARDS)[number]["role"];
+
+function isPublicPath(pathname: string) {
+    for (const prefix of PUBLIC_PATH_PREFIXES) {
+        if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function createRedirect(req: NextRequest, path: string) {
+    return NextResponse.redirect(new URL(path, req.url));
+}
+
+function guardResponse(req: NextRequest, status: number, message: string, redirectPath: string) {
+    if (req.nextUrl.pathname.startsWith("/api")) {
+        return NextResponse.json({ error: message }, { status });
+    }
+    return createRedirect(req, redirectPath);
+}
+
+function allowRequest() {
+    const response = NextResponse.next();
+    response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate");
+    response.headers.set("Pragma", "no-cache");
+    response.headers.set("Expires", "0");
+    return response;
+}
 
 /**
  * Guards protected routes by validating the session token and role access.
@@ -9,73 +55,33 @@ import { AccountStatus } from "@prisma/client";
 export async function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;
 
-    // Allow all public and auth routes without token
-    const publicPaths = [
-        "/login",
-        "/forgot-password",
-        "/reset-password",
-        "/verify-reset",
-        "/api/auth",
-        "/api/contact",
-        "/api/account/email/verify",
-    ];
-
-    if (publicPaths.some((path) => pathname.startsWith(path))) {
-        return NextResponse.next();
+    if (req.method === "OPTIONS") {
+        return allowRequest();
     }
 
-    // Extract session token
+    if (isPublicPath(pathname)) {
+        return allowRequest();
+    }
+
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
 
-    // No token → redirect to login page
     if (!token) {
-        // For API routes, return 401 JSON instead of redirect
-        if (pathname.startsWith("/api")) {
-            return NextResponse.json(
-                { error: "Unauthorized: no session token" },
-                { status: 401 }
-            );
-        }
-        return NextResponse.redirect(new URL("/login", req.url));
+        return guardResponse(req, 401, "Unauthorized: no session token", "/login");
     }
 
-    // If token exists
-    const role = token.role as string | undefined;
-    const status = token.status as AccountStatus | undefined;
-
-    // Block inactive users
+    const status = typeof token.status === "string" ? token.status : undefined;
     if (status === "Inactive") {
-        if (pathname.startsWith("/api")) {
-            return NextResponse.json(
-                { error: "Account inactive. Contact admin." },
-                { status: 403 }
-            );
-        }
-        return NextResponse.redirect(new URL("/login?error=inactive", req.url));
+        return guardResponse(req, 403, "Account inactive. Contact admin.", "/login?error=inactive");
     }
 
-    // Role-based route guards
-    const roleGuardMap: Record<string, string> = {
-        "/nurse": "NURSE",
-        "/doctor": "DOCTOR",
-        "/scholar": "SCHOLAR",
-        "/patient": "PATIENT",
-    };
-
-    for (const prefix in roleGuardMap) {
-        if (pathname.startsWith(prefix) && role !== roleGuardMap[prefix]) {
-            if (pathname.startsWith("/api")) {
-                return NextResponse.json(
-                    { error: "Unauthorized: insufficient role" },
-                    { status: 403 }
-                );
-            }
-            return NextResponse.redirect(new URL("/login?error=unauthorized", req.url));
+    const role = typeof token.role === "string" ? (token.role.toUpperCase() as GuardRole) : undefined;
+    for (const { prefix, role: requiredRole } of ROLE_GUARDS) {
+        if (pathname.startsWith(prefix) && role !== requiredRole) {
+            return guardResponse(req, 403, "Unauthorized: insufficient role", "/login?error=unauthorized");
         }
     }
 
-    // Allow if all checks pass
-    return NextResponse.next();
+    return allowRequest();
 }
 
 // Apply only to protected routes

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,18 +1,21 @@
 // src/types/next-auth.d.ts
 import { DefaultSession, DefaultUser } from "next-auth";
 import { JWT as DefaultJWT } from "next-auth/jwt";
+import type { AccountStatus, Role } from "@prisma/client";
 
 declare module "next-auth" {
     interface Session {
         user: {
             id: string;
-            role: string;
+            role: Role;
+            status?: AccountStatus;
         } & DefaultSession["user"];
     }
 
     interface User extends DefaultUser {
         id: string;       // add id
-        role: string;     // make required
+        role: Role;       // make required
+        status?: AccountStatus;
         name?: string | null;
     }
 }
@@ -20,6 +23,7 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
     interface JWT extends DefaultJWT {
         id?: string;
-        role?: string;
+        role?: Role;
+        status?: AccountStatus;
     }
 }


### PR DESCRIPTION
## Summary
- refactor the authentication middleware to centralize guard helpers, enforce cache prevention, and keep role/status checks consistent
- gate panel layouts behind an authenticated session with a loading state and controlled logout redirects
- align client session watching and NextAuth typings with status-aware sign-out flows

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e084418c08327ba8f0406e08d3709)