### PR TITLE
Allow formatPatientName without tokens

### DIFF
--- a/src/lib/appointment-email.ts
+++ b/src/lib/appointment-email.ts
@@ -18,7 +18,7 @@ export interface AppointmentEmailPatient {
     username: string;
     student: { fname: string | null; lname: string | null; email?: string | null } | null;
     employee: { fname: string | null; lname: string | null; email?: string | null } | null;
-    passwordResetTokens: { contact: string }[];
+    passwordResetTokens?: { contact: string }[];
 }
 
 export interface AppointmentEmailDoctor {
@@ -49,7 +49,7 @@ export function formatDoctorName(doctor: AppointmentEmailDoctor) {
 
 export function getPatientEmail(patient: AppointmentEmailPatient) {
     const verifiedContacts = new Set(
-        patient.passwordResetTokens.map((token) => token.contact.toLowerCase()),
+        (patient.passwordResetTokens ?? []).map((token) => token.contact.toLowerCase()),
     );
 
     const studentEmail = patient.student?.email?.trim() ?? "";


### PR DESCRIPTION
## Summary
- make `passwordResetTokens` optional on `AppointmentEmailPatient`
- guard `getPatientEmail` against missing tokens

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2ceab8a08327b95aa9762180f35d)