### PR TITLE
Add slide-in mobile menu for site header

### DIFF
--- a/src/components/marketing/site-header.tsx
+++ b/src/components/marketing/site-header.tsx
@@ -32,6 +32,22 @@ export function SiteHeader({ navigation }: { navigation: SiteHeaderNavItem[] }) 
     }, [pathname]);
 
     useEffect(() => {
+        if (typeof document === "undefined") {
+            return;
+        }
+
+        if (menuOpen) {
+            const previousOverflow = document.body.style.overflow;
+            document.body.style.overflow = "hidden";
+            return () => {
+                document.body.style.overflow = previousOverflow;
+            };
+        }
+
+        document.body.style.removeProperty("overflow");
+    }, [menuOpen]);
+
+    useEffect(() => {
         if (typeof window === "undefined") {
             return;
         }
@@ -157,7 +173,7 @@ export function SiteHeader({ navigation }: { navigation: SiteHeaderNavItem[] }) 
 
             <div
                 className={cn(
-                    "pointer-events-none fixed inset-0 z-40 bg-slate-900/40 opacity-0 transition-opacity duration-300 md:hidden",
+                    "pointer-events-none fixed inset-0 z-40 bg-slate-950/20 backdrop-blur-sm opacity-0 transition-opacity duration-300 md:hidden",
                     menuOpen && "pointer-events-auto opacity-100",
                 )}
                 aria-hidden={menuOpen ? undefined : true}
@@ -165,44 +181,89 @@ export function SiteHeader({ navigation }: { navigation: SiteHeaderNavItem[] }) 
             />
             <div
                 className={cn(
-                    "fixed inset-y-0 right-0 z-50 w-80 max-w-sm translate-x-full border-l border-green-100/80 bg-white/95 shadow-xl transition-transform duration-300 md:hidden",
+                    "fixed inset-y-0 right-0 z-50 w-full max-w-xs translate-x-full border-l border-green-100/80 bg-white/95 shadow-[0_10px_50px_rgba(15,118,110,0.28)] transition-transform duration-300 ease-out md:hidden",
                     menuOpen && "translate-x-0",
                 )}
                 aria-hidden={menuOpen ? undefined : true}
                 role="dialog"
                 aria-modal={menuOpen ? true : undefined}
-                aria-label="Mobile navigation"
+                aria-labelledby="mobile-nav-heading"
             >
-                <div className="flex h-full flex-col gap-4 overflow-y-auto px-6 py-8">
-                    <div className="flex flex-col gap-2">
-                        {navigation.map((item) => {
-                            const active = isItemActive(item.href) || isHashActive(item.href);
-
-                            return (
-                                <Link
-                                    key={item.label}
-                                    href={item.href}
-                                    className={cn(
-                                        "rounded-xl border px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
-                                        active
-                                            ? "border-green-200 bg-green-600 text-white shadow-sm"
-                                            : "border-green-100/80 bg-white/70 text-slate-700 hover:border-green-200 hover:bg-green-50 hover:text-green-700",
-                                    )}
-                                    onClick={() => {
-                                        handleNavClick(item.href);
-                                        closeMenu();
-                                    }}
-                                >
-                                    {item.label}
-                                </Link>
-                            );
-                        })}
+                <div className="flex h-full flex-col overflow-hidden">
+                    <div className="flex items-center justify-between border-b border-green-100/80 px-6 py-4">
+                        <div className="flex items-center gap-3">
+                            <span className="relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-green-100/70 bg-white shadow-sm">
+                                <Image
+                                    src="/clinic-illustration.svg"
+                                    alt="HNU Clinic icon"
+                                    width={40}
+                                    height={40}
+                                    className="h-8 w-8 object-contain"
+                                />
+                            </span>
+                            <div className="leading-tight">
+                                <p id="mobile-nav-heading" className="text-sm font-semibold text-green-700">
+                                    HNU Clinic Navigation
+                                </p>
+                                <p className="text-xs text-slate-500">Quick links to explore the platform</p>
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            className="rounded-lg p-1.5 text-slate-500 transition hover:bg-green-50 hover:text-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                            onClick={closeMenu}
+                            aria-label="Close menu"
+                        >
+                            <XIcon className="h-5 w-5" />
+                        </button>
                     </div>
-                    <Link href="/login" onClick={closeMenu}>
-                        <Button className="mt-auto w-full rounded-full bg-green-600 py-2 text-sm font-semibold hover:bg-green-700">
-                            Login
-                        </Button>
-                    </Link>
+                    <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-6">
+                        <nav className="flex flex-col gap-2">
+                            {navigation.map((item) => {
+                                const active = isItemActive(item.href) || isHashActive(item.href);
+
+                                return (
+                                    <Link
+                                        key={item.label}
+                                        href={item.href}
+                                        className={cn(
+                                            "group relative overflow-hidden rounded-2xl border px-4 py-3 text-sm font-semibold transition-all duration-200",
+                                            active
+                                                ? "border-transparent bg-gradient-to-r from-green-600 via-emerald-500 to-teal-500 text-white shadow-[0_14px_35px_rgba(16,185,129,0.25)]"
+                                                : "border-green-100/80 bg-white/90 text-slate-700 hover:border-green-200 hover:bg-green-50/60 hover:text-green-700",
+                                        )}
+                                        onClick={() => {
+                                            handleNavClick(item.href);
+                                            closeMenu();
+                                        }}
+                                    >
+                                        <span className="relative z-10 flex items-center justify-between gap-4">
+                                            {item.label}
+                                            <span
+                                                className={cn(
+                                                    "text-xs font-medium transition-opacity",
+                                                    active ? "opacity-100" : "opacity-60",
+                                                )}
+                                            >
+                                                {active ? "Currently viewing" : "Tap to visit"}
+                                            </span>
+                                        </span>
+                                    </Link>
+                                );
+                            })}
+                        </nav>
+                        <div className="rounded-2xl border border-green-100/70 bg-green-50/80 p-4 text-sm text-slate-600">
+                            <p className="font-semibold text-green-700">Need to manage your visits?</p>
+                            <p className="mt-1 text-xs text-slate-500">
+                                Sign in to access health records, appointments, and secure messaging with the HNU Clinic team.
+                            </p>
+                            <Link href="/login" onClick={closeMenu} className="mt-4 inline-flex w-full">
+                                <Button className="w-full rounded-full bg-green-600 py-2 text-sm font-semibold hover:bg-green-700">
+                                    Login to Dashboard
+                                </Button>
+                            </Link>
+                        </div>
+                    </div>
                 </div>
             </div>
         </header>

--- a/src/components/marketing/site-header.tsx
+++ b/src/components/marketing/site-header.tsx
@@ -155,41 +155,56 @@ export function SiteHeader({ navigation }: { navigation: SiteHeaderNavItem[] }) 
                 </button>
             </div>
 
-            {menuOpen ? (
-                <div className="border-t border-green-100/80 bg-white/95 shadow-inner md:hidden">
-                    <div className="mx-auto flex max-w-7xl flex-col gap-2 px-4 py-5 sm:px-6 lg:px-8">
-                        <div className="flex flex-col gap-2">
-                            {navigation.map((item) => {
-                                const active = isItemActive(item.href) || isHashActive(item.href);
+            <div
+                className={cn(
+                    "pointer-events-none fixed inset-0 z-40 bg-slate-900/40 opacity-0 transition-opacity duration-300 md:hidden",
+                    menuOpen && "pointer-events-auto opacity-100",
+                )}
+                aria-hidden={menuOpen ? undefined : true}
+                onClick={closeMenu}
+            />
+            <div
+                className={cn(
+                    "fixed inset-y-0 right-0 z-50 w-80 max-w-sm translate-x-full border-l border-green-100/80 bg-white/95 shadow-xl transition-transform duration-300 md:hidden",
+                    menuOpen && "translate-x-0",
+                )}
+                aria-hidden={menuOpen ? undefined : true}
+                role="dialog"
+                aria-modal={menuOpen ? true : undefined}
+                aria-label="Mobile navigation"
+            >
+                <div className="flex h-full flex-col gap-4 overflow-y-auto px-6 py-8">
+                    <div className="flex flex-col gap-2">
+                        {navigation.map((item) => {
+                            const active = isItemActive(item.href) || isHashActive(item.href);
 
-                                return (
-                                    <Link
-                                        key={item.label}
-                                        href={item.href}
-                                        className={cn(
-                                            "rounded-xl border px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
-                                            active
-                                                ? "border-green-200 bg-green-600 text-white shadow-sm"
-                                                : "border-green-100/80 bg-white/70 text-slate-700 hover:border-green-200 hover:bg-green-50 hover:text-green-700",
-                                        )}
-                                        onClick={() => {
-                                            handleNavClick(item.href);
-                                            closeMenu();
-                                        }}
-                                    >
-                                        {item.label}
-                                    </Link>
-                                );
-                            })}
-                        </div>
-                        <Link href="/login" onClick={closeMenu}>
-                            <Button className="mt-2 w-full rounded-full bg-green-600 py-2 text-sm font-semibold hover:bg-green-700">
-                                Login
-                            </Button>
-                        </Link>
+                            return (
+                                <Link
+                                    key={item.label}
+                                    href={item.href}
+                                    className={cn(
+                                        "rounded-xl border px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
+                                        active
+                                            ? "border-green-200 bg-green-600 text-white shadow-sm"
+                                            : "border-green-100/80 bg-white/70 text-slate-700 hover:border-green-200 hover:bg-green-50 hover:text-green-700",
+                                    )}
+                                    onClick={() => {
+                                        handleNavClick(item.href);
+                                        closeMenu();
+                                    }}
+                                >
+                                    {item.label}
+                                </Link>
+                            );
+                        })}
                     </div>
+                    <Link href="/login" onClick={closeMenu}>
+                        <Button className="mt-auto w-full rounded-full bg-green-600 py-2 text-sm font-semibold hover:bg-green-700">
+                            Login
+                        </Button>
+                    </Link>
                 </div>
-            ) : null}
+            </div>
         </header>
     );
 }


### PR DESCRIPTION
## Summary
- replace the mobile site header dropdown with a slide-in panel that opens from the right
- add an overlay backdrop and dialog metadata for the mobile navigation experience

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eeae94660832783add1cc8af996ee)