### PR TITLE
Update nurse account creation and gender management

### DIFF
--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -140,6 +140,14 @@ export async function PUT(req: Request) {
         const existing = user.employee;
         const incomingDOB = toDate(profile.date_of_birth);
         const existingDOB = existing.date_of_birth ?? null;
+        const incomingGender = isGender(profile.gender) ? profile.gender : null;
+
+        if (existing.gender && incomingGender && existing.gender !== incomingGender) {
+            return NextResponse.json(
+                { error: "Gender cannot be changed once set." },
+                { status: 400 }
+            );
+        }
 
         // Prevent DOB change once set
         if (existingDOB && incomingDOB && existingDOB.getTime() !== incomingDOB.getTime()) {
@@ -153,6 +161,7 @@ export async function PUT(req: Request) {
 
         // Remove unchanged / null / empty fields safely
         if (existingDOB) delete data.date_of_birth;
+        if (existing.gender) delete data.gender;
 
         let verificationEmail: string | null = null;
         let shouldClearVerification = false;

--- a/src/app/api/nurse/accounts/me/route.ts
+++ b/src/app/api/nurse/accounts/me/route.ts
@@ -164,6 +164,11 @@ export async function PUT(req: Request) {
             delete data.date_of_birth;
         }
 
+        // Prevent modifying gender if already set
+        if (user.employee.gender && data.gender) {
+            delete data.gender;
+        }
+
         const current = user.employee;
 
         let verificationEmail: string | null = null;

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -2,14 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { customAlphabet } from "nanoid";
 import bcrypt from "bcryptjs";
-import {
-    Prisma,
-    Gender,
-    BloodType,
-    Department,
-    Role,
-    AccountStatus,
-} from "@prisma/client";
+import { Prisma, BloodType, Department, Role, AccountStatus } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
 
 // Generate random password (8 chars)
@@ -118,7 +111,6 @@ export async function POST(req: Request) {
             fname: payload.fname,
             mname: payload.mname,
             lname: payload.lname,
-            gender: payload.gender as Gender,
             bloodtype: bloodTypeMap[payload.bloodtype] || null,
             address: payload.address ?? null,
             allergies: payload.allergies ?? null,
@@ -128,7 +120,6 @@ export async function POST(req: Request) {
             emergencyco_relation: payload.emergencyco_relation ?? null,
             email: payload.email?.trim() || null,
             contactno: payload.phone?.trim() || null,
-            date_of_birth: payload.date_of_birth ? new Date(payload.date_of_birth) : null,
         };
 
         // Create profile based on role

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -273,6 +273,14 @@ export async function PUT(req: Request) {
 
         const incomingDOB = toDate(profile.date_of_birth);
         const existingDOB = existingProfile?.date_of_birth ?? null;
+        const incomingGender = isGender(profile.gender) ? profile.gender : null;
+
+        if (existingProfile?.gender && incomingGender && existingProfile.gender !== incomingGender) {
+            return NextResponse.json(
+                { error: "Gender cannot be changed once set." },
+                { status: 400 }
+            );
+        }
 
         if (existingDOB && incomingDOB && existingDOB.getTime() !== incomingDOB.getTime()) {
             return NextResponse.json(
@@ -288,6 +296,7 @@ export async function PUT(req: Request) {
 
             // Ensure we don't override DOB if already set
             if (existingDOB) delete data.date_of_birth;
+            if (studentProfile.gender) delete data.gender;
 
             let verificationEmail: string | null = null;
             let shouldClearVerification = false;
@@ -375,6 +384,7 @@ export async function PUT(req: Request) {
 
             // Ensure we don't override DOB if already set
             if (existingDOB) delete data.date_of_birth;
+            if (employeeProfile.gender) delete data.gender;
 
             let verificationEmail: string | null = null;
             let shouldClearVerification = false;

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -197,6 +197,14 @@ export async function PUT(req: Request) {
         // Prevent changing DOB once set
         const incomingDOB = toDate(profile.date_of_birth);
         const existingDOB = existingProfile.date_of_birth ?? null;
+        const incomingGender = isGender(profile.gender) ? profile.gender : null;
+
+        if (existingProfile.gender && incomingGender && existingProfile.gender !== incomingGender) {
+            return NextResponse.json(
+                { error: "Gender cannot be changed once set." },
+                { status: 400 }
+            );
+        }
 
         if (existingDOB && incomingDOB && existingDOB.getTime() !== incomingDOB.getTime()) {
             return NextResponse.json(
@@ -209,6 +217,9 @@ export async function PUT(req: Request) {
         const data = buildStudentUpdateInput(profile);
         if (existingDOB && "date_of_birth" in data) {
             delete data.date_of_birth;
+        }
+        if (existingProfile.gender && "gender" in data) {
+            delete data.gender;
         }
 
         let verificationEmail: string | null = null;

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -100,6 +100,8 @@ export default function DoctorAccountPage() {
 
     const [tempDOB, setTempDOB] = useState("");
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
+    const [tempGender, setTempGender] = useState<"Male" | "Female" | "">("");
+    const [showGenderConfirm, setShowGenderConfirm] = useState(false);
     const [refreshing, setRefreshing] = useState(false);
 
 
@@ -571,7 +573,133 @@ export default function DoctorAccountPage() {
                                         </div>
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Gender</Label>
-                                            <Input value={profile.gender || ""} disabled />
+                                            {profile.gender ? (
+                                                <Input value={profile.gender || ""} disabled />
+                                            ) : (
+                                                <>
+                                                    <Select
+                                                        value={tempGender}
+                                                        onValueChange={(value) => setTempGender(value as "Male" | "Female")}
+                                                    >
+                                                        <SelectTrigger>
+                                                            <SelectValue placeholder="Select gender" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="Male">Male</SelectItem>
+                                                            <SelectItem value="Female">Female</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    {tempGender ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setShowGenderConfirm(true)}
+                                                        >
+                                                            Confirm gender
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                    <AlertDialog open={showGenderConfirm} onOpenChange={setShowGenderConfirm}>
+                                                        <AlertDialogContent className="max-w-sm sm:max-w-md">
+                                                            <AlertDialogHeader>
+                                                                <AlertDialogTitle>Confirm Gender</AlertDialogTitle>
+                                                                <AlertDialogDescription>
+                                                                    You are about to set your gender to{" "}
+                                                                    <span className="font-semibold text-emerald-700">{tempGender}</span>.
+                                                                    <br />
+                                                                    This action can only be done once and cannot be changed later.
+                                                                </AlertDialogDescription>
+                                                            </AlertDialogHeader>
+                                                            <AlertDialogFooter className="mt-4">
+                                                                <AlertDialogCancel
+                                                                    onClick={() => {
+                                                                        setTempGender("");
+                                                                        setShowGenderConfirm(false);
+                                                                    }}
+                                                                >
+                                                                    Cancel
+                                                                </AlertDialogCancel>
+                                                                <AlertDialogAction
+                                                                    className="bg-emerald-600 hover:bg-emerald-700"
+                                                                    onClick={async () => {
+                                                                        const contactValidation = validateAndNormalizeContacts({
+                                                                            email: profile.email,
+                                                                            contactNumber: profile.contactno,
+                                                                            emergencyNumber: profile.emergencyco_num,
+                                                                        });
+
+                                                                        if (!contactValidation.success) {
+                                                                            toast.error(contactValidation.error);
+                                                                            return;
+                                                                        }
+
+                                                                        const updatedProfile = {
+                                                                            ...profile,
+                                                                            email: contactValidation.email,
+                                                                            contactno: contactValidation.contactNumber,
+                                                                            emergencyco_num: contactValidation.emergencyNumber,
+                                                                            gender: tempGender,
+                                                                        };
+
+                                                                        setProfile(updatedProfile);
+                                                                        setShowGenderConfirm(false);
+
+                                                                        try {
+                                                                            setProfileLoading(true);
+                                                                            const payload = {
+                                                                                ...updatedProfile,
+                                                                                medical_cond: serializeMedicalHistory(updatedProfile.medicalHistory),
+                                                                                bloodtype: reverseBloodTypeEnumMap[updatedProfile.bloodtype || ""] || null,
+                                                                            };
+
+                                                                            const res = await fetch("/api/doctor/account/me", {
+                                                                                method: "PUT",
+                                                                                headers: { "Content-Type": "application/json" },
+                                                                                body: JSON.stringify({ profile: payload }),
+                                                                            });
+
+                                                                            const data = await res.json();
+                                                                            if (!res.ok) {
+                                                                                if (
+                                                                                    handleRateLimitError(
+                                                                                        res,
+                                                                                        data,
+                                                                                        "Too many profile updates. Please wait before trying again."
+                                                                                    )
+                                                                                ) {
+                                                                                    return;
+                                                                                }
+                                                                                toast.error(data.error ?? "Failed to save gender");
+                                                                            } else if (data.error) {
+                                                                                toast.error(data.error);
+                                                                            } else {
+                                                                                toast.success("Gender saved!");
+                                                                                if (data.verificationEmailSent) {
+                                                                                    const targetEmail = data.profile?.email?.trim();
+                                                                                    toast.success(
+                                                                                        targetEmail
+                                                                                            ? `A verification email was sent to ${targetEmail}. Please confirm it to receive clinic notifications.`
+                                                                                            : "A verification email was sent. Please check your inbox to confirm the address."
+                                                                                    );
+                                                                                }
+                                                                                await loadProfile();
+                                                                            }
+                                                                        } catch {
+                                                                            toast.error("Failed to save gender");
+                                                                        } finally {
+                                                                            setProfileLoading(false);
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    Confirm
+                                                                </AlertDialogAction>
+                                                            </AlertDialogFooter>
+                                                        </AlertDialogContent>
+                                                    </AlertDialog>
+                                                </>
+                                            )}
                                         </div>
                                     </div>
                                 </AccountSection>

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -91,8 +91,6 @@ type CreateUserPayload = {
     fname: string;
     mname?: string | null;
     lname: string;
-    date_of_birth: string;
-    gender: "Male" | "Female";
     employee_id?: string | null;
     student_id?: string | null;
     school_id?: string | null;
@@ -125,7 +123,6 @@ export function NurseAccountsPageClient({
     const [loading, setLoading] = useState(false);
 
     const [role, setRole] = useState("");
-    const [gender, setGender] = useState<"Male" | "Female" | "">("");
     const [patientType, setPatientType] = useState<"student" | "employee" | "">("");
     const [roleFilter, setRoleFilter] = useState<RoleFilterValue>("ALL");
     const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("ALL");
@@ -143,6 +140,8 @@ export function NurseAccountsPageClient({
 
     const [tempDOB, setTempDOB] = useState(""); // temporary holding value
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
+    const [tempGender, setTempGender] = useState<"Male" | "Female" | "">("");
+    const [showGenderConfirm, setShowGenderConfirm] = useState(false);
 
     const [specialization, setSpecialization] = useState<"Physician" | "Dentist" | null>(null);
     const [pendingPayload, setPendingPayload] = useState<CreateUserPayload | null>(null);
@@ -336,6 +335,12 @@ export function NurseAccountsPageClient({
         setCurrentPage(1);
     }, [roleFilter, statusFilter]);
 
+    useEffect(() => {
+        if (profile?.gender) {
+            setTempGender("");
+        }
+    }, [profile?.gender]);
+
     const filteredUsers = useMemo(() => {
         if (roleFilter === "ALL" && statusFilter === "ALL" && !deferredSearch) {
             return users;
@@ -364,11 +369,6 @@ export function NurseAccountsPageClient({
             return;
         }
 
-        if (!gender) {
-            toast.error("Please choose a gender for the new account.", { position: "top-center" });
-            return;
-        }
-
         if (role === "PATIENT" && !patientType) {
             toast.error("Please specify whether the patient is a student or employee.", {
                 position: "top-center",
@@ -393,7 +393,6 @@ export function NurseAccountsPageClient({
         const fname = getTrimmedValue("fname");
         const mnameRaw = getTrimmedValue("mname");
         const lname = getTrimmedValue("lname");
-        const date_of_birth = getTrimmedValue("date_of_birth");
         const employeeId = getTrimmedValue("employee_id");
         const studentId = getTrimmedValue("student_id");
         const schoolId = getTrimmedValue("school_id");
@@ -403,8 +402,6 @@ export function NurseAccountsPageClient({
             fname,
             mname: mnameRaw || null,
             lname,
-            date_of_birth,
-            gender: gender as "Male" | "Female",
             employee_id:
                 role === "NURSE" ||
                     role === "DOCTOR" ||
@@ -469,7 +466,6 @@ export function NurseAccountsPageClient({
 
             formRef.current?.reset();
             setRole("");
-            setGender("");
             setPatientType("");
             setSpecialization(null);
             setPendingPayload(null);
@@ -519,6 +515,12 @@ export function NurseAccountsPageClient({
             return;
         }
 
+        // If user is trying to set gender for the first time but hasn't confirmed yet
+        if (!updatedProfile.gender && tempGender) {
+            setShowGenderConfirm(true);
+            return;
+        }
+
         try {
             setProfileLoading(true);
 
@@ -532,6 +534,11 @@ export function NurseAccountsPageClient({
             // Prevent DOB modification if it was already set
             if (originalProfile?.date_of_birth) {
                 payload.date_of_birth = originalProfile.date_of_birth;
+            }
+
+            // Prevent gender modification if it was already set
+            if (originalProfile?.gender) {
+                payload.gender = originalProfile.gender;
             }
 
             const res = await fetch("/api/nurse/accounts/me", {
@@ -657,16 +664,6 @@ export function NurseAccountsPageClient({
             return null;
         })()
         : null;
-
-    const pendingDOBLabel = pendingPayload?.date_of_birth
-        ? (() => {
-            const parsed = new Date(pendingPayload.date_of_birth);
-            if (Number.isNaN(parsed.getTime())) {
-                return pendingPayload.date_of_birth;
-            }
-            return new Intl.DateTimeFormat("en-PH", { dateStyle: "medium" }).format(parsed);
-        })()
-        : "—";
 
     const pendingPatientTypeLabel = pendingPayload?.patientType
         ? pendingPayload.patientType === "student"
@@ -858,7 +855,133 @@ export function NurseAccountsPageClient({
                                         </div>
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Gender</Label>
-                                            <Input value={profile.gender || ""} disabled />
+                                            {profile.gender ? (
+                                                <Input value={profile.gender || ""} disabled />
+                                            ) : (
+                                                <>
+                                                    <Select
+                                                        value={tempGender}
+                                                        onValueChange={(value) => setTempGender(value as "Male" | "Female")}
+                                                    >
+                                                        <SelectTrigger>
+                                                            <SelectValue placeholder="Select gender" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="Male">Male</SelectItem>
+                                                            <SelectItem value="Female">Female</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    {tempGender ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setShowGenderConfirm(true)}
+                                                        >
+                                                            Confirm gender
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                    <AlertDialog open={showGenderConfirm} onOpenChange={setShowGenderConfirm}>
+                                                        <AlertDialogContent className="max-w-sm sm:max-w-md rounded-3xl border border-emerald-100/80 bg-white/95">
+                                                            <AlertDialogHeader>
+                                                                <AlertDialogTitle>Confirm Gender</AlertDialogTitle>
+                                                                <AlertDialogDescription>
+                                                                    You are about to set your gender to {" "}
+                                                                    <span className="font-semibold text-emerald-700">{tempGender}</span>.
+                                                                    <br />
+                                                                    This action can only be done once and cannot be changed later.
+                                                                </AlertDialogDescription>
+                                                            </AlertDialogHeader>
+                                                            <AlertDialogFooter className="mt-4">
+                                                                <AlertDialogCancel
+                                                                    onClick={() => {
+                                                                        setTempGender("");
+                                                                        setShowGenderConfirm(false);
+                                                                    }}
+                                                                >
+                                                                    Cancel
+                                                                </AlertDialogCancel>
+                                                                <AlertDialogAction
+                                                                    className="bg-emerald-600 hover:bg-emerald-700"
+                                                                    onClick={async () => {
+                                                                        const contactValidation = validateAndNormalizeContacts({
+                                                                            email: profile.email,
+                                                                            contactNumber: profile.contactno,
+                                                                            emergencyNumber: profile.emergencyco_num,
+                                                                        });
+
+                                                                        if (!contactValidation.success) {
+                                                                            toast.error(contactValidation.error);
+                                                                            return;
+                                                                        }
+
+                                                                        const updatedProfile = {
+                                                                            ...profile,
+                                                                            email: contactValidation.email,
+                                                                            contactno: contactValidation.contactNumber,
+                                                                            emergencyco_num: contactValidation.emergencyNumber,
+                                                                            gender: tempGender,
+                                                                        };
+
+                                                                        setProfile(updatedProfile);
+                                                                        setShowGenderConfirm(false);
+
+                                                                        try {
+                                                                            setProfileLoading(true);
+                                                                            const payload = {
+                                                                                ...updatedProfile,
+                                                                                bloodtype:
+                                                                                    nurseReverseBloodTypeEnumMap[updatedProfile?.bloodtype || ""] || null,
+                                                                            };
+
+                                                                            const res = await fetch("/api/nurse/accounts/me", {
+                                                                                method: "PUT",
+                                                                                headers: { "Content-Type": "application/json" },
+                                                                                body: JSON.stringify({ profile: payload }),
+                                                                            });
+
+                                                                            const data = await res.json();
+                                                                            if (!res.ok) {
+                                                                                if (
+                                                                                    handleRateLimitError(
+                                                                                        res,
+                                                                                        data,
+                                                                                        "Too many profile updates. Please wait before trying again."
+                                                                                    )
+                                                                                ) {
+                                                                                    return;
+                                                                                }
+                                                                                toast.error(data.error ?? "Failed to save gender");
+                                                                            } else if (data.error) {
+                                                                                toast.error(data.error);
+                                                                            } else {
+                                                                                toast.success("Gender saved!");
+                                                                                if (data.verificationEmailSent) {
+                                                                                    const targetEmail = data.profile?.email?.trim();
+                                                                                    toast.success(
+                                                                                        targetEmail
+                                                                                            ? `A verification email was sent to ${targetEmail}. Please confirm it to receive clinic notifications.`
+                                                                                            : "A verification email was sent. Please check your inbox to confirm the address."
+                                                                                    );
+                                                                                }
+                                                                                await loadProfile();
+                                                                            }
+                                                                        } catch {
+                                                                            toast.error("Failed to save gender");
+                                                                        } finally {
+                                                                            setProfileLoading(false);
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    Confirm
+                                                                </AlertDialogAction>
+                                                            </AlertDialogFooter>
+                                                        </AlertDialogContent>
+                                                    </AlertDialog>
+                                                </>
+                                            )}
                                         </div>
                                     </div>
                                 </AccountSection>
@@ -1135,27 +1258,6 @@ export function NurseAccountsPageClient({
                                 </div>
                             </div>
 
-                            {/* DOB + Gender */}
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <Label className="block mb-1 font-medium">Date of Birth</Label>
-                                    <Input type="date" name="date_of_birth" />
-                                </div>
-                                <div>
-                                    <Label className="block mb-1 font-medium">Gender</Label>
-                                    <Select
-                                        value={gender}
-                                        onValueChange={(val) => setGender(val as "Male" | "Female")}
-                                    >
-                                        <SelectTrigger><SelectValue placeholder="Select gender" /></SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="Male">Male</SelectItem>
-                                            <SelectItem value="Female">Female</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                            </div>
-
                             {/* Submit */}
                             <Button
                                 type="submit"
@@ -1188,14 +1290,6 @@ export function NurseAccountsPageClient({
                                                 <dd className="text-right font-medium text-gray-900">
                                                     {pendingFullName || "—"}
                                                 </dd>
-                                            </div>
-                                            <div className="flex items-center justify-between gap-4">
-                                                <dt className="text-gray-500">Gender</dt>
-                                                <dd className="font-medium text-gray-900">{pendingPayload.gender}</dd>
-                                            </div>
-                                            <div className="flex items-center justify-between gap-4">
-                                                <dt className="text-gray-500">Date of Birth</dt>
-                                                <dd className="font-medium text-gray-900">{pendingDOBLabel}</dd>
                                             </div>
                                             {pendingPatientTypeLabel && (
                                                 <div className="flex items-center justify-between gap-4">

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -140,6 +140,8 @@ export function PatientAccountPageClient({
 
     const [tempDOB, setTempDOB] = useState("");
     const [showDOBConfirm, setShowDOBConfirm] = useState(false);
+    const [tempGender, setTempGender] = useState<"Male" | "Female" | "">("");
+    const [showGenderConfirm, setShowGenderConfirm] = useState(false);
     const [refreshingProfile, setRefreshingProfile] = useState(false);
 
     useEffect(() => {
@@ -645,7 +647,141 @@ export function PatientAccountPageClient({
                                         </div>
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Gender</Label>
-                                            <Input value={profile.gender || ""} disabled />
+                                            {profile.gender ? (
+                                                <Input value={profile.gender || ""} disabled />
+                                            ) : (
+                                                <>
+                                                    <Select
+                                                        value={tempGender}
+                                                        onValueChange={(value) => setTempGender(value as "Male" | "Female")}
+                                                    >
+                                                        <SelectTrigger>
+                                                            <SelectValue placeholder="Select gender" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="Male">Male</SelectItem>
+                                                            <SelectItem value="Female">Female</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    {tempGender ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setShowGenderConfirm(true)}
+                                                        >
+                                                            Confirm gender
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                    <AlertDialog open={showGenderConfirm} onOpenChange={setShowGenderConfirm}>
+                                                        <AlertDialogContent className="max-w-sm sm:max-w-md">
+                                                            <AlertDialogHeader>
+                                                                <AlertDialogTitle>Confirm Gender</AlertDialogTitle>
+                                                                <AlertDialogDescription>
+                                                                    You are about to set your gender to{" "}
+                                                                    <span className="font-semibold text-emerald-700">{tempGender}</span>.
+                                                                    <br />
+                                                                    This action can only be done once and cannot be changed later.
+                                                                </AlertDialogDescription>
+                                                            </AlertDialogHeader>
+                                                            <AlertDialogFooter className="mt-4">
+                                                                <AlertDialogCancel
+                                                                    onClick={() => {
+                                                                        setTempGender("");
+                                                                        setShowGenderConfirm(false);
+                                                                    }}
+                                                                >
+                                                                    Cancel
+                                                                </AlertDialogCancel>
+                                                                <AlertDialogAction
+                                                                    className="bg-emerald-600 hover:bg-emerald-700"
+                                                                    onClick={async () => {
+                                                                        const contactValidation = validateAndNormalizeContacts({
+                                                                            email: profile.email,
+                                                                            contactNumber: profile.contactno,
+                                                                            emergencyNumber: profile.emergencyco_num,
+                                                                        });
+
+                                                                        if (!contactValidation.success) {
+                                                                            toast.error(contactValidation.error);
+                                                                            return;
+                                                                        }
+
+                                                                        const updatedProfile = {
+                                                                            ...profile,
+                                                                            email: contactValidation.email,
+                                                                            contactno: contactValidation.contactNumber,
+                                                                            emergencyco_num: contactValidation.emergencyNumber,
+                                                                            gender: tempGender,
+                                                                        };
+
+                                                                        setProfile(updatedProfile);
+                                                                        setShowGenderConfirm(false);
+
+                                                                        try {
+                                                                            setProfileLoading(true);
+                                                                            const payload = {
+                                                                                ...updatedProfile,
+                                                                                medical_cond: serializePatientMedicalHistory(updatedProfile.medicalHistory),
+                                                                                department:
+                                                                                    profileType === "student"
+                                                                                        ? patientReverseDepartmentEnumMap[updatedProfile.department || ""] || null
+                                                                                        : updatedProfile.department || null,
+                                                                                year_level:
+                                                                                    profileType === "student"
+                                                                                        ? patientReverseYearLevelEnumMap[updatedProfile.year_level || ""] || null
+                                                                                        : null,
+                                                                                bloodtype: patientReverseBloodTypeEnumMap[updatedProfile.bloodtype || ""] || null,
+                                                                            };
+
+                                                                            const res = await fetch("/api/patient/account/me", {
+                                                                                method: "PUT",
+                                                                                headers: { "Content-Type": "application/json" },
+                                                                                body: JSON.stringify({ profile: payload }),
+                                                                            });
+
+                                                                            const data = await res.json();
+                                                                            if (!res.ok) {
+                                                                                if (
+                                                                                    handleRateLimitError(
+                                                                                        res,
+                                                                                        data,
+                                                                                        "Too many profile updates. Please wait before trying again."
+                                                                                    )
+                                                                                ) {
+                                                                                    return;
+                                                                                }
+                                                                                toast.error(data.error ?? "Failed to save gender");
+                                                                            } else if (data.error) {
+                                                                                toast.error(data.error);
+                                                                            } else {
+                                                                                toast.success("Gender saved!");
+                                                                                if (data.verificationEmailSent) {
+                                                                                    const targetEmail = data.profile?.email?.trim();
+                                                                                    toast.success(
+                                                                                        targetEmail
+                                                                                            ? `A verification email was sent to ${targetEmail}. Please confirm it to receive clinic notifications.`
+                                                                                            : "A verification email was sent. Please check your inbox to confirm the address."
+                                                                                    );
+                                                                                }
+                                                                                await loadProfile();
+                                                                            }
+                                                                        } catch {
+                                                                            toast.error("Failed to save gender");
+                                                                        } finally {
+                                                                            setProfileLoading(false);
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    Confirm
+                                                                </AlertDialogAction>
+                                                            </AlertDialogFooter>
+                                                        </AlertDialogContent>
+                                                    </AlertDialog>
+                                                </>
+                                            )}
                                         </div>
                                     </div>
                                 </AccountSection>

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -263,6 +263,9 @@ export default function ScholarAccountPage() {
     const [dobConfirmOpen, setDobConfirmOpen] = useState(false);
     const [dobSaving, setDobSaving] = useState(false);
     const [tempDOB, setTempDOB] = useState("");
+    const [tempGender, setTempGender] = useState<"Male" | "Female" | "">("");
+    const [genderConfirmOpen, setGenderConfirmOpen] = useState(false);
+    const [genderSaving, setGenderSaving] = useState(false);
 
     const availablePrograms = useMemo(
         () => (profile?.department ? programOptions[profile.department] ?? [] : []),
@@ -548,6 +551,70 @@ export default function ScholarAccountPage() {
         }
     }, [loadProfile, profile, tempDOB]);
 
+    const confirmGender = useCallback(async () => {
+        if (!profile || !tempGender) return;
+
+        const contactValidation = validateAndNormalizeContacts({
+            email: profile.email,
+            contactNumber: profile.contactno,
+            emergencyNumber: profile.emergencyco_num,
+        });
+
+        if (!contactValidation.success) {
+            toast.error(contactValidation.error);
+            return;
+        }
+
+        const updatedProfile = {
+            ...profile,
+            email: contactValidation.email,
+            contactno: contactValidation.contactNumber,
+            emergencyco_num: contactValidation.emergencyNumber,
+            gender: tempGender,
+        };
+
+        setProfile(updatedProfile);
+
+        try {
+            setGenderSaving(true);
+            const payload = formatRequestPayload(updatedProfile);
+            const res = await fetch("/api/scholar/account/me", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ profile: payload }),
+            });
+            const data = await res.json();
+
+            if (!res.ok) {
+                if (handleRateLimitError(res, data, "Too many profile updates. Please wait before trying again.")) {
+                    return;
+                }
+                throw new Error(data.error ?? "Failed to save gender");
+            }
+
+            if (data.error) {
+                throw new Error(data.error);
+            }
+
+            toast.success("Gender saved!");
+            if (data.verificationEmailSent) {
+                const targetEmail = data.profile?.email?.trim();
+                toast.success(
+                    targetEmail
+                        ? `A verification email was sent to ${targetEmail}. Please confirm it to receive clinic notifications.`
+                        : "A verification email was sent. Please check your inbox to confirm the address."
+                );
+            }
+            await loadProfile();
+        } catch (error) {
+            console.error(error);
+            toast.error(error instanceof Error ? error.message : "Failed to save gender");
+        } finally {
+            setGenderSaving(false);
+            setGenderConfirmOpen(false);
+        }
+    }, [loadProfile, profile, tempGender]);
+
     if (initializing) {
         return <ScholarAccountLoading />;
     }
@@ -643,7 +710,36 @@ export default function ScholarAccountPage() {
                                         </div>
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Gender</Label>
-                                            <Input value={profile.gender ?? ""} disabled />
+                                            {profile.gender ? (
+                                                <Input value={profile.gender ?? ""} disabled />
+                                            ) : (
+                                                <>
+                                                    <Select
+                                                        value={tempGender}
+                                                        onValueChange={(value) => setTempGender(value as "Male" | "Female")}
+                                                    >
+                                                        <SelectTrigger>
+                                                            <SelectValue placeholder="Select gender" />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="Male">Male</SelectItem>
+                                                            <SelectItem value="Female">Female</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    {tempGender ? (
+                                                        <Button
+                                                            type="button"
+                                                            className="mt-2 w-max rounded-2xl bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                                                            onClick={() => setGenderConfirmOpen(true)}
+                                                        >
+                                                            Confirm gender
+                                                        </Button>
+                                                    ) : null}
+                                                    <p className="text-xs text-muted-foreground">
+                                                        This can only be saved once. Double-check before confirming.
+                                                    </p>
+                                                </>
+                                            )}
                                         </div>
                                     </div>
                                 </AccountSection>
@@ -926,15 +1022,15 @@ export default function ScholarAccountPage() {
                                 <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
                                     <AccountRefreshButton
                                         onClick={() => void loadProfile()}
-                                        disabled={profileLoading || updating || dobSaving}
+                                        disabled={profileLoading || updating || dobSaving || genderSaving}
                                         isRefreshing={profileLoading}
                                     />
                                     <Button
                                         type="submit"
                                         className="flex items-center justify-center gap-2 rounded-2xl bg-green-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700 disabled:opacity-60"
-                                        disabled={updating || dobSaving}
+                                        disabled={updating || dobSaving || genderSaving}
                                     >
-                                        {updating || dobSaving ? (
+                                        {updating || dobSaving || genderSaving ? (
                                             <>
                                                 <Loader2 className="h-4 w-4 animate-spin" /> Saving…
                                             </>
@@ -988,6 +1084,41 @@ export default function ScholarAccountPage() {
                             disabled={dobSaving}
                         >
                             {dobSaving ? (
+                                <span className="flex items-center gap-2">
+                                    <Loader2 className="h-4 w-4 animate-spin" /> Saving…
+                                </span>
+                            ) : (
+                                "Confirm"
+                            )}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+            <AlertDialog open={genderConfirmOpen} onOpenChange={setGenderConfirmOpen}>
+                <AlertDialogContent className="max-w-sm rounded-3xl border border-emerald-100/80 bg-white/95">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Confirm gender</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            You are about to set your gender to{' '}
+                            <span className="font-semibold text-emerald-700">{tempGender}</span>. This action can only be done once
+                            and cannot be changed later.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel
+                            onClick={() => {
+                                setTempGender("");
+                                setGenderConfirmOpen(false);
+                            }}
+                        >
+                            Cancel
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                            className="bg-emerald-600 hover:bg-emerald-700"
+                            onClick={() => void confirmGender()}
+                            disabled={genderSaving}
+                        >
+                            {genderSaving ? (
                                 <span className="flex items-center gap-2">
                                     <Loader2 className="h-4 w-4 animate-spin" /> Saving…
                                 </span>


### PR DESCRIPTION
## Summary
- remove date of birth and gender fields from nurse account creation and confirmation
- allow nurses to set gender once via My Account with confirmation flow and backend protections
- prevent updates to already-set birthdate or gender while keeping profile updates intact

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919aa9782d0832795685b09429c72a7)