### PR TITLE
Enforce 11-digit clinic contact numbers

### DIFF
--- a/src/app/api/nurse/clinic/[id]/route.ts
+++ b/src/app/api/nurse/clinic/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Role } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
+import {
+    CLINIC_CONTACT_NUMBER_LENGTH,
+    isValidClinicContactNumber,
+} from "@/lib/clinic-contact";
 
 // GET /api/nurse/clinic/[id]
 type ClinicRouteContext = {
@@ -59,6 +63,28 @@ export async function PUT(
             return NextResponse.json({ error: "No fields provided to update" }, { status: 400 });
         }
 
+        let normalizedContactNumber: string | undefined;
+        if (clinic_contactno !== undefined) {
+            if (typeof clinic_contactno !== "string") {
+                return NextResponse.json(
+                    { error: "Clinic contact number must be provided as a string" },
+                    { status: 400 }
+                );
+            }
+
+            const trimmedContactNo = clinic_contactno.trim();
+            if (!isValidClinicContactNumber(trimmedContactNo)) {
+                return NextResponse.json(
+                    {
+                        error: `Clinic contact number must be exactly ${CLINIC_CONTACT_NUMBER_LENGTH} digits`,
+                    },
+                    { status: 400 }
+                );
+            }
+
+            normalizedContactNumber = trimmedContactNo;
+        }
+
         // Prevent renaming to an existing clinic
         if (clinic_name) {
             const duplicate = await prisma.clinic.findFirst({
@@ -77,7 +103,7 @@ export async function PUT(
             data: {
                 ...(clinic_name && { clinic_name }),
                 ...(clinic_location && { clinic_location }),
-                ...(clinic_contactno && { clinic_contactno }),
+                ...(normalizedContactNumber && { clinic_contactno: normalizedContactNumber }),
             },
         });
 

--- a/src/app/api/nurse/clinic/[id]/route.ts
+++ b/src/app/api/nurse/clinic/[id]/route.ts
@@ -4,6 +4,7 @@ import { Role } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
 import {
     CLINIC_CONTACT_NUMBER_LENGTH,
+    PH_MOBILE_PREFIX,
     isValidClinicContactNumber,
 } from "@/lib/clinic-contact";
 
@@ -76,7 +77,7 @@ export async function PUT(
             if (!isValidClinicContactNumber(trimmedContactNo)) {
                 return NextResponse.json(
                     {
-                        error: `Clinic contact number must be exactly ${CLINIC_CONTACT_NUMBER_LENGTH} digits`,
+                        error: `Clinic contact number must be a valid Philippine mobile number (${CLINIC_CONTACT_NUMBER_LENGTH} digits starting with ${PH_MOBILE_PREFIX}).`,
                     },
                     { status: 400 }
                 );

--- a/src/app/api/nurse/clinic/route.ts
+++ b/src/app/api/nurse/clinic/route.ts
@@ -4,6 +4,7 @@ import { Role } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
 import {
     CLINIC_CONTACT_NUMBER_LENGTH,
+    PH_MOBILE_PREFIX,
     isValidClinicContactNumber,
 } from "@/lib/clinic-contact";
 
@@ -45,7 +46,7 @@ export async function POST(req: NextRequest) {
         if (!isValidClinicContactNumber(trimmedContactNo)) {
             return NextResponse.json(
                 {
-                    error: `Clinic contact number must be exactly ${CLINIC_CONTACT_NUMBER_LENGTH} digits`,
+                    error: `Clinic contact number must be a valid Philippine mobile number (${CLINIC_CONTACT_NUMBER_LENGTH} digits starting with ${PH_MOBILE_PREFIX}).`,
                 },
                 { status: 400 }
             );

--- a/src/app/api/nurse/clinic/route.ts
+++ b/src/app/api/nurse/clinic/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Role } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
+import {
+    CLINIC_CONTACT_NUMBER_LENGTH,
+    isValidClinicContactNumber,
+} from "@/lib/clinic-contact";
 
 // GET /api/nurse/clinic
 export async function GET() {
@@ -29,11 +33,29 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "All fields are required" }, { status: 400 });
         }
 
+        if (typeof clinic_contactno !== "string") {
+            return NextResponse.json(
+                { error: "Clinic contact number must be provided as a string" },
+                { status: 400 }
+            );
+        }
+
+        const trimmedContactNo = clinic_contactno.trim();
+
+        if (!isValidClinicContactNumber(trimmedContactNo)) {
+            return NextResponse.json(
+                {
+                    error: `Clinic contact number must be exactly ${CLINIC_CONTACT_NUMBER_LENGTH} digits`,
+                },
+                { status: 400 }
+            );
+        }
+
         const newClinic = await prisma.clinic.create({
             data: {
                 clinic_name,
                 clinic_location,
-                clinic_contactno
+                clinic_contactno: trimmedContactNo,
             },
         });
 

--- a/src/app/nurse/clinic/page.tsx
+++ b/src/app/nurse/clinic/page.tsx
@@ -36,6 +36,7 @@ import { formatManilaISODate, formatTimeRange, PH_TIME_ZONE } from "@/lib/time";
 import { toast } from "sonner";
 import {
     CLINIC_CONTACT_NUMBER_LENGTH,
+    PH_MOBILE_PREFIX,
     isValidClinicContactNumber,
     sanitizeClinicContactInput,
 } from "@/lib/clinic-contact";
@@ -84,7 +85,9 @@ const STATUS_BADGE_CLASSES: Record<string, string> = {
 
 const ACTIVE_STATUSES = new Set(["Pending", "Approved", "Moved"]);
 
-const CONTACT_NUMBER_ERROR_MESSAGE = `Clinic contact number must be exactly ${CLINIC_CONTACT_NUMBER_LENGTH} digits.`;
+const CONTACT_NUMBER_ERROR_MESSAGE =
+    `Clinic contact number must be a valid Philippine mobile number (${CLINIC_CONTACT_NUMBER_LENGTH} digits starting with ${PH_MOBILE_PREFIX}).`;
+const CONTACT_INPUT_PATTERN = `${PH_MOBILE_PREFIX}[0-9]{${CLINIC_CONTACT_NUMBER_LENGTH - PH_MOBILE_PREFIX.length}}`;
 
 export default function NurseClinicPage() {
     const [clinics, setClinics] = useState<Clinic[]>([]);
@@ -377,7 +380,7 @@ export default function NurseClinicPage() {
                                                 type="tel"
                                                 inputMode="numeric"
                                                 maxLength={CLINIC_CONTACT_NUMBER_LENGTH}
-                                                pattern="[0-9]{11}"
+                                                pattern={CONTACT_INPUT_PATTERN}
                                                 onInput={(event) => {
                                                     event.currentTarget.value = sanitizeClinicContactInput(
                                                         event.currentTarget.value
@@ -460,7 +463,7 @@ export default function NurseClinicPage() {
                                                                 type="tel"
                                                                 inputMode="numeric"
                                                                 maxLength={CLINIC_CONTACT_NUMBER_LENGTH}
-                                                                pattern="[0-9]{11}"
+                                                                pattern={CONTACT_INPUT_PATTERN}
                                                                 onInput={(event) => {
                                                                     event.currentTarget.value = sanitizeClinicContactInput(
                                                                         event.currentTarget.value

--- a/src/app/nurse/clinic/page.tsx
+++ b/src/app/nurse/clinic/page.tsx
@@ -34,6 +34,11 @@ import {
 } from "@/components/ui/select";
 import { formatManilaISODate, formatTimeRange, PH_TIME_ZONE } from "@/lib/time";
 import { toast } from "sonner";
+import {
+    CLINIC_CONTACT_NUMBER_LENGTH,
+    isValidClinicContactNumber,
+    sanitizeClinicContactInput,
+} from "@/lib/clinic-contact";
 
 import NurseClinicLoading from "./loading";
 
@@ -78,6 +83,8 @@ const STATUS_BADGE_CLASSES: Record<string, string> = {
 };
 
 const ACTIVE_STATUSES = new Set(["Pending", "Approved", "Moved"]);
+
+const CONTACT_NUMBER_ERROR_MESSAGE = `Clinic contact number must be exactly ${CLINIC_CONTACT_NUMBER_LENGTH} digits.`;
 
 export default function NurseClinicPage() {
     const [clinics, setClinics] = useState<Clinic[]>([]);
@@ -251,12 +258,23 @@ export default function NurseClinicPage() {
 
     async function handleAddClinic(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
-        setLoading(true);
         const formData = new FormData(e.currentTarget);
+        const clinic_name = String(formData.get("clinic_name") ?? "").trim();
+        const clinic_location = String(formData.get("clinic_location") ?? "").trim();
+        const clinic_contactno = sanitizeClinicContactInput(
+            String(formData.get("clinic_contactno") ?? "")
+        );
+
+        if (!isValidClinicContactNumber(clinic_contactno)) {
+            toast.error(CONTACT_NUMBER_ERROR_MESSAGE);
+            return;
+        }
+
+        setLoading(true);
         const payload = {
-            clinic_name: formData.get("clinic_name"),
-            clinic_location: formData.get("clinic_location"),
-            clinic_contactno: formData.get("clinic_contactno"),
+            clinic_name,
+            clinic_location,
+            clinic_contactno,
         };
 
         const res = await fetch("/api/nurse/clinic", {
@@ -280,12 +298,22 @@ export default function NurseClinicPage() {
         e.preventDefault();
         if (!selectedClinic) return;
 
-        setLoading(true);
         const formData = new FormData(e.currentTarget);
+        const clinic_location = String(formData.get("clinic_location") ?? "").trim();
+        const clinic_contactno = sanitizeClinicContactInput(
+            String(formData.get("clinic_contactno") ?? "")
+        );
+
+        if (!isValidClinicContactNumber(clinic_contactno)) {
+            toast.error(CONTACT_NUMBER_ERROR_MESSAGE);
+            return;
+        }
+
+        setLoading(true);
         const payload = {
             clinic_name: selectedClinic.clinic_name,
-            clinic_location: formData.get("clinic_location"),
-            clinic_contactno: formData.get("clinic_contactno"),
+            clinic_location,
+            clinic_contactno,
         };
 
         const res = await fetch(`/api/nurse/clinic/${selectedClinic.clinic_id}`, {
@@ -343,7 +371,19 @@ export default function NurseClinicPage() {
                                         </div>
                                         <div>
                                             <Label className="block mb-1">Contact No</Label>
-                                            <Input name="clinic_contactno" required />
+                                            <Input
+                                                name="clinic_contactno"
+                                                required
+                                                type="tel"
+                                                inputMode="numeric"
+                                                maxLength={CLINIC_CONTACT_NUMBER_LENGTH}
+                                                pattern="[0-9]{11}"
+                                                onInput={(event) => {
+                                                    event.currentTarget.value = sanitizeClinicContactInput(
+                                                        event.currentTarget.value
+                                                    );
+                                                }}
+                                            />
                                         </div>
                                         <DialogFooter>
                                             <Button
@@ -417,6 +457,15 @@ export default function NurseClinicPage() {
                                                                 name="clinic_contactno"
                                                                 defaultValue={clinic.clinic_contactno}
                                                                 required
+                                                                type="tel"
+                                                                inputMode="numeric"
+                                                                maxLength={CLINIC_CONTACT_NUMBER_LENGTH}
+                                                                pattern="[0-9]{11}"
+                                                                onInput={(event) => {
+                                                                    event.currentTarget.value = sanitizeClinicContactInput(
+                                                                        event.currentTarget.value
+                                                                    );
+                                                                }}
                                                             />
                                                         </div>
                                                         <DialogFooter>

--- a/src/lib/clinic-contact.ts
+++ b/src/lib/clinic-contact.ts
@@ -1,9 +1,12 @@
 export const CLINIC_CONTACT_NUMBER_LENGTH = 11;
+export const PH_MOBILE_PREFIX = "09";
 
-const DIGITS_ONLY_PATTERN = new RegExp(`^\\d{${CLINIC_CONTACT_NUMBER_LENGTH}}$`);
+const PH_MOBILE_PATTERN = new RegExp(
+    `^${PH_MOBILE_PREFIX}\\d{${CLINIC_CONTACT_NUMBER_LENGTH - PH_MOBILE_PREFIX.length}}$`
+);
 
 export function isValidClinicContactNumber(value: unknown): value is string {
-    return typeof value === "string" && DIGITS_ONLY_PATTERN.test(value.trim());
+    return typeof value === "string" && PH_MOBILE_PATTERN.test(value.trim());
 }
 
 export function sanitizeClinicContactInput(value: string): string {

--- a/src/lib/clinic-contact.ts
+++ b/src/lib/clinic-contact.ts
@@ -1,0 +1,11 @@
+export const CLINIC_CONTACT_NUMBER_LENGTH = 11;
+
+const DIGITS_ONLY_PATTERN = new RegExp(`^\\d{${CLINIC_CONTACT_NUMBER_LENGTH}}$`);
+
+export function isValidClinicContactNumber(value: unknown): value is string {
+    return typeof value === "string" && DIGITS_ONLY_PATTERN.test(value.trim());
+}
+
+export function sanitizeClinicContactInput(value: string): string {
+    return value.replace(/\D/g, "").slice(0, CLINIC_CONTACT_NUMBER_LENGTH);
+}


### PR DESCRIPTION
## Summary
- add shared clinic contact helper utilities and wire them into both nurse clinic API routes so they now reject contact numbers that are not 11 digits
- tighten the nurse clinic management UI to sanitize contact input, validate before submitting, and present numeric-only inputs capped at 11 digits

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5e37b7c08327a4267bf5b96158bb)