### PR TITLE
refactor: unify account refresh button UI

### DIFF
--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card } from "@/components/ui/card";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
@@ -706,21 +707,11 @@ export default function DoctorAccountPage() {
                                 </AccountSection>
 
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
+                                    <AccountRefreshButton
                                         onClick={() => void handleManualRefresh()}
                                         disabled={refreshing || profileLoading}
-                                    >
-                                        {refreshing ? (
-                                            <>
-                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
-                                            </>
-                                        ) : (
-                                            "Refresh profile"
-                                        )}
-                                    </Button>
+                                        isRefreshing={refreshing}
+                                    />
                                     <Button
                                         type="submit"
                                         className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -60,6 +60,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
@@ -988,21 +989,11 @@ export function NurseAccountsPageClient({
                                 </AccountSection>
 
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
+                                    <AccountRefreshButton
                                         onClick={() => void handleRefreshProfile()}
                                         disabled={profileLoading || refreshingProfile}
-                                    >
-                                        {refreshingProfile ? (
-                                            <>
-                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
-                                            </>
-                                        ) : (
-                                            "Refresh profile"
-                                        )}
-                                    </Button>
+                                        isRefreshing={refreshingProfile}
+                                    />
                                     <Button
                                         type="submit"
                                         className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useTransition } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { toast } from "sonner";
 import {
     Loader2,
@@ -137,7 +137,7 @@ export function PatientAccountPageClient({
 
     const [tempDOB, setTempDOB] = useState("");
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
-    const [isRefreshingProfile, startProfileTransition] = useTransition();
+    const [refreshingProfile, setRefreshingProfile] = useState(false);
 
     useEffect(() => {
         if (initialProfileLoaded) {
@@ -164,8 +164,11 @@ export function PatientAccountPageClient({
         }
     };
 
-    const loadProfile = useCallback(async () => {
+    const loadProfile = useCallback(async ({ fromRefresh = false } = {}) => {
         try {
+            if (fromRefresh) {
+                setRefreshingProfile(true);
+            }
             setProfileLoading(true);
             const res = await fetch("/api/patient/account/me", { cache: "no-store" });
             const data = await res.json();
@@ -182,20 +185,21 @@ export function PatientAccountPageClient({
             }
 
             const normalized = normalizePatientAccountProfile(data as PatientAccountProfileApi);
-            startProfileTransition(() => {
-                const nextType =
-                    normalized.type === "student" || normalized.type === "employee" ? normalized.type : null;
-                setProfile(normalized.profile);
-                setProfileType(nextType);
-                setProfileLoaded(Boolean(normalized.profile));
-            });
+            const nextType =
+                normalized.type === "student" || normalized.type === "employee" ? normalized.type : null;
+            setProfile(normalized.profile);
+            setProfileType(nextType);
+            setProfileLoaded(Boolean(normalized.profile));
         } catch {
             toast.error("Failed to load profile");
         } finally {
             setProfileLoading(false);
             setInitializing(false);
+            if (fromRefresh) {
+                setRefreshingProfile(false);
+            }
         }
-    }, [startProfileTransition]);
+    }, []);
 
     useEffect(() => {
         if (!profileLoaded) {
@@ -203,7 +207,7 @@ export function PatientAccountPageClient({
         }
     }, [profileLoaded, loadProfile]);
 
-    const layoutTitle = profileLoading || isRefreshingProfile
+    const layoutTitle = profileLoading || refreshingProfile
         ? "Loading profile"
         : profileType === "employee"
           ? "Employee profile"
@@ -211,7 +215,7 @@ export function PatientAccountPageClient({
             ? "Student profile"
             : "Account overview";
 
-    const layoutDescription = profileLoading || isRefreshingProfile
+    const layoutDescription = profileLoading || refreshingProfile
         ? "Please wait while we retrieve your account data."
         : "Review and update your personal, academic, and emergency contact information to keep the clinic prepared.";
 
@@ -882,13 +886,9 @@ export function PatientAccountPageClient({
 
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
                                     <AccountRefreshButton
-                                        onClick={() => {
-                                            startProfileTransition(() => {
-                                                void loadProfile();
-                                            });
-                                        }}
-                                        disabled={profileLoading || isRefreshingProfile}
-                                        isRefreshing={isRefreshingProfile}
+                                        onClick={() => void loadProfile({ fromRefresh: true })}
+                                        disabled={profileLoading || refreshingProfile}
+                                        isRefreshing={refreshingProfile}
                                     />
                                     <Button
                                         type="submit"

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -40,6 +40,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
@@ -880,25 +881,15 @@ export function PatientAccountPageClient({
                                 </AccountSection>
 
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
+                                    <AccountRefreshButton
                                         onClick={() => {
                                             startProfileTransition(() => {
                                                 void loadProfile();
                                             });
                                         }}
                                         disabled={profileLoading || isRefreshingProfile}
-                                    >
-                                        {isRefreshingProfile ? (
-                                            <>
-                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
-                                            </>
-                                        ) : (
-                                            "Refresh profile"
-                                        )}
-                                    </Button>
+                                        isRefreshing={isRefreshingProfile}
+                                    />
                                     <Button
                                         type="submit"
                                         className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -129,6 +129,7 @@ export function PatientAccountPageClient({
             : null;
     const [profile, setProfile] = useState<PatientAccountProfile | null>(initialProfile);
     const [profileLoading, setProfileLoading] = useState(false);
+    const [hydratingProfile, setHydratingProfile] = useState(false);
 
     const [initializing, setInitializing] = useState(!initialProfileLoaded);
 
@@ -169,7 +170,7 @@ export function PatientAccountPageClient({
             if (fromRefresh) {
                 setRefreshingProfile(true);
             }
-            setProfileLoading(true);
+            setHydratingProfile(true);
             const res = await fetch("/api/patient/account/me", { cache: "no-store" });
             const data = await res.json();
             if (!res.ok) {
@@ -193,7 +194,7 @@ export function PatientAccountPageClient({
         } catch {
             toast.error("Failed to load profile");
         } finally {
-            setProfileLoading(false);
+            setHydratingProfile(false);
             setInitializing(false);
             if (fromRefresh) {
                 setRefreshingProfile(false);
@@ -207,7 +208,7 @@ export function PatientAccountPageClient({
         }
     }, [profileLoaded, loadProfile]);
 
-    const layoutTitle = profileLoading || refreshingProfile
+    const layoutTitle = hydratingProfile
         ? "Loading profile"
         : profileType === "employee"
           ? "Employee profile"
@@ -215,7 +216,7 @@ export function PatientAccountPageClient({
             ? "Student profile"
             : "Account overview";
 
-    const layoutDescription = profileLoading || refreshingProfile
+    const layoutDescription = hydratingProfile
         ? "Please wait while we retrieve your account data."
         : "Review and update your personal, academic, and emergency contact information to keep the clinic prepared.";
 
@@ -443,7 +444,7 @@ export function PatientAccountPageClient({
             }
         >
             <div className="mx-auto w-full max-w-5xl space-y-8">
-                {profileLoading ? (
+                {hydratingProfile ? (
                     <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-8 text-center shadow-sm backdrop-blur">
                         <div className="flex flex-col items-center gap-3 text-emerald-700">
                             <Loader2 className="h-6 w-6 animate-spin" />
@@ -452,7 +453,7 @@ export function PatientAccountPageClient({
                     </Card>
                 ) : null}
 
-                {!profileLoading && !profile ? (
+                {!hydratingProfile && !profile ? (
                     <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-8 text-center shadow-sm backdrop-blur">
                         <p className="text-sm text-muted-foreground">
                             We couldn&apos;t load your account information right now. Please refresh or contact the clinic team.
@@ -887,7 +888,7 @@ export function PatientAccountPageClient({
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
                                     <AccountRefreshButton
                                         onClick={() => void loadProfile({ fromRefresh: true })}
-                                        disabled={profileLoading || refreshingProfile}
+                                        disabled={hydratingProfile || profileLoading}
                                         isRefreshing={refreshingProfile}
                                     />
                                     <Button

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -17,6 +17,7 @@ import {
 
 import ScholarLayout from "@/components/scholar/scholar-layout";
 import { AccountCard } from "@/components/account/account-card";
+import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
@@ -910,21 +911,11 @@ export default function ScholarAccountPage() {
                                 </AccountSection>
 
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
+                                    <AccountRefreshButton
                                         onClick={() => void loadProfile()}
                                         disabled={profileLoading || updating || dobSaving}
-                                    >
-                                        {profileLoading ? (
-                                            <>
-                                                <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
-                                            </>
-                                        ) : (
-                                            "Refresh profile"
-                                        )}
-                                    </Button>
+                                        isRefreshing={profileLoading}
+                                    />
                                     <Button
                                         type="submit"
                                         className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"

--- a/src/components/account/account-refresh-button.tsx
+++ b/src/components/account/account-refresh-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type AccountRefreshButtonProps = {
+    onClick: () => void;
+    disabled?: boolean;
+    isRefreshing?: boolean;
+};
+
+export function AccountRefreshButton({
+    onClick,
+    disabled = false,
+    isRefreshing = false,
+}: AccountRefreshButtonProps) {
+    return (
+        <Button
+            type="button"
+            variant="outline"
+            className="flex items-center justify-center gap-2 rounded-2xl border-green-200 bg-white/95 px-5 py-2 text-sm font-semibold text-green-700 shadow-sm transition hover:bg-green-50 disabled:opacity-60"
+            onClick={onClick}
+            disabled={disabled}
+        >
+            {isRefreshing ? (
+                <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Refreshing…
+                </>
+            ) : (
+                "Refresh profile"
+            )}
+        </Button>
+    );
+}
+
+export default AccountRefreshButton;


### PR DESCRIPTION
## Summary
- add a shared AccountRefreshButton component that encapsulates the doctor profile refresh styling
- update doctor, nurse, patient, and scholar account pages to render the unified refresh control

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691343a1ed54832797f5be1d51fc5956)