### PR TITLE
Allow duplicate IDs across roles during account creation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Users {
 model Student {
   stud_user_id         String        @id @default(dbgenerated("concat('STUD_', (floor((random() * (1000000)::double precision)))::integer)"))
   user_id              String        @unique
-  student_id           String        @unique
+  student_id           String
   fname                String
   mname                String?
   lname                String
@@ -66,12 +66,14 @@ model Student {
   bloodtype            BloodType?
   email                String?       @unique
   user                 Users         @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@index([student_id])
 }
 
 model Employee {
   emp_id               String        @id @default(dbgenerated("concat('EMP_', (floor((random() * (1000000)::double precision)))::integer)"))
   user_id              String        @unique
-  employee_id          String        @unique
+  employee_id          String
   fname                String
   mname                String?
   lname                String
@@ -88,6 +90,8 @@ model Employee {
   bloodtype            BloodType?
   email                String?       @unique
   user                 Users         @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@index([employee_id])
 }
 
 model MedInventory {

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -33,6 +33,13 @@ const bloodTypeEnumMap: Record<string, string> = {
 };
 
 // ---------------- UNIQUE ID HELPERS ----------------
+class DuplicateRoleAccountError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "DuplicateRoleAccountError";
+    }
+}
+
 async function ensureUniqueUsername(base: string): Promise<string> {
     let candidate = base;
     let n = 1;
@@ -42,22 +49,30 @@ async function ensureUniqueUsername(base: string): Promise<string> {
     return candidate;
 }
 
-async function ensureUniqueStudentId(value: string): Promise<string> {
-    let id = value;
-    let n = 1;
-    while (await prisma.student.findUnique({ where: { student_id: id } })) {
-        id = `${value}-${n++}`;
+async function assertStudentIdAvailableForRole(studentId: string, role: Role) {
+    const existingStudents = await prisma.student.findMany({
+        where: { student_id: studentId },
+        include: { user: { select: { role: true } } },
+    });
+
+    const hasSameRole = existingStudents.some((student) => student.user?.role === role);
+
+    if (hasSameRole) {
+        throw new DuplicateRoleAccountError("An account with this student ID already exists for this role.");
     }
-    return id;
 }
 
-async function ensureUniqueEmployeeId(value: string): Promise<string> {
-    let id = value;
-    let n = 1;
-    while (await prisma.employee.findUnique({ where: { employee_id: id } })) {
-        id = `${value}-${n++}`;
+async function assertEmployeeIdAvailableForRole(employeeId: string, role: Role) {
+    const existingEmployees = await prisma.employee.findMany({
+        where: { employee_id: employeeId },
+        include: { user: { select: { role: true } } },
+    });
+
+    const hasSameRole = existingEmployees.some((employee) => employee.user?.role === role);
+
+    if (hasSameRole) {
+        throw new DuplicateRoleAccountError("An account with this employee ID already exists for this role.");
     }
-    return id;
 }
 
 // ---------------- CREATE USER ----------------
@@ -67,6 +82,22 @@ export async function POST(req: Request) {
 
         const payload = await req.json();
         const roleEnum = payload.role as Role;
+
+        if (roleEnum === Role.SCHOLAR) {
+            await assertStudentIdAvailableForRole(payload.school_id, roleEnum);
+        }
+
+        if (roleEnum === Role.PATIENT && payload.patientType === "student") {
+            await assertStudentIdAvailableForRole(payload.student_id, roleEnum);
+        }
+
+        if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
+            await assertEmployeeIdAvailableForRole(payload.employee_id, roleEnum);
+        }
+
+        if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
+            await assertEmployeeIdAvailableForRole(payload.employee_id, roleEnum);
+        }
 
         // Determine username
         let username: string;
@@ -124,7 +155,6 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.student_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -132,7 +162,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: payload.student_id,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,
@@ -142,29 +172,26 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
                     user_id: newUser.user_id,
-                    employee_id: uniqueEmployeeId,
+                    employee_id: payload.employee_id,
                     ...sharedProfileData,
                 },
             });
         }
 
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
                     user_id: newUser.user_id,
-                    employee_id: uniqueEmployeeId,
+                    employee_id: payload.employee_id,
                     ...sharedProfileData,
                 },
             });
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.school_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -172,7 +199,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: payload.school_id,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,
@@ -189,6 +216,10 @@ export async function POST(req: Request) {
         const authResponse = handleAuthError(err);
         if (authResponse) return authResponse;
         console.error("[POST /api/nurse/accounts]", err);
+
+        if (err instanceof DuplicateRoleAccountError) {
+            return NextResponse.json({ error: err.message }, { status: 400 });
+        }
 
         if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
             const field = (err.meta?.target as string[])?.[0] ?? "field";

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import type { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { ipKey, withRateLimit } from "@/lib/rate-limit";
 
-const baseSelect = {
+const studentSelect = Prisma.validator<Prisma.StudentSelect>()({
     fname: true,
     lname: true,
     user: {
@@ -14,11 +14,23 @@ const baseSelect = {
             password: true,
         },
     },
-} satisfies Prisma.StudentSelect & Prisma.EmployeeSelect;
+});
+
+const employeeSelect = Prisma.validator<Prisma.EmployeeSelect>()({
+    fname: true,
+    lname: true,
+    user: {
+        select: {
+            user_id: true,
+            role: true,
+            password: true,
+        },
+    },
+});
 
 type MinimalUserRelation =
-    | Prisma.StudentGetPayload<{ select: typeof baseSelect }>
-    | Prisma.EmployeeGetPayload<{ select: typeof baseSelect }>;
+    | Prisma.StudentGetPayload<{ select: typeof studentSelect }>
+    | Prisma.EmployeeGetPayload<{ select: typeof employeeSelect }>;
 
 async function handler(req: Request) {
     try {
@@ -46,7 +58,7 @@ async function handler(req: Request) {
             }
             userRecord = await prisma.employee.findUnique({
                 where: { employee_id },
-                select: baseSelect,
+                select: employeeSelect,
             });
         } else if (normalizedRole === "SCHOLAR") {
             if (typeof school_id !== "string" || school_id.length === 0) {
@@ -57,7 +69,7 @@ async function handler(req: Request) {
             }
             userRecord = await prisma.student.findUnique({
                 where: { student_id: school_id },
-                select: baseSelect,
+                select: studentSelect,
             });
         } else if (normalizedRole === "PATIENT") {
             if (typeof patient_id !== "string" || patient_id.length === 0) {
@@ -70,11 +82,11 @@ async function handler(req: Request) {
             const [studentRecord, employeeRecord] = await Promise.all([
                 prisma.student.findUnique({
                     where: { student_id: patient_id },
-                    select: baseSelect,
+                    select: studentSelect,
                 }),
                 prisma.employee.findUnique({
                     where: { employee_id: patient_id },
-                    select: baseSelect,
+                    select: employeeSelect,
                 }),
             ]);
 

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,17 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { ipKey, withRateLimit } from "@/lib/rate-limit";
-
-type MinimalUserRelation = {
-    fname: string;
-    lname: string;
-    user: {
-        user_id: string;
-        role: string;
-        password: string;
-    } | null;
-};
 
 const baseSelect = {
     fname: true,
@@ -23,7 +14,9 @@ const baseSelect = {
             password: true,
         },
     },
-} as const;
+} satisfies Prisma.StudentSelect & Prisma.EmployeeSelect;
+
+type MinimalUserRelation = Prisma.StudentGetPayload<{ select: typeof baseSelect }>;
 
 async function handler(req: Request) {
     try {

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -16,7 +16,9 @@ const baseSelect = {
     },
 } satisfies Prisma.StudentSelect & Prisma.EmployeeSelect;
 
-type MinimalUserRelation = Prisma.StudentGetPayload<{ select: typeof baseSelect }>;
+type MinimalUserRelation =
+    | Prisma.StudentGetPayload<{ select: typeof baseSelect }>
+    | Prisma.EmployeeGetPayload<{ select: typeof baseSelect }>;
 
 async function handler(req: Request) {
     try {


### PR DESCRIPTION
## Summary
- add role-aware validation in the nurse account creation API so duplicate IDs are only blocked for the same role
- allow shared student and employee IDs across roles by removing unique constraints while keeping lookup indexes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e676d657c8327a6d56f39a381b5a4)