### PR TITLE
Add appointment email notifications

### DIFF
--- a/src/app/api/doctor/appointments/[id]/route.ts
+++ b/src/app/api/doctor/appointments/[id]/route.ts
@@ -15,168 +15,15 @@ import {
 } from "@/lib/time";
 import { sendEmail } from "@/lib/email";
 import { EMAIL_VERIFICATION_TOKEN_TYPE } from "@/lib/email-verification";
+import {
+    buildMoveEmail,
+    buildStatusEmail,
+    formatDoctorName,
+    formatPatientName,
+    getPatientEmail,
+} from "@/lib/appointment-email";
 
-const EMAIL_BACKGROUND_COLOR = "#f0fdf4";
-const EMAIL_BORDER_COLOR = "#bbf7d0";
-const EMAIL_TEXT_COLOR = "#065f46";
-const EMAIL_ACCENT_COLOR = "#047857";
 
-function escapeHtml(input: string) {
-    return input
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
-}
-
-function formatPatientName(patient: {
-    username: string;
-    student: { fname: string | null; lname: string | null } | null;
-    employee: { fname: string | null; lname: string | null } | null;
-}) {
-    if (patient.student?.fname && patient.student?.lname)
-        return `${patient.student.fname} ${patient.student.lname}`;
-    if (patient.employee?.fname && patient.employee?.lname)
-        return `${patient.employee.fname} ${patient.employee.lname}`;
-    return patient.username;
-}
-
-function getPatientEmail(patient: {
-    username: string;
-    student: { email: string | null } | null;
-    employee: { email: string | null } | null;
-    passwordResetTokens: { contact: string }[];
-}) {
-    const verifiedContacts = new Set(
-        patient.passwordResetTokens.map((token) => token.contact.toLowerCase()),
-    );
-
-    const studentEmail = patient.student?.email?.trim() ?? "";
-    if (studentEmail && verifiedContacts.has(studentEmail.toLowerCase())) {
-        return studentEmail;
-    }
-
-    const employeeEmail = patient.employee?.email?.trim() ?? "";
-    if (employeeEmail && verifiedContacts.has(employeeEmail.toLowerCase())) {
-        return employeeEmail;
-    }
-
-    return patient.username.includes("@") ? patient.username : "";
-}
-
-function formatDoctorName(doctor: {
-    username: string;
-    employee: { fname: string | null; lname: string | null } | null;
-}) {
-    if (doctor.employee?.fname && doctor.employee?.lname)
-        return `Dr. ${doctor.employee.fname} ${doctor.employee.lname}`;
-    return doctor.username.startsWith("Dr.")
-        ? doctor.username
-        : `Dr. ${doctor.username}`;
-}
-
-function buildStatusEmail({
-    status,
-    patientName,
-    clinicName,
-    schedule,
-    doctorName,
-    cancelReason,
-}: {
-    status: AppointmentStatus;
-    patientName: string;
-    clinicName: string;
-    schedule: string;
-    doctorName: string;
-    cancelReason?: string | null;
-}): { subject: string; html: string; text: string } | null {
-    const safeName = escapeHtml(patientName);
-    const safeClinic = escapeHtml(clinicName);
-    const safeSchedule = escapeHtml(schedule);
-    const safeDoctor = escapeHtml(doctorName);
-    const safeReason = cancelReason ? escapeHtml(cancelReason) : null;
-
-    const rows = [
-        { label: "Clinic", value: safeClinic },
-        { label: "Doctor", value: safeDoctor },
-        { label: "Schedule", value: safeSchedule },
-    ];
-
-    const textRows: Array<[string, string]> = [
-        ["Clinic", clinicName],
-        ["Doctor", doctorName],
-        ["Schedule", schedule],
-    ];
-
-    let heading = "";
-    let intro = "";
-    let outro = `Thank you,<br/>${safeDoctor}<br/>HNU Clinic`;
-    let subject = "";
-    let textIntro = "";
-    let textOutro = `Thank you,\n${doctorName}\nHNU Clinic`;
-
-    switch (status) {
-        case AppointmentStatus.Approved:
-            heading = "Appointment Approved";
-            intro = `<span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Good news, <strong style="color: inherit;">${safeName}</strong>! <strong style="color: inherit;">${safeDoctor}</strong> has approved your appointment.</span>`;
-            subject = "Your appointment has been approved";
-            textIntro = `Good news, ${patientName}! ${doctorName} has approved your appointment.`;
-            break;
-        case AppointmentStatus.Cancelled:
-            heading = "Appointment Cancelled";
-            intro = `<span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Hello <strong style="color: inherit;">${safeName}</strong>, <strong style="color: inherit;">${safeDoctor}</strong> has cancelled your appointment.</span>`;
-            subject = "Your appointment has been cancelled";
-            if (safeReason) rows.push({ label: "Cancellation Reason", value: safeReason });
-            if (cancelReason) textRows.push(["Cancellation Reason", cancelReason]);
-            outro = `If you still need assistance, please book another schedule through the patient portal.<br/><br/>Thank you,<br/>${safeDoctor}<br/>HNU Clinic`;
-            textIntro = `Hello ${patientName}, ${doctorName} has cancelled your appointment.`;
-            textOutro = `If you still need assistance, please book another schedule through the patient portal.\n\nThank you,\n${doctorName}\nHNU Clinic`;
-            break;
-        case AppointmentStatus.Completed:
-            heading = "Appointment Completed";
-            intro = `<span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Hello <strong style="color: inherit;">${safeName}</strong>, <strong style="color: inherit;">${safeDoctor}</strong> has marked your appointment as completed.</span>`;
-            subject = "Your appointment has been completed";
-            outro = `We hope you had a good visit. You can review your consultation notes and next steps inside the patient portal.<br/><br/>Thank you,<br/>${safeDoctor}<br/>HNU Clinic`;
-            textIntro = `Hello ${patientName}, ${doctorName} has marked your appointment as completed.`;
-            textOutro = `We hope you had a good visit. You can review your consultation notes and next steps inside the patient portal.\n\nThank you,\n${doctorName}\nHNU Clinic`;
-            break;
-        default:
-            return null;
-    }
-
-    const rowHtml = rows
-        .map(
-            (row) => `
-        <tr>
-          <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">${row.label}</td>
-          <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${row.value}</td>
-        </tr>`
-        )
-        .join("");
-
-    const html = `
-    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: ${EMAIL_BACKGROUND_COLOR}; padding: 24px; border-radius: 16px; border: 1px solid ${EMAIL_BORDER_COLOR}; color: ${EMAIL_TEXT_COLOR};">
-      <h2 style="margin-top: 0; color: ${EMAIL_ACCENT_COLOR};">${heading}</h2>
-      <p>${intro}</p>
-      <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
-        <tbody>${rowHtml}</tbody>
-      </table>
-      <p style="margin-bottom: 0;">${outro}</p>
-    </div>`;
-
-    const text = [
-        textIntro,
-        "",
-        ...textRows.map(([label, value]) => `${label}: ${value}`),
-        "",
-        textOutro,
-    ]
-        .join("\n")
-        .trim();
-
-    return { subject, html, text };
-}
 function shapeResponse(appointment: {
     appointment_id: string;
     appointment_timestart: Date;
@@ -412,60 +259,21 @@ export async function PATCH(
             const doctorName = formatDoctorName(updated.doctor);
 
             if (patientEmail) {
-                const oldSchedule = formatManilaDateTime(appointment.appointment_timestart);
-                const newSchedule = formatManilaDateTime(updated.appointment_timestart);
-                const html = `
-                    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: ${EMAIL_BACKGROUND_COLOR}; padding: 24px; border-radius: 16px; border: 1px solid ${EMAIL_BORDER_COLOR}; color: ${EMAIL_TEXT_COLOR};">
-                        <h2 style="margin-top: 0; color: ${EMAIL_ACCENT_COLOR};">Appointment Update</h2>
-                        <p style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Hello <strong style="color: inherit;">${escapeHtml(patientName)}</strong>, <strong style="color: inherit;">${escapeHtml(doctorName)}</strong> has updated your appointment.</p>
-                        <p>Your visit at <strong>${escapeHtml(updated.clinic.clinic_name)}</strong> has been moved.</p>
-                        <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
-                            <tbody>
-                                <tr>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">Doctor</td>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(doctorName)}</td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">Previous Schedule</td>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(oldSchedule)}</td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">New Schedule</td>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(newSchedule)}</td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">Doctor's Note</td>
-                                    <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${escapeHtml(trimmedReason)}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <p>Please log in to your patient portal if you need to reschedule again or have any questions.</p>
-                        <p style="margin-bottom: 0;">Thank you,<br/>${escapeHtml(doctorName)}<br/>HNU Clinic</p>
-                    </div>
-                `;
-
-                const text = [
-                    `Hello ${patientName},`,
-                    "",
-                    `${doctorName} has updated your appointment at ${updated.clinic.clinic_name}.`,
-                    "",
-                    `Previous Schedule: ${oldSchedule ?? "Unavailable"}`,
-                    `New Schedule: ${newSchedule ?? "Unavailable"}`,
-                    `Doctor's Note: ${trimmedReason}`,
-                    "",
-                    "Please log in to your patient portal if you need to reschedule again or have any questions.",
-                    "",
-                    "Thank you,",
+                const moveEmail = buildMoveEmail({
+                    patientName,
                     doctorName,
-                    "HNU Clinic",
-                ].join("\n");
+                    clinicName: updated.clinic.clinic_name,
+                    oldSchedule: formatManilaDateTime(appointment.appointment_timestart),
+                    newSchedule: formatManilaDateTime(updated.appointment_timestart),
+                    reason: trimmedReason,
+                });
 
                 try {
                     await sendEmail({
                         to: patientEmail,
-                        subject: "Your appointment has been moved",
-                        html,
-                        text,
+                        subject: moveEmail.subject,
+                        html: moveEmail.html,
+                        text: moveEmail.text,
                     });
                 } catch (emailErr) {
                     console.error("[PATCH /api/doctor/appointments/:id] email error", emailErr);

--- a/src/app/api/scholar/appointments/route.ts
+++ b/src/app/api/scholar/appointments/route.ts
@@ -8,6 +8,7 @@ import { archiveExpiredDutyHours } from "@/lib/duty-hours";
 import {
     buildManilaDate,
     endOfManilaDay,
+    formatManilaDateTime,
     formatManilaISODate,
     manilaNow,
     startOfManilaDay,
@@ -22,6 +23,14 @@ import {
     type RateLimitResult,
     withRateLimit,
 } from "@/lib/rate-limit";
+import { sendEmail } from "@/lib/email";
+import { EMAIL_VERIFICATION_TOKEN_TYPE } from "@/lib/email-verification";
+import {
+    buildStatusEmail,
+    formatDoctorName,
+    formatPatientName,
+    getPatientEmail,
+} from "@/lib/appointment-email";
 
 function rateLimitResponse(message: string, result: RateLimitResult) {
     const response = NextResponse.json({ error: message }, { status: 429 });
@@ -439,7 +448,8 @@ export async function PATCH(req: Request) {
         const payload = await req.json();
         const appointmentId = payload?.appointment_id as string | undefined;
         const newStatus = payload?.status as AppointmentStatus | undefined;
-        const remarks = typeof payload?.remarks === "string" ? payload.remarks : undefined;
+        const remarks =
+            typeof payload?.remarks === "string" ? payload.remarks.trim() : undefined;
 
         if (!appointmentId) {
             return NextResponse.json({ error: "Appointment ID is required" }, { status: 400 });
@@ -458,9 +468,21 @@ export async function PATCH(req: Request) {
             return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
         }
 
+        if (
+            newStatus === AppointmentStatus.Cancelled &&
+            !(remarks && remarks.length > 0)
+        ) {
+            return NextResponse.json(
+                { error: "Cancellation reason is required" },
+                { status: 400 }
+            );
+        }
+
         const data: Prisma.AppointmentUpdateInput = {};
         if (newStatus) data.status = newStatus;
-        if (typeof remarks === "string") data.remarks = remarks;
+        if (typeof remarks === "string") {
+            data.remarks = remarks.length > 0 ? remarks : null;
+        }
 
         if (Object.keys(data).length === 0) {
             return NextResponse.json({ error: "No updates provided" }, { status: 400 });
@@ -474,8 +496,62 @@ export async function PATCH(req: Request) {
                 status: true,
                 remarks: true,
                 updatedAt: true,
+                appointment_timestart: true,
+                clinic: { select: { clinic_name: true } },
+                doctor: {
+                    select: {
+                        username: true,
+                        employee: { select: { fname: true, lname: true } },
+                    },
+                },
+                patient: {
+                    select: {
+                        username: true,
+                        student: { select: { fname: true, lname: true, email: true } },
+                        employee: { select: { fname: true, lname: true, email: true } },
+                        passwordResetTokens: {
+                            where: {
+                                type: EMAIL_VERIFICATION_TOKEN_TYPE,
+                                verified: true,
+                            },
+                            select: { contact: true },
+                        },
+                    },
+                },
             },
         });
+
+        if (newStatus && updated.patient && updated.doctor) {
+            const patientEmail = getPatientEmail(updated.patient);
+            if (patientEmail) {
+                const emailPayload = buildStatusEmail({
+                    status: newStatus,
+                    patientName: formatPatientName(updated.patient),
+                    clinicName: updated.clinic.clinic_name,
+                    schedule: formatManilaDateTime(updated.appointment_timestart),
+                    doctorName: formatDoctorName(updated.doctor),
+                    cancelReason:
+                        newStatus === AppointmentStatus.Cancelled
+                            ? remarks && remarks.length > 0
+                                ? remarks
+                                : updated.remarks ?? undefined
+                            : undefined,
+                });
+
+                if (emailPayload) {
+                    try {
+                        await sendEmail({
+                            to: patientEmail,
+                            subject: emailPayload.subject,
+                            html: emailPayload.html,
+                            text: emailPayload.text,
+                        });
+                    } catch (emailErr) {
+                        console.error("[PATCH /api/scholar/appointments] email error", emailErr);
+                    }
+                }
+            }
+        }
 
         return NextResponse.json({
             appointment_id: updated.appointment_id,

--- a/src/lib/appointment-email.ts
+++ b/src/lib/appointment-email.ts
@@ -26,7 +26,12 @@ export interface AppointmentEmailDoctor {
     employee: { fname: string | null; lname: string | null } | null;
 }
 
-export function formatPatientName(patient: AppointmentEmailPatient) {
+export type AppointmentNameSource = Pick<
+    AppointmentEmailPatient,
+    "username" | "student" | "employee"
+>;
+
+export function formatPatientName(patient: AppointmentNameSource) {
     if (patient.student?.fname && patient.student?.lname)
         return `${patient.student.fname} ${patient.student.lname}`;
     if (patient.employee?.fname && patient.employee?.lname)

--- a/src/lib/appointment-email.ts
+++ b/src/lib/appointment-email.ts
@@ -1,0 +1,222 @@
+import { AppointmentStatus } from "@prisma/client";
+
+const EMAIL_BACKGROUND_COLOR = "#f0fdf4";
+const EMAIL_BORDER_COLOR = "#bbf7d0";
+const EMAIL_TEXT_COLOR = "#065f46";
+const EMAIL_ACCENT_COLOR = "#047857";
+
+function escapeHtml(input: string) {
+    return input
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+export interface AppointmentEmailPatient {
+    username: string;
+    student: { fname: string | null; lname: string | null; email?: string | null } | null;
+    employee: { fname: string | null; lname: string | null; email?: string | null } | null;
+    passwordResetTokens: { contact: string }[];
+}
+
+export interface AppointmentEmailDoctor {
+    username: string;
+    employee: { fname: string | null; lname: string | null } | null;
+}
+
+export function formatPatientName(patient: AppointmentEmailPatient) {
+    if (patient.student?.fname && patient.student?.lname)
+        return `${patient.student.fname} ${patient.student.lname}`;
+    if (patient.employee?.fname && patient.employee?.lname)
+        return `${patient.employee.fname} ${patient.employee.lname}`;
+    return patient.username;
+}
+
+export function formatDoctorName(doctor: AppointmentEmailDoctor) {
+    if (doctor.employee?.fname && doctor.employee?.lname)
+        return `Dr. ${doctor.employee.fname} ${doctor.employee.lname}`;
+    return doctor.username.startsWith("Dr.")
+        ? doctor.username
+        : `Dr. ${doctor.username}`;
+}
+
+export function getPatientEmail(patient: AppointmentEmailPatient) {
+    const verifiedContacts = new Set(
+        patient.passwordResetTokens.map((token) => token.contact.toLowerCase()),
+    );
+
+    const studentEmail = patient.student?.email?.trim() ?? "";
+    if (studentEmail && verifiedContacts.has(studentEmail.toLowerCase())) {
+        return studentEmail;
+    }
+
+    const employeeEmail = patient.employee?.email?.trim() ?? "";
+    if (employeeEmail && verifiedContacts.has(employeeEmail.toLowerCase())) {
+        return employeeEmail;
+    }
+
+    return patient.username.includes("@") ? patient.username : "";
+}
+
+function buildTableRows(rows: { label: string; value: string }[]) {
+    return rows
+        .map(
+            (row) => `
+        <tr>
+          <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR}; font-weight: 600;">${row.label}</td>
+          <td style="padding: 8px; border: 1px solid ${EMAIL_BORDER_COLOR};">${row.value}</td>
+        </tr>`
+        )
+        .join("");
+}
+
+export function buildMoveEmail({
+    patientName,
+    doctorName,
+    clinicName,
+    oldSchedule,
+    newSchedule,
+    reason,
+}: {
+    patientName: string;
+    doctorName: string;
+    clinicName: string;
+    oldSchedule: string | null | undefined;
+    newSchedule: string | null | undefined;
+    reason: string;
+}) {
+    const rows = [
+        { label: "Doctor", value: escapeHtml(doctorName) },
+        { label: "Previous Schedule", value: escapeHtml(oldSchedule ?? "Unavailable") },
+        { label: "New Schedule", value: escapeHtml(newSchedule ?? "Unavailable") },
+        { label: "Doctor's Note", value: escapeHtml(reason) },
+    ];
+
+    const html = `
+    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: ${EMAIL_BACKGROUND_COLOR}; padding: 24px; border-radius: 16px; border: 1px solid ${EMAIL_BORDER_COLOR}; color: ${EMAIL_TEXT_COLOR};">
+      <h2 style="margin-top: 0; color: ${EMAIL_ACCENT_COLOR};">Appointment Update</h2>
+      <p style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Hello <strong style="color: inherit;">${escapeHtml(
+          patientName,
+      )}</strong>, <strong style="color: inherit;">${escapeHtml(
+          doctorName,
+      )}</strong> has updated your appointment.</p>
+      <p>Your visit at <strong>${escapeHtml(clinicName)}</strong> has been moved.</p>
+      <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+        <tbody>${buildTableRows(rows)}</tbody>
+      </table>
+      <p>Please log in to your patient portal if you need to reschedule again or have any questions.</p>
+      <p style="margin-bottom: 0;">Thank you,<br/>${escapeHtml(doctorName)}<br/>HNU Clinic</p>
+    </div>`;
+
+    const text = [
+        `Hello ${patientName},`,
+        "",
+        `${doctorName} has updated your appointment at ${clinicName}.`,
+        "",
+        `Previous Schedule: ${oldSchedule ?? "Unavailable"}`,
+        `New Schedule: ${newSchedule ?? "Unavailable"}`,
+        `Doctor's Note: ${reason}`,
+        "",
+        "Please log in to your patient portal if you need to reschedule again or have any questions.",
+        "",
+        "Thank you,",
+        doctorName,
+        "HNU Clinic",
+    ].join("\n");
+
+    return { subject: "Your appointment has been moved", html, text };
+}
+
+export function buildStatusEmail({
+    status,
+    patientName,
+    clinicName,
+    schedule,
+    doctorName,
+    cancelReason,
+}: {
+    status: AppointmentStatus;
+    patientName: string;
+    clinicName: string;
+    schedule: string | null | undefined;
+    doctorName: string;
+    cancelReason?: string | null;
+}): { subject: string; html: string; text: string } | null {
+    const safeName = escapeHtml(patientName);
+    const safeClinic = escapeHtml(clinicName);
+    const safeSchedule = escapeHtml(schedule ?? "Unavailable");
+    const safeDoctor = escapeHtml(doctorName);
+    const safeReason = cancelReason ? escapeHtml(cancelReason) : null;
+
+    const rows = [
+        { label: "Clinic", value: safeClinic },
+        { label: "Doctor", value: safeDoctor },
+        { label: "Schedule", value: safeSchedule },
+    ];
+
+    const textRows: Array<[string, string]> = [
+        ["Clinic", clinicName],
+        ["Doctor", doctorName],
+        ["Schedule", schedule ?? "Unavailable"],
+    ];
+
+    let heading = "";
+    let intro = "";
+    let outro = `Thank you,<br/>${safeDoctor}<br/>HNU Clinic`;
+    let subject = "";
+    let textIntro = "";
+    let textOutro = `Thank you,\n${doctorName}\nHNU Clinic`;
+
+    switch (status) {
+        case AppointmentStatus.Approved:
+            heading = "Appointment Approved";
+            intro = `<span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Good news, <strong style="color: inherit;">${safeName}</strong>! <strong style="color: inherit;">${safeDoctor}</strong> has approved your appointment.</span>`;
+            subject = "Your appointment has been approved";
+            textIntro = `Good news, ${patientName}! ${doctorName} has approved your appointment.`;
+            break;
+        case AppointmentStatus.Cancelled:
+            heading = "Appointment Cancelled";
+            intro = `<span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Hello <strong style="color: inherit;">${safeName}</strong>, <strong style="color: inherit;">${safeDoctor}</strong> has cancelled your appointment.</span>`;
+            subject = "Your appointment has been cancelled";
+            if (safeReason) rows.push({ label: "Cancellation Reason", value: safeReason });
+            if (cancelReason) textRows.push(["Cancellation Reason", cancelReason]);
+            outro = `If you still need assistance, please book another schedule through the patient portal.<br/><br/>Thank you,<br/>${safeDoctor}<br/>HNU Clinic`;
+            textIntro = `Hello ${patientName}, ${doctorName} has cancelled your appointment.`;
+            textOutro = `If you still need assistance, please book another schedule through the patient portal.\n\nThank you,\n${doctorName}\nHNU Clinic`;
+            break;
+        case AppointmentStatus.Completed:
+            heading = "Appointment Completed";
+            intro = `<span style="color: ${EMAIL_ACCENT_COLOR}; font-weight: 600;">Hello <strong style="color: inherit;">${safeName}</strong>, <strong style="color: inherit;">${safeDoctor}</strong> has marked your appointment as completed.</span>`;
+            subject = "Your appointment has been completed";
+            outro = `We hope you had a good visit. You can review your consultation notes and next steps inside the patient portal.<br/><br/>Thank you,<br/>${safeDoctor}<br/>HNU Clinic`;
+            textIntro = `Hello ${patientName}, ${doctorName} has marked your appointment as completed.`;
+            textOutro = `We hope you had a good visit. You can review your consultation notes and next steps inside the patient portal.\n\nThank you,\n${doctorName}\nHNU Clinic`;
+            break;
+        default:
+            return null;
+    }
+
+    const html = `
+    <div style="font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: ${EMAIL_BACKGROUND_COLOR}; padding: 24px; border-radius: 16px; border: 1px solid ${EMAIL_BORDER_COLOR}; color: ${EMAIL_TEXT_COLOR};">
+      <h2 style="margin-top: 0; color: ${EMAIL_ACCENT_COLOR};">${heading}</h2>
+      <p>${intro}</p>
+      <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+        <tbody>${buildTableRows(rows)}</tbody>
+      </table>
+      <p style="margin-bottom: 0;">${outro}</p>
+    </div>`;
+
+    const text = [
+        textIntro,
+        "",
+        ...textRows.map(([label, value]) => `${label}: ${value}`),
+        "",
+        textOutro,
+    ]
+        .join("\n")
+        .trim();
+
+    return { subject, html, text };
+}


### PR DESCRIPTION
## Summary
- add a shared appointment email helper that centralizes patient name formatting and email templates
- update the doctor appointment workflow to reuse the helper for move/approve/cancel/completed notices
- send approval and cancellation emails (with reasons) from the scholar appointment endpoint so patients are notified regardless of who updates the status

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1613fb08832795ec144fc1b1a744)