### PR TITLE
Sanitize medical condition inputs

### DIFF
--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -296,9 +296,11 @@ export default function DoctorPatientsPage() {
 
         setUpdatingPatientId(selectedRecord.id);
         const form = event.currentTarget;
+        const rawMedicalCond = (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value ?? "";
+        const sanitizedMedicalCond = formatMedicalHistory(parseMedicalHistory(rawMedicalCond));
         const payload = {
             type: selectedRecord.patientType,
-            medical_cond: (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value,
+            medical_cond: sanitizedMedicalCond || null,
             allergies: (form.elements.namedItem("allergies") as HTMLInputElement)?.value,
         };
 
@@ -725,7 +727,7 @@ export default function DoctorPatientsPage() {
                                                 <Input
                                                     id="medical_cond"
                                                     name="medical_cond"
-                                                    defaultValue={selectedRecord.medical_cond || ""}
+                                                    defaultValue={selectedMedicalHistoryText || ""}
                                                 />
                                             </div>
                                             <div>

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -23,6 +23,7 @@ import NurseRecordsLoading from "./loading";
 import { PatientDirectoryTable } from "./patient-directory-table";
 import type { RecordDetailsDialogTab } from "./patient-record-dialog";
 import type { PatientRecord } from "./types";
+import { formatMedicalHistory, parseMedicalHistory } from "@/lib/medical-history";
 
 const RecordDetailsDialog = dynamic(
     () => import("./patient-record-dialog").then((mod) => mod.RecordDetailsDialog),
@@ -137,9 +138,11 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
 
         setUpdatingPatientId(selectedRecord.id);
         const form = event.currentTarget;
+        const rawMedicalCond = (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value ?? "";
+        const sanitizedMedicalCond = formatMedicalHistory(parseMedicalHistory(rawMedicalCond));
         const body = {
             type: selectedRecord.patientType,
-            medical_cond: (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value,
+            medical_cond: sanitizedMedicalCond || null,
             allergies: (form.elements.namedItem("allergies") as HTMLInputElement)?.value,
         };
 

--- a/src/app/nurse/records/patient-record-dialog.tsx
+++ b/src/app/nurse/records/patient-record-dialog.tsx
@@ -198,7 +198,11 @@ function RecordDetailsDialogComponent({
                                     <Label className="mb-1 block font-medium" htmlFor="medical_cond">
                                         Medical Conditions
                                     </Label>
-                                    <Input id="medical_cond" name="medical_cond" defaultValue={record.medical_cond || ""} />
+                                    <Input
+                                        id="medical_cond"
+                                        name="medical_cond"
+                                        defaultValue={medicalHistoryText || ""}
+                                    />
                                 </div>
                                 <div>
                                     <Label className="mb-1 block font-medium" htmlFor="allergies">

--- a/src/lib/patient-records-update.ts
+++ b/src/lib/patient-records-update.ts
@@ -18,7 +18,7 @@ export const patientRecordPatchSchema = z.object({
     address: z.string().optional(),
     bloodtype: z.enum(BLOOD_TYPES).nullable().optional(),
     allergies: z.string().optional(),
-    medical_cond: z.string().optional(),
+    medical_cond: z.string().optional().nullable(),
     emergency: z
         .object({
             name: z.string().optional(),
@@ -38,7 +38,7 @@ export async function updatePatientRecordEntry(id: string, input: PatientRecordP
         address: data.address ?? undefined,
         bloodtype: data.bloodtype !== undefined ? { set: data.bloodtype } : undefined,
         allergies: data.allergies ?? undefined,
-        medical_cond: data.medical_cond ?? undefined,
+        medical_cond: data.medical_cond === undefined ? undefined : data.medical_cond,
         emergencyco_name: data.emergency?.name ?? undefined,
         emergencyco_num: data.emergency?.num ?? undefined,
         emergencyco_relation: data.emergency?.relation ?? undefined,


### PR DESCRIPTION
## Summary
- show medical conditions in their formatted form in the nurse and doctor dialogs and sanitize the values before persisting updates
- normalize the medical condition payload on the client so that updates store human-readable strings or clear the field when empty
- allow the API schema to accept nullable medical condition values so cleared entries are persisted properly

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d09cf2e1883279d6ea3439cf40a11)