### PR TITLE
Improve login session redirects and middleware guards

### DIFF
--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -90,6 +90,13 @@ export default function LoginPageClient() {
     };
 
     // ---------- LOGIN ----------
+    const roleDestinations = {
+        NURSE: "/nurse",
+        DOCTOR: "/doctor",
+        SCHOLAR: "/scholar",
+        PATIENT: "/patient",
+    } as const;
+
     async function handleLogin(e: React.FormEvent<HTMLFormElement>, role: string) {
         e.preventDefault();
         const formData = new FormData(e.currentTarget);
@@ -106,7 +113,14 @@ export default function LoginPageClient() {
         try {
             setLoadingRole(role);
 
-            const result = await signIn("credentials", { redirect: false, ...payload });
+            const normalizedRole = payload.role as keyof typeof roleDestinations;
+            const defaultDestination = roleDestinations[normalizedRole] ?? "/login";
+
+            const result = await signIn("credentials", {
+                redirect: false,
+                callbackUrl: defaultDestination,
+                ...payload,
+            });
 
             if (result?.error) {
                 const message = result.error.includes("inactive")
@@ -119,23 +133,8 @@ export default function LoginPageClient() {
 
             toast.success("Successful login!", { position: "top-center" });
 
-            // Redirect by role
-            switch (payload.role) {
-                case "NURSE":
-                    router.push("/nurse");
-                    break;
-                case "DOCTOR":
-                    router.push("/doctor");
-                    break;
-                case "SCHOLAR":
-                    router.push("/scholar");
-                    break;
-                case "PATIENT":
-                    router.push("/patient");
-                    break;
-                default:
-                    router.push("/login");
-            }
+            const targetUrl = result?.url ?? defaultDestination;
+            router.replace(targetUrl);
         } catch (error) {
             const message =
                 error instanceof Error ? error.message : "Unexpected error occurred.";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,13 @@ const ROLE_GUARDS = [
 
 type GuardRole = (typeof ROLE_GUARDS)[number]["role"];
 
+const ROLE_HOME: Record<GuardRole, string> = {
+    NURSE: "/nurse",
+    DOCTOR: "/doctor",
+    SCHOLAR: "/scholar",
+    PATIENT: "/patient",
+};
+
 function isPublicPath(pathname: string) {
     for (const prefix of PUBLIC_PATH_PREFIXES) {
         if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
@@ -49,6 +56,12 @@ function allowRequest() {
     return response;
 }
 
+function resolveRoleHome(role: unknown) {
+    if (typeof role !== "string") return null;
+    const normalized = role.toUpperCase() as GuardRole;
+    return ROLE_HOME[normalized] ?? null;
+}
+
 /**
  * Guards protected routes by validating the session token and role access.
  */
@@ -59,11 +72,17 @@ export async function middleware(req: NextRequest) {
         return allowRequest();
     }
 
+    const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+
     if (isPublicPath(pathname)) {
+        if (pathname.startsWith("/login")) {
+            const redirectPath = resolveRoleHome(token?.role);
+            if (redirectPath) {
+                return createRedirect(req, redirectPath);
+            }
+        }
         return allowRequest();
     }
-
-    const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
 
     if (!token) {
         return guardResponse(req, 401, "Unauthorized: no session token", "/login");
@@ -92,5 +111,6 @@ export const config = {
         "/scholar/:path*",
         "/patient/:path*",
         "/api/:path*", // secure API routes too
+        "/login",
     ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,9 +73,14 @@ export async function middleware(req: NextRequest) {
     }
 
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+    const status = typeof token?.status === "string" ? token.status : undefined;
 
     if (isPublicPath(pathname)) {
         if (pathname.startsWith("/login")) {
+            if (status === "Inactive") {
+                return allowRequest();
+            }
+
             const redirectPath = resolveRoleHome(token?.role);
             if (redirectPath) {
                 return createRedirect(req, redirectPath);
@@ -88,7 +93,6 @@ export async function middleware(req: NextRequest) {
         return guardResponse(req, 401, "Unauthorized: no session token", "/login");
     }
 
-    const status = typeof token.status === "string" ? token.status : undefined;
     if (status === "Inactive") {
         return guardResponse(req, 403, "Account inactive. Contact admin.", "/login?error=inactive");
     }


### PR DESCRIPTION
## Summary
- redirect authenticated users away from the login route based on their role
- align login flow with NextAuth callback URLs to keep session state and history clean

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0f35ce3c8327bfd81b2d94a2f15b)