### PR TITLE
Add structured medical history management

### DIFF
--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -12,6 +12,12 @@ import {
   Role,
 } from "@prisma/client";
 import { formatManilaDateTime, manilaNow } from "@/lib/time";
+import {
+  MEDICAL_HISTORY_OPTIONS,
+  hasMedicalCondition,
+  parseMedicalHistory,
+  type MedicalHistoryValue,
+} from "@/lib/medical-history";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -111,6 +117,7 @@ type CertificateContext = {
   findings: string;
   reason: string;
   allergies: string[];
+  medicalHistory: MedicalHistoryValue;
   doctorName: string;
   doctorTitle: string;
   licenseNumber: string;
@@ -148,29 +155,18 @@ function renderCertificateHtml(context: CertificateContext) {
       context.patientName
     )}</strong>, a student of Holy Name University, was examined at the Holy Name University College Clinic.`;
 
-  const medicalHistoryOptions = [
-    "Asthma",
-    "Hypertension",
-    "Cancer",
-    "Epilepsy",
-    "Diabetes",
-    "Heart Disease",
-    "Kidney Disease",
-    "Nervous/Mental Disorder",
-  ];
-
-  const renderCheckbox = (label: string) => `
-        <div class="checkbox">
+  const renderCheckbox = (label: string, checked: boolean) => `
+        <div class="checkbox${checked ? " checked" : ""}">
           <span class="box" aria-hidden="true"></span>
           <span class="text">${escapeHtml(label)}</span>
         </div>
     `;
 
-  const medicalHistoryBoxes = medicalHistoryOptions
-    .map((option) => renderCheckbox(option))
-    .join("");
+  const medicalHistoryBoxes = MEDICAL_HISTORY_OPTIONS.map((option) =>
+    renderCheckbox(option, hasMedicalCondition(context.medicalHistory, option))
+  ).join("");
 
-  const remainingMedical = "";
+  const remainingMedical = context.medicalHistory.other?.trim() ?? "";
 
   const allergiesList = context.allergies
     .map((value) => titleCase(value))
@@ -364,6 +360,24 @@ function renderCertificateHtml(context: CertificateContext) {
         display: inline-block;
         margin-top: 1px;
         flex-shrink: 0;
+        position: relative;
+      }
+
+      .checkbox.checked .box {
+        background: #047857;
+        border-color: #047857;
+      }
+
+      .checkbox.checked .box::after {
+        content: "";
+        position: absolute;
+        top: 1px;
+        left: 3px;
+        width: 3px;
+        height: 6px;
+        border: solid #ffffff;
+        border-width: 0 1px 1px 0;
+        transform: rotate(45deg);
       }
 
       .statement {
@@ -784,6 +798,7 @@ export async function GET(
         },
       });
 
+    const medicalHistory = parseMedicalHistory(studentProfile.medical_cond);
     const age = computeAge(studentProfile.date_of_birth, now);
     const sex = studentProfile.gender ? titleCase(studentProfile.gender) : "";
     const program = titleCase(studentProfile.program);
