### PR TITLE
Allow account IDs to be reused across roles

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Users {
 model Student {
   stud_user_id         String        @id @default(dbgenerated("concat('STUD_', (floor((random() * (1000000)::double precision)))::integer)"))
   user_id              String        @unique
-  student_id           String        @unique
+  student_id           String
   fname                String
   mname                String?
   lname                String
@@ -66,12 +66,14 @@ model Student {
   bloodtype            BloodType?
   email                String?       @unique
   user                 Users         @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@index([student_id])
 }
 
 model Employee {
   emp_id               String        @id @default(dbgenerated("concat('EMP_', (floor((random() * (1000000)::double precision)))::integer)"))
   user_id              String        @unique
-  employee_id          String        @unique
+  employee_id          String
   fname                String
   mname                String?
   lname                String
@@ -88,6 +90,8 @@ model Employee {
   bloodtype            BloodType?
   email                String?       @unique
   user                 Users         @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
+  @@index([employee_id])
 }
 
 model MedInventory {

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -42,24 +42,6 @@ async function ensureUniqueUsername(base: string): Promise<string> {
     return candidate;
 }
 
-async function ensureUniqueStudentId(value: string): Promise<string> {
-    let id = value;
-    let n = 1;
-    while (await prisma.student.findUnique({ where: { student_id: id } })) {
-        id = `${value}-${n++}`;
-    }
-    return id;
-}
-
-async function ensureUniqueEmployeeId(value: string): Promise<string> {
-    let id = value;
-    let n = 1;
-    while (await prisma.employee.findUnique({ where: { employee_id: id } })) {
-        id = `${value}-${n++}`;
-    }
-    return id;
-}
-
 // ---------------- CREATE USER ----------------
 export async function POST(req: Request) {
     try {
@@ -68,21 +50,66 @@ export async function POST(req: Request) {
         const payload = await req.json();
         const roleEnum = payload.role as Role;
 
-        // Determine username
-        let username: string;
+        // Determine username and enforce per-role ID uniqueness
+        let usernameBase: string;
+        let idValue: string;
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            username = payload.employee_id;
+            usernameBase = payload.employee_id;
+            idValue = payload.employee_id;
         } else if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            username = payload.student_id;
+            usernameBase = payload.student_id;
+            idValue = payload.student_id;
         } else if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            username = payload.employee_id;
+            usernameBase = payload.employee_id;
+            idValue = payload.employee_id;
         } else if (roleEnum === Role.SCHOLAR) {
-            username = payload.school_id;
+            usernameBase = payload.school_id;
+            idValue = payload.school_id;
         } else {
-            username = `${payload.fname.toLowerCase()}.${payload.lname.toLowerCase()}`;
+            usernameBase = `${payload.fname.toLowerCase()}.${payload.lname.toLowerCase()}`;
+            idValue = usernameBase;
         }
 
-        const finalUsername = await ensureUniqueUsername(username);
+        if (!idValue || typeof idValue !== "string") {
+            return NextResponse.json(
+                { error: "A valid ID number is required to create this account." },
+                { status: 400 }
+            );
+        }
+
+        if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR || (roleEnum === Role.PATIENT && payload.patientType === "employee")) {
+            const existingEmployee = await prisma.employee.findFirst({
+                where: {
+                    employee_id: idValue,
+                    user: { role: roleEnum },
+                },
+            });
+
+            if (existingEmployee) {
+                return NextResponse.json(
+                    { error: "An account with this employee ID already exists for the selected role." },
+                    { status: 400 }
+                );
+            }
+        }
+
+        if (roleEnum === Role.SCHOLAR || (roleEnum === Role.PATIENT && payload.patientType === "student")) {
+            const existingStudent = await prisma.student.findFirst({
+                where: {
+                    student_id: idValue,
+                    user: { role: roleEnum },
+                },
+            });
+
+            if (existingStudent) {
+                return NextResponse.json(
+                    { error: "An account with this student ID already exists for the selected role." },
+                    { status: 400 }
+                );
+            }
+        }
+
+        const finalUsername = await ensureUniqueUsername(`${usernameBase}-${roleEnum.toLowerCase()}`);
 
         // Generate password
         const plainPassword = generatePassword();
@@ -124,7 +151,6 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.student_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -132,7 +158,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: idValue,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,
@@ -142,29 +168,26 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
                     user_id: newUser.user_id,
-                    employee_id: uniqueEmployeeId,
+                    employee_id: idValue,
                     ...sharedProfileData,
                 },
             });
         }
 
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
                     user_id: newUser.user_id,
-                    employee_id: uniqueEmployeeId,
+                    employee_id: idValue,
                     ...sharedProfileData,
                 },
             });
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.school_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -172,7 +195,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: idValue,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,
@@ -182,7 +205,7 @@ export async function POST(req: Request) {
         }
 
         return NextResponse.json({
-            id: username.replace(/-\d+$/, ""), // hide "-1" suffix if any
+            id: idValue,
             password: plainPassword,
         });
     } catch (err) {

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,17 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { ipKey, withRateLimit } from "@/lib/rate-limit";
-
-type MinimalUserRelation = {
-    fname: string;
-    lname: string;
-    user: {
-        user_id: string;
-        role: string;
-        password: string;
-    } | null;
-};
 
 const baseSelect = {
     fname: true,
@@ -23,7 +14,9 @@ const baseSelect = {
             password: true,
         },
     },
-} as const;
+} satisfies Prisma.EmployeeSelect & Prisma.StudentSelect;
+
+type MinimalUserRelation = Prisma.EmployeeGetPayload<{ select: typeof baseSelect }>;
 
 async function handler(req: Request) {
     try {


### PR DESCRIPTION
## Summary
- allow account creation to reuse an ID across different roles while blocking duplicates within the same role
- generate role-scoped usernames and store the provided ID without suffix adjustments
- relax student and employee ID uniqueness constraints while indexing those fields

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6fce75cc832786fdc8a07f581127)