### PR TITLE
Fix Basic Education year level saving

### DIFF
--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -114,6 +114,22 @@ const programOptions: Record<string, string[]> = {
 const departmentOptions = Object.values(patientDepartmentEnumMap);
 const bloodTypeOptions = Object.values(patientBloodTypeEnumMap);
 
+const collegeYearLevels = ["1st Year", "2nd Year", "3rd Year", "4th Year", "5th Year"] as const;
+
+const basicEducationYearLevels: Record<string, string[]> = {
+    Kindergarten: ["Kindergarten 1", "Kindergarten 2"],
+    Elementary: ["Grade 1", "Grade 2", "Grade 3", "Grade 4", "Grade 5", "Grade 6"],
+    "Junior High School": ["Grade 7", "Grade 8", "Grade 9", "Grade 10"],
+    "Senior High School": ["Grade 11", "Grade 12"],
+};
+
+function mergeYearLevelOptions(options: string[], current?: string | null) {
+    if (current && current.trim().length > 0 && !options.includes(current)) {
+        return [current, ...options];
+    }
+    return options;
+}
+
 export type PatientAccountPageClientProps = {
     initialProfile: PatientAccountProfile | null;
     initialPatientType: string | null;
@@ -150,23 +166,12 @@ export function PatientAccountPageClient({
         }
     }, [initialProfileLoaded]);
 
-    const getYearLevelOptions = (dept: string, program?: string) => {
+    const getYearLevelOptions = (dept: string, program?: string, current?: string | null) => {
         if (dept === "Basic Education Department") {
-            switch (program) {
-                case "Kindergarten":
-                    return ["Kindergarten 1", "Kindergarten 2"];
-                case "Elementary":
-                    return ["Grade 1", "Grade 2", "Grade 3", "Grade 4", "Grade 5", "Grade 6"];
-                case "Junior High School":
-                    return ["Grade 7", "Grade 8", "Grade 9", "Grade 10"];
-                case "Senior High School":
-                    return ["Grade 11", "Grade 12"];
-                default:
-                    return [];
-            }
-        } else {
-            return ["1st Year", "2nd Year", "3rd Year", "4th Year", "5th Year"];
+            const options = basicEducationYearLevels[program ?? ""] ?? [];
+            return mergeYearLevelOptions(options, current);
         }
+        return mergeYearLevelOptions([...collegeYearLevels], current);
     };
 
     const loadProfile = useCallback(async ({ fromRefresh = false } = {}) => {
@@ -911,14 +916,26 @@ export function PatientAccountPageClient({
                                                 <Select
                                                     value={profile.year_level || ""}
                                                     onValueChange={(val) => setProfile({ ...profile, year_level: val })}
+                                                    disabled={
+                                                        profile.department === "Basic Education Department" &&
+                                                        !profile.program
+                                                    }
                                                 >
                                                     <SelectTrigger>
-                                                        <SelectValue placeholder="Select year level" />
+                                                        <SelectValue
+                                                            placeholder={
+                                                                profile.department === "Basic Education Department" &&
+                                                                !profile.program
+                                                                    ? "Select program first"
+                                                                    : "Select year level"
+                                                            }
+                                                        />
                                                     </SelectTrigger>
                                                     <SelectContent>
                                                         {getYearLevelOptions(
                                                             profile.department || "",
-                                                            profile.program ?? undefined
+                                                            profile.program ?? undefined,
+                                                            profile.year_level ?? null
                                                         ).map((lvl) => (
                                                             <SelectItem key={lvl} value={lvl}>
                                                                 {lvl}

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -149,7 +149,7 @@ export function normalizePatientAccountProfile(
         gender: raw.gender || "",
         department: raw.department ? patientDepartmentEnumMap[raw.department] || "" : "",
         program: raw.program || "",
-        year_level: raw.year_level ? patientYearLevelEnumMap[raw.year_level] || "" : "",
+        year_level: raw.year_level ? patientYearLevelEnumMap[raw.year_level] || raw.year_level || "" : "",
         emergencyco_name: raw.emergencyco_name || "",
         emergencyco_num: raw.emergencyco_num || "",
         emergencyco_relation: raw.emergencyco_relation || "",

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -59,9 +59,25 @@ export const patientYearLevelEnumMap: Record<string, string> = {
     SENIOR_HIGH: "Senior High School",
 };
 
-export const patientReverseYearLevelEnumMap = Object.fromEntries(
-    Object.entries(patientYearLevelEnumMap).map(([key, val]) => [val, key])
-);
+export const patientReverseYearLevelEnumMap: Record<string, string> = {
+    ...Object.fromEntries(
+        Object.entries(patientYearLevelEnumMap).map(([key, val]) => [val, key])
+    ),
+    "Kindergarten 1": "KINDERGARTEN",
+    "Kindergarten 2": "KINDERGARTEN",
+    "Grade 1": "ELEMENTARY",
+    "Grade 2": "ELEMENTARY",
+    "Grade 3": "ELEMENTARY",
+    "Grade 4": "ELEMENTARY",
+    "Grade 5": "ELEMENTARY",
+    "Grade 6": "ELEMENTARY",
+    "Grade 7": "JUNIOR_HIGH",
+    "Grade 8": "JUNIOR_HIGH",
+    "Grade 9": "JUNIOR_HIGH",
+    "Grade 10": "JUNIOR_HIGH",
+    "Grade 11": "SENIOR_HIGH",
+    "Grade 12": "SENIOR_HIGH",
+};
 
 export const patientBloodTypeEnumMap: Record<string, string> = {
     A_POS: "A+",


### PR DESCRIPTION
## Summary
- add explicit reverse mapping for kindergarten and grade-specific year levels so that Basic Education students serialize correctly

## Testing
- `./node_modules/.bin/eslint src/app/patient/account/types.ts`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2dc85c8c83278daf5db560c84b9f)