@@ -837,6 +852,7 @@ export async function GET(
       findings: appointment.consultation.findings ?? "",
       reason: appointment.consultation.reason_of_visit ?? "",
       allergies,
+      medicalHistory,
       doctorName,
       doctorTitle,
       licenseNumber: "",

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -23,9 +23,15 @@ import { Card } from "@/components/ui/card";
 import { AccountCard } from "@/components/account/account-card";
 import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
+import { MedicalHistoryField } from "@/components/account/medical-history-field";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
+import {
+    parseMedicalHistory,
+    serializeMedicalHistory,
+    type MedicalHistoryValue,
+} from "@/lib/medical-history";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 
@@ -65,7 +71,7 @@ type Profile = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medicalHistory: MedicalHistoryValue;
     emergencyco_name?: string | null;
     emergencyco_num?: string | null;
     emergencyco_relation?: string | null;
@@ -141,7 +147,7 @@ export default function DoctorAccountPage() {
                 address: data.profile?.address || "",
                 bloodtype: bloodTypeValue,
                 allergies: data.profile?.allergies || "",
-                medical_cond: data.profile?.medical_cond || "",
+                medicalHistory: parseMedicalHistory(data.profile?.medical_cond || ""),
                 emergencyco_name: data.profile?.emergencyco_name || "",
                 emergencyco_num: data.profile?.emergencyco_num || "",
                 emergencyco_relation: data.profile?.emergencyco_relation || "",
@@ -190,8 +196,10 @@ export default function DoctorAccountPage() {
 
         try {
             setProfileLoading(true);
+            const { medicalHistory, ...restProfile } = updatedProfile;
             const payload = {
-                ...updatedProfile,
+                ...restProfile,
+                medical_cond: serializeMedicalHistory(medicalHistory),
                 bloodtype: reverseBloodTypeEnumMap[updatedProfile.bloodtype || ""] || null,
             };
 
@@ -637,7 +645,7 @@ export default function DoctorAccountPage() {
 
                                 <AccountSection
                                     icon={HeartPulse}
-                                    title="Medical background"
+                                    title="Medical history"
                                     description="Supports faster care during clinical operations."
                                 >
                                     <div className="grid gap-4 md:grid-cols-2">
@@ -668,10 +676,13 @@ export default function DoctorAccountPage() {
                                         </div>
                                     </div>
                                     <div className="space-y-2">
-                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
-                                        <Input
-                                            value={profile.medical_cond || ""}
-                                            onChange={(e) => setProfile({ ...profile, medical_cond: e.target.value })}
+                                        <Label className="text-sm font-medium text-emerald-900">
+                                            Medical conditions
+                                        </Label>
+                                        <MedicalHistoryField
+                                            value={profile.medicalHistory}
+                                            onChange={(value) => setProfile({ ...profile, medicalHistory: value })}
+                                            idPrefix="doctor-medical-history"
                                         />
                                     </div>
                                 </AccountSection>

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -30,6 +30,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { formatManilaDateTime } from "@/lib/time";
 import { BLOOD_TYPES } from "@/lib/patient-records-update";
+import { formatMedicalHistory, parseMedicalHistory } from "@/lib/medical-history";
 
 import DoctorPatientsLoading from "./loading";
 
@@ -207,6 +208,10 @@ export default function DoctorPatientsPage() {
     const [detailOpen, setDetailOpen] = useState(false);
     const [selectedRecord, setSelectedRecord] = useState<PatientRecord | null>(null);
     const [activeTab, setActiveTab] = useState<"details" | "update" | "notes">("details");
+
+    const selectedMedicalHistoryText = selectedRecord
+        ? formatMedicalHistory(parseMedicalHistory(selectedRecord.medical_cond))
+        : "";
 
     const loadRecords = useCallback(async () => {
         try {
@@ -643,7 +648,7 @@ export default function DoctorPatientsPage() {
                                                 <strong>Allergies:</strong> {selectedRecord.allergies || "—"}
                                             </p>
                                             <p>
-                                                <strong>Medical Conditions:</strong> {selectedRecord.medical_cond || "—"}
+                                                <strong>Medical Conditions:</strong> {selectedMedicalHistoryText || "—"}
                                             </p>
                                             <p>
                                                 <strong>Emergency:</strong> {selectedRecord.emergency?.name || "—"} (

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -62,6 +62,7 @@ import {
 import { AccountCard } from "@/components/account/account-card";
 import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
+import { MedicalHistoryField } from "@/components/account/medical-history-field";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
@@ -74,6 +75,7 @@ import {
     normalizeNurseAccountProfile,
     normalizeNurseAccountUsers,
     nurseReverseBloodTypeEnumMap,
+    serializeNurseMedicalHistory,
     type NurseAccountProfile,
     type NurseAccountProfileApi,
     type NurseAccountUser,
@@ -520,8 +522,10 @@ export function NurseAccountsPageClient({
         try {
             setProfileLoading(true);
 
+            const { medicalHistory, ...restProfile } = updatedProfile;
             const payload = {
-                ...updatedProfile,
+                ...restProfile,
+                medical_cond: serializeNurseMedicalHistory(medicalHistory),
                 bloodtype: nurseReverseBloodTypeEnumMap[updatedProfile?.bloodtype || ""] || null,
             };
 
@@ -919,7 +923,7 @@ export function NurseAccountsPageClient({
 
                                 <AccountSection
                                     icon={HeartPulse}
-                                    title="Medical background"
+                                    title="Medical history"
                                     description="Supports emergency preparedness."
                                 >
                                     <div className="grid gap-4 md:grid-cols-2">
@@ -950,10 +954,13 @@ export function NurseAccountsPageClient({
                                         </div>
                                     </div>
                                     <div className="space-y-2">
-                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
-                                        <Input
-                                            value={profile.medical_cond || ""}
-                                            onChange={(event) => setProfile({ ...profile, medical_cond: event.target.value })}
+                                        <Label className="text-sm font-medium text-emerald-900">
+                                            Medical conditions
+                                        </Label>
+                                        <MedicalHistoryField
+                                            value={profile.medicalHistory}
+                                            onChange={(value) => setProfile({ ...profile, medicalHistory: value })}
+                                            idPrefix="nurse-medical-history"
                                         />
                                     </div>
                                 </AccountSection>

--- a/src/app/nurse/accounts/types.ts
+++ b/src/app/nurse/accounts/types.ts
@@ -1,5 +1,11 @@
 import orderBy from "lodash/orderBy";
 
+import {
+    parseMedicalHistory,
+    serializeMedicalHistory,
+    type MedicalHistoryValue,
+} from "@/lib/medical-history";
+
 export type NurseAccountsUserApi = {
     user_id?: string;
     accountId?: string;
@@ -61,7 +67,7 @@ export type NurseAccountProfile = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medicalHistory: MedicalHistoryValue;
     emergencyco_name?: string | null;
     emergencyco_num?: string | null;
     emergencyco_relation?: string | null;
@@ -154,9 +160,15 @@ export function normalizeNurseAccountProfile(
         address: response.profile?.address || "",
         bloodtype: bloodTypeValue,
         allergies: response.profile?.allergies || "",
-        medical_cond: response.profile?.medical_cond || "",
+        medicalHistory: parseMedicalHistory(response.profile?.medical_cond || ""),
         emergencyco_name: response.profile?.emergencyco_name || "",
         emergencyco_num: response.profile?.emergencyco_num || "",
         emergencyco_relation: response.profile?.emergencyco_relation || "",
     };
+}
+
+export function serializeNurseMedicalHistory(
+    value: MedicalHistoryValue
+): string | null {
+    return serializeMedicalHistory(value);
 }

--- a/src/app/nurse/records/patient-record-dialog.tsx
+++ b/src/app/nurse/records/patient-record-dialog.tsx
@@ -13,6 +13,7 @@ import {
     formatStaffName,
     formatYearLevel,
 } from "@/lib/patient-format";
+import { formatMedicalHistory, parseMedicalHistory } from "@/lib/medical-history";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -49,6 +50,7 @@ function RecordDetailsDialogComponent({
 }: RecordDetailsDialogProps) {
     if (!record) return null;
 
+    const medicalHistoryText = formatMedicalHistory(parseMedicalHistory(record.medical_cond));
     const isUpdating = updatingPatientId === record.id;
     const isSavingNotes = savingNotesPatientId === record.id;
     const hasAppointment = Boolean(record.latestAppointment?.id);
@@ -121,7 +123,7 @@ function RecordDetailsDialogComponent({
                                     <strong>Allergies:</strong> {record.allergies || "—"}
                                 </p>
                                 <p>
-                                    <strong>Medical Conditions:</strong> {record.medical_cond || "—"}
+                                    <strong>Medical Conditions:</strong> {medicalHistoryText || "—"}
                                 </p>
                                 <p>
                                     <strong>Emergency:</strong> {record.emergency?.name || "—"} ({

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -42,6 +42,7 @@ import {
 import { AccountCard } from "@/components/account/account-card";
 import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
+import { MedicalHistoryField } from "@/components/account/medical-history-field";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
@@ -57,6 +58,7 @@ import {
     patientReverseDepartmentEnumMap,
     patientReverseYearLevelEnumMap,
     patientYearLevelEnumMap,
+    serializePatientMedicalHistory,
     type PatientAccountProfile,
     type PatientAccountProfileApi,
 } from "./types";
@@ -229,7 +231,8 @@ export function PatientAccountPageClient({
               profile.address,
               profile.bloodtype,
               profile.allergies,
-              profile.medical_cond,
+              profile.medicalHistory.conditions.length > 0 ||
+                  (profile.medicalHistory.other?.trim() ?? ""),
               profile.emergencyco_name,
               profile.emergencyco_num,
               profile.emergencyco_relation,
@@ -324,8 +327,10 @@ export function PatientAccountPageClient({
 
         try {
             setProfileLoading(true);
+            const { medicalHistory, ...restProfile } = updatedProfile;
             const payload = {
-                ...updatedProfile,
+                ...restProfile,
+                medical_cond: serializePatientMedicalHistory(medicalHistory),
                 department:
                     profileType === "student"
                         ? patientReverseDepartmentEnumMap[updatedProfile.department || ""] || null
@@ -814,7 +819,7 @@ export function PatientAccountPageClient({
 
                                 <AccountSection
                                     icon={HeartPulse}
-                                    title="Medical background"
+                                    title="Medical history"
                                     description="Supports faster care during clinic visits."
                                 >
                                     <div className="grid gap-4 md:grid-cols-2">
@@ -845,10 +850,15 @@ export function PatientAccountPageClient({
                                         </div>
                                     </div>
                                     <div className="space-y-2">
-                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
-                                        <Input
-                                            value={profile.medical_cond || ""}
-                                            onChange={(e) => setProfile({ ...profile, medical_cond: e.target.value })}
+                                        <Label className="text-sm font-medium text-emerald-900">
+                                            Medical conditions
+                                        </Label>
+                                        <MedicalHistoryField
+                                            value={profile.medicalHistory}
+                                            onChange={(value) =>
+                                                setProfile({ ...profile, medicalHistory: value })
+                                            }
+                                            idPrefix="patient-medical-history"
                                         />
                                     </div>
                                 </AccountSection>

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -1,3 +1,9 @@
+import {
+    parseMedicalHistory,
+    serializeMedicalHistory,
+    type MedicalHistoryValue,
+} from "@/lib/medical-history";
+
 export type PatientAccountProfileApi = {
     accountId?: string;
     username?: string;
@@ -86,7 +92,7 @@ export type PatientAccountProfile = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medicalHistory: MedicalHistoryValue;
     gender?: string | null;
     department?: string | null;
     program?: string | null;
@@ -123,7 +129,7 @@ export function normalizePatientAccountProfile(
         address: raw.address || "",
         bloodtype: raw.bloodtype ? patientBloodTypeEnumMap[raw.bloodtype] || raw.bloodtype : "",
         allergies: raw.allergies || "",
-        medical_cond: raw.medical_cond || "",
+        medicalHistory: parseMedicalHistory(raw.medical_cond || ""),
         gender: raw.gender || "",
         department: raw.department ? patientDepartmentEnumMap[raw.department] || "" : "",
         program: raw.program || "",
@@ -137,4 +143,10 @@ export function normalizePatientAccountProfile(
         profile,
         type: response.patientType ?? response.type ?? null,
     };
+}
+
+export function serializePatientMedicalHistory(
+    value: MedicalHistoryValue
+): string | null {
+    return serializeMedicalHistory(value);
 }

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -20,6 +20,7 @@ import { AccountCard } from "@/components/account/account-card";
 import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
+import { MedicalHistoryField } from "@/components/account/medical-history-field";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
 import { Button } from "@/components/ui/button";
@@ -43,6 +44,11 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    parseMedicalHistory,
+    serializeMedicalHistory,
+    type MedicalHistoryValue,
+} from "@/lib/medical-history";
 import { validateAndNormalizeContacts } from "@/lib/validation";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 
@@ -156,7 +162,7 @@ type Profile = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medicalHistory: MedicalHistoryValue;
     gender?: string | null;
     department?: string | null;
     program?: string | null;
@@ -186,7 +192,7 @@ function normalizeProfile(
             ? bloodTypeEnumMap[String(profile.bloodtype)] ?? String(profile.bloodtype)
             : "",
         allergies: (profile?.allergies as string | null) ?? "",
-        medical_cond: (profile?.medical_cond as string | null) ?? "",
+        medicalHistory: parseMedicalHistory(profile?.medical_cond as string | null),
         gender: (profile?.gender as string | null) ?? "",
         department: profile?.department
             ? departmentEnumMap[String(profile.department)] ?? String(profile.department)
@@ -214,7 +220,7 @@ function mapUpdatedProfile(profile: Record<string, unknown>): Partial<Profile> {
             ? bloodTypeEnumMap[String(profile.bloodtype)] ?? String(profile.bloodtype)
             : "",
         allergies: (profile?.allergies as string | null) ?? "",
-        medical_cond: (profile?.medical_cond as string | null) ?? "",
+        medicalHistory: parseMedicalHistory(profile?.medical_cond as string | null),
         department: profile?.department
             ? departmentEnumMap[String(profile.department)] ?? String(profile.department)
             : "",
@@ -229,15 +235,17 @@ function mapUpdatedProfile(profile: Record<string, unknown>): Partial<Profile> {
 }
 
 function formatRequestPayload(profile: Profile) {
+    const { medicalHistory, ...rest } = profile;
+
     return {
-        ...profile,
+        ...rest,
         mname: profile.mname?.trim() ? profile.mname : null,
         email: profile.email?.trim() ? profile.email : null,
         contactno: profile.contactno?.trim() ? profile.contactno : null,
         address: profile.address?.trim() ? profile.address : null,
         bloodtype: profile.bloodtype ? reverseBloodTypeEnumMap[profile.bloodtype] ?? null : null,
         allergies: profile.allergies?.trim() ? profile.allergies : null,
-        medical_cond: profile.medical_cond?.trim() ? profile.medical_cond : null,
+        medical_cond: serializeMedicalHistory(medicalHistory),
         department: profile.department ? reverseDepartmentEnumMap[profile.department] ?? null : null,
         program: profile.program?.trim() ? profile.program : null,
         year_level: profile.year_level ? reverseYearLevelEnumMap[profile.year_level] ?? null : null,
@@ -817,7 +825,7 @@ export default function ScholarAccountPage() {
 
                                 <AccountSection
                                     icon={HeartPulse}
-                                    title="Medical background"
+                                    title="Medical history"
                                     description="Helps the clinic respond quickly in emergencies."
                                 >
                                     <div className="grid gap-4 md:grid-cols-2">
@@ -856,14 +864,17 @@ export default function ScholarAccountPage() {
                                         </div>
                                     </div>
                                     <div className="space-y-2">
-                                        <Label className="text-sm font-medium text-emerald-900">Medical conditions</Label>
-                                        <Input
-                                            value={profile.medical_cond ?? ""}
-                                            onChange={(event) =>
+                                        <Label className="text-sm font-medium text-emerald-900">
+                                            Medical conditions
+                                        </Label>
+                                        <MedicalHistoryField
+                                            value={profile.medicalHistory}
+                                            onChange={(next) =>
                                                 setProfile((prev) =>
-                                                    prev ? { ...prev, medical_cond: event.target.value } : prev
+                                                    prev ? { ...prev, medicalHistory: next } : prev
                                                 )
                                             }
+                                            idPrefix="scholar-medical-history"
                                         />
                                     </div>
                                 </AccountSection>

--- a/src/app/scholar/patients/patient-detail-dialog.tsx
+++ b/src/app/scholar/patients/patient-detail-dialog.tsx
@@ -12,6 +12,7 @@ import {
     formatStaffName,
     formatYearLevel,
 } from "@/lib/patient-format";
+import { formatMedicalHistory, parseMedicalHistory } from "@/lib/medical-history";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
@@ -25,6 +26,8 @@ interface PatientDetailDialogProps {
 
 function PatientDetailDialogComponent({ open, record, onClose }: PatientDetailDialogProps) {
     if (!record) return null;
+
+    const medicalHistoryText = formatMedicalHistory(parseMedicalHistory(record.medical_cond));
 
     return (
         <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? undefined : onClose())}>
@@ -94,7 +97,7 @@ function PatientDetailDialogComponent({ open, record, onClose }: PatientDetailDi
                                 </div>
                                 <div>
                                     <dt className="text-xs uppercase tracking-wide">Medical conditions</dt>
-                                    <dd>{record.medical_cond || "—"}</dd>
+                                    <dd>{medicalHistoryText || "—"}</dd>
                                 </div>
                             </dl>
                         </div>

--- a/src/components/account/medical-history-field.tsx
+++ b/src/components/account/medical-history-field.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    MEDICAL_HISTORY_OPTIONS,
+    type MedicalHistoryOption,
+    type MedicalHistoryValue,
+} from "@/lib/medical-history";
+import { cn } from "@/lib/utils";
+
+function optionId(option: MedicalHistoryOption, prefix: string) {
+    return `${prefix}-${option.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}
+
+export type MedicalHistoryFieldProps = {
+    value: MedicalHistoryValue;
+    onChange: (value: MedicalHistoryValue) => void;
+    disabled?: boolean;
+    idPrefix?: string;
+    className?: string;
+};
+
+export function MedicalHistoryField({
+    value,
+    onChange,
+    disabled,
+    idPrefix = "medical-history",
+    className,
+}: MedicalHistoryFieldProps) {
+    const toggleOption = (option: MedicalHistoryOption, nextChecked: boolean) => {
+        const nextConditions = nextChecked
+            ? Array.from(new Set([...value.conditions, option]))
+            : value.conditions.filter((item) => item !== option);
+
+        onChange({
+            ...value,
+            conditions: nextConditions,
+        });
+    };
+
+    return (
+        <div className={cn("space-y-4", className)}>
+            <div className="grid gap-3 md:grid-cols-2">
+                {MEDICAL_HISTORY_OPTIONS.map((option) => {
+                    const id = optionId(option, idPrefix);
+                    return (
+                        <label key={option} htmlFor={id} className="flex items-center gap-2">
+                            <Checkbox
+                                id={id}
+                                checked={value.conditions.includes(option)}
+                                onCheckedChange={(checked) =>
+                                    toggleOption(option, checked === true)
+                                }
+                                disabled={disabled}
+                            />
+                            <span className="text-sm font-medium text-emerald-900">{option}</span>
+                        </label>
+                    );
+                })}
+            </div>
+            <div className="space-y-2">
+                <Label
+                    htmlFor={`${idPrefix}-other`}
+                    className="text-sm font-medium text-emerald-900"
+                >
+                    Others
+                </Label>
+                <Input
+                    id={`${idPrefix}-other`}
+                    placeholder="Please specify"
+                    value={value.other ?? ""}
+                    onChange={(event) =>
+                        onChange({
+                            ...value,
+                            other: event.target.value,
+                        })
+                    }
+                    disabled={disabled}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-emerald-600 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:text-emerald-400 data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-emerald-600 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:text-emerald-400 data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-emerald-600 data-[state=checked]:border-emerald-600 data-[state=checked]:text-white dark:data-[state=checked]:bg-emerald-500 dark:data-[state=checked]:border-emerald-500 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-4px border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/lib/medical-history.ts
+++ b/src/lib/medical-history.ts
@@ -1,0 +1,123 @@
+export const MEDICAL_HISTORY_OPTIONS = [
+    "Asthma",
+    "Hypertension",
+    "Cancer",
+    "Epilepsy",
+    "Diabetes",
+    "Heart Disease",
+    "Kidney Disease",
+    "Nervous/Mental Disorder",
+] as const;
+
+export type MedicalHistoryOption = (typeof MEDICAL_HISTORY_OPTIONS)[number];
+
+export type MedicalHistoryValue = {
+    conditions: MedicalHistoryOption[];
+    other?: string;
+};
+
+function normalizeOptions(options: unknown): MedicalHistoryOption[] {
+    if (!Array.isArray(options)) {
+        return [];
+    }
+
+    const normalized: MedicalHistoryOption[] = [];
+    for (const option of options) {
+        if (typeof option !== "string") continue;
+        const match = MEDICAL_HISTORY_OPTIONS.find(
+            (candidate) => candidate.toLowerCase() === option.toLowerCase()
+        );
+        if (match && !normalized.includes(match)) {
+            normalized.push(match);
+        }
+    }
+    return normalized;
+}
+
+export function parseMedicalHistory(raw?: string | null): MedicalHistoryValue {
+    if (!raw) {
+        return { conditions: [], other: "" };
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as {
+            conditions?: unknown;
+            other?: unknown;
+        };
+        const conditions = normalizeOptions(parsed.conditions);
+        const other = typeof parsed.other === "string" ? parsed.other : "";
+        return {
+            conditions,
+            other,
+        };
+    } catch {
+        // fall through to legacy parsing
+    }
+
+    const segments = raw
+        .split(/[,;\n]/)
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+
+    const conditions: MedicalHistoryOption[] = [];
+    const otherValues: string[] = [];
+
+    for (const segment of segments) {
+        const match = MEDICAL_HISTORY_OPTIONS.find(
+            (candidate) => candidate.toLowerCase() === segment.toLowerCase()
+        );
+        if (match) {
+            if (!conditions.includes(match)) {
+                conditions.push(match);
+            }
+        } else {
+            otherValues.push(segment);
+        }
+    }
+
+    return {
+        conditions,
+        other: otherValues.join(", "),
+    };
+}
+
+export function serializeMedicalHistory(value: MedicalHistoryValue | null | undefined): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const conditions = normalizeOptions(value.conditions);
+    const other = value.other?.trim() ?? "";
+
+    if (conditions.length === 0 && other.length === 0) {
+        return null;
+    }
+
+    return JSON.stringify({
+        conditions,
+        other,
+    });
+}
+
+export function formatMedicalHistory(value: MedicalHistoryValue | null | undefined): string {
+    if (!value) {
+        return "";
+    }
+
+    const other = value.other?.trim() ?? "";
+    const parts = [...value.conditions];
+    if (other) {
+        parts.push(other);
+    }
+    return parts.join(", ");
+}
+
+export function hasMedicalCondition(
+    value: MedicalHistoryValue | null | undefined,
+    option: MedicalHistoryOption
+): boolean {
+    if (!value) {
+        return false;
+    }
+    return value.conditions.includes(option);
+}

--- a/src/lib/medical-history.ts
+++ b/src/lib/medical-history.ts
@@ -105,7 +105,7 @@ export function formatMedicalHistory(value: MedicalHistoryValue | null | undefin
     }
 
     const other = value.other?.trim() ?? "";
-    const parts = [...value.conditions];
+    const parts: string[] = [...value.conditions];
     if (other) {
         parts.push(other);
     }


### PR DESCRIPTION
## Summary
- add shared medical history utilities and checkbox field component
- update account management screens to capture structured medical history
- render medical certificate checkboxes and patient views based on stored medical history

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914728374d083278fd6e96acff4816f)