### PR TITLE
Enforce role-specific ID uniqueness for nurse accounts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Users {
 model Student {
   stud_user_id         String        @id @default(dbgenerated("concat('STUD_', (floor((random() * (1000000)::double precision)))::integer)"))
   user_id              String        @unique
-  student_id           String        @unique
+  student_id           String
   fname                String
   mname                String?
   lname                String

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -33,6 +33,12 @@ const bloodTypeEnumMap: Record<string, string> = {
 };
 
 // ---------------- UNIQUE ID HELPERS ----------------
+const numericIdPattern = /^\d+$/;
+
+function isNumericId(value: unknown): value is string {
+    return typeof value === "string" && numericIdPattern.test(value.trim());
+}
+
 async function ensureUniqueUsername(base: string): Promise<string> {
     let candidate = base;
     let n = 1;
@@ -82,9 +88,30 @@ export async function POST(req: Request) {
         const payload = await req.json();
         const roleEnum = payload.role as Role;
 
+        const trimmedStudentId = typeof payload.student_id === "string" ? payload.student_id.trim() : "";
+        const trimmedEmployeeId = typeof payload.employee_id === "string" ? payload.employee_id.trim() : "";
+        const trimmedSchoolId = typeof payload.school_id === "string" ? payload.school_id.trim() : "";
+
+        // Validate numeric ID inputs by role
+        if (roleEnum === Role.PATIENT && payload.patientType === "student" && !isNumericId(trimmedStudentId)) {
+            return NextResponse.json({ error: "Student ID must contain numbers only." }, { status: 400 });
+        }
+
+        if (roleEnum === Role.PATIENT && payload.patientType === "employee" && !isNumericId(trimmedEmployeeId)) {
+            return NextResponse.json({ error: "Employee ID must contain numbers only." }, { status: 400 });
+        }
+
+        if ((roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) && !isNumericId(trimmedEmployeeId)) {
+            return NextResponse.json({ error: "Employee ID must contain numbers only." }, { status: 400 });
+        }
+
+        if (roleEnum === Role.SCHOLAR && !isNumericId(trimmedSchoolId)) {
+            return NextResponse.json({ error: "School ID must contain numbers only." }, { status: 400 });
+        }
+
         // Pre-validate role-specific ID reuse to avoid creating orphaned user rows
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const duplicateStudent = await existingStudentWithRole(payload.student_id, Role.PATIENT);
+            const duplicateStudent = await existingStudentWithRole(trimmedStudentId, Role.PATIENT);
             if (duplicateStudent) {
                 return NextResponse.json(
                     { error: "A patient account with this student ID already exists." },
@@ -94,7 +121,7 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, Role.PATIENT);
+            const duplicateEmployee = await existingEmployeeWithRole(trimmedEmployeeId, Role.PATIENT);
             if (duplicateEmployee) {
                 return NextResponse.json(
                     { error: "A patient account with this employee ID already exists." },
@@ -104,7 +131,7 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, roleEnum);
+            const duplicateEmployee = await existingEmployeeWithRole(trimmedEmployeeId, roleEnum);
             if (duplicateEmployee) {
                 const roleLabel = roleEnum === Role.NURSE ? "nurse" : "doctor";
                 return NextResponse.json(
@@ -115,7 +142,7 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const duplicateScholar = await existingStudentWithRole(payload.school_id, Role.SCHOLAR);
+            const duplicateScholar = await existingStudentWithRole(trimmedSchoolId, Role.SCHOLAR);
             if (duplicateScholar) {
                 return NextResponse.json(
                     { error: "A scholar account with this school ID already exists." },
@@ -127,13 +154,13 @@ export async function POST(req: Request) {
         // Determine username
         let username: string;
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            username = payload.employee_id;
+            username = trimmedEmployeeId;
         } else if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            username = payload.student_id;
+            username = trimmedStudentId;
         } else if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            username = payload.employee_id;
+            username = trimmedEmployeeId;
         } else if (roleEnum === Role.SCHOLAR) {
-            username = payload.school_id;
+            username = trimmedSchoolId;
         } else {
             username = `${payload.fname.toLowerCase()}.${payload.lname.toLowerCase()}`;
         }
@@ -180,7 +207,7 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.student_id);
+            const uniqueStudentId = await ensureUniqueStudentId(trimmedStudentId);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -198,7 +225,7 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
+            const uniqueEmployeeId = await ensureUniqueEmployeeId(trimmedEmployeeId);
             await prisma.employee.create({
                 data: {
                     user_id: newUser.user_id,
@@ -209,7 +236,7 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
+            const uniqueEmployeeId = await ensureUniqueEmployeeId(trimmedEmployeeId);
             await prisma.employee.create({
                 data: {
                     user_id: newUser.user_id,
@@ -220,7 +247,7 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.school_id);
+            const uniqueStudentId = await ensureUniqueStudentId(trimmedSchoolId);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -60,6 +60,20 @@ async function ensureUniqueEmployeeId(value: string): Promise<string> {
     return id;
 }
 
+async function existingStudentWithRole(studentId: string, role: Role) {
+    return prisma.student.findFirst({
+        where: { student_id: studentId, user: { role } },
+        select: { stud_user_id: true },
+    });
+}
+
+async function existingEmployeeWithRole(employeeId: string, role: Role) {
+    return prisma.employee.findFirst({
+        where: { employee_id: employeeId, user: { role } },
+        select: { emp_id: true },
+    });
+}
+
 // ---------------- CREATE USER ----------------
 export async function POST(req: Request) {
     try {
@@ -124,6 +138,13 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
+            const duplicateStudent = await existingStudentWithRole(payload.student_id, Role.PATIENT);
+            if (duplicateStudent) {
+                return NextResponse.json(
+                    { error: "A patient account with this student ID already exists." },
+                    { status: 400 }
+                );
+            }
             const uniqueStudentId = await ensureUniqueStudentId(payload.student_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
@@ -142,6 +163,13 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
+            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, Role.PATIENT);
+            if (duplicateEmployee) {
+                return NextResponse.json(
+                    { error: "A patient account with this employee ID already exists." },
+                    { status: 400 }
+                );
+            }
             const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
@@ -153,6 +181,14 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
+            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, roleEnum);
+            if (duplicateEmployee) {
+                const roleLabel = roleEnum === Role.NURSE ? "nurse" : "doctor";
+                return NextResponse.json(
+                    { error: `A ${roleLabel} account with this employee ID already exists.` },
+                    { status: 400 }
+                );
+            }
             const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
@@ -164,6 +200,13 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.SCHOLAR) {
+            const duplicateScholar = await existingStudentWithRole(payload.school_id, Role.SCHOLAR);
+            if (duplicateScholar) {
+                return NextResponse.json(
+                    { error: "A scholar account with this school ID already exists." },
+                    { status: 400 }
+                );
+            }
             const uniqueStudentId = await ensureUniqueStudentId(payload.school_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -82,6 +82,48 @@ export async function POST(req: Request) {
         const payload = await req.json();
         const roleEnum = payload.role as Role;
 
+        // Pre-validate role-specific ID reuse to avoid creating orphaned user rows
+        if (roleEnum === Role.PATIENT && payload.patientType === "student") {
+            const duplicateStudent = await existingStudentWithRole(payload.student_id, Role.PATIENT);
+            if (duplicateStudent) {
+                return NextResponse.json(
+                    { error: "A patient account with this student ID already exists." },
+                    { status: 400 }
+                );
+            }
+        }
+
+        if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
+            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, Role.PATIENT);
+            if (duplicateEmployee) {
+                return NextResponse.json(
+                    { error: "A patient account with this employee ID already exists." },
+                    { status: 400 }
+                );
+            }
+        }
+
+        if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
+            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, roleEnum);
+            if (duplicateEmployee) {
+                const roleLabel = roleEnum === Role.NURSE ? "nurse" : "doctor";
+                return NextResponse.json(
+                    { error: `A ${roleLabel} account with this employee ID already exists.` },
+                    { status: 400 }
+                );
+            }
+        }
+
+        if (roleEnum === Role.SCHOLAR) {
+            const duplicateScholar = await existingStudentWithRole(payload.school_id, Role.SCHOLAR);
+            if (duplicateScholar) {
+                return NextResponse.json(
+                    { error: "A scholar account with this school ID already exists." },
+                    { status: 400 }
+                );
+            }
+        }
+
         // Determine username
         let username: string;
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
@@ -138,13 +180,6 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const duplicateStudent = await existingStudentWithRole(payload.student_id, Role.PATIENT);
-            if (duplicateStudent) {
-                return NextResponse.json(
-                    { error: "A patient account with this student ID already exists." },
-                    { status: 400 }
-                );
-            }
             const uniqueStudentId = await ensureUniqueStudentId(payload.student_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
@@ -163,13 +198,6 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, Role.PATIENT);
-            if (duplicateEmployee) {
-                return NextResponse.json(
-                    { error: "A patient account with this employee ID already exists." },
-                    { status: 400 }
-                );
-            }
             const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
@@ -181,14 +209,6 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            const duplicateEmployee = await existingEmployeeWithRole(payload.employee_id, roleEnum);
-            if (duplicateEmployee) {
-                const roleLabel = roleEnum === Role.NURSE ? "nurse" : "doctor";
-                return NextResponse.json(
-                    { error: `A ${roleLabel} account with this employee ID already exists.` },
-                    { status: 400 }
-                );
-            }
             const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
             await prisma.employee.create({
                 data: {
@@ -200,13 +220,6 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const duplicateScholar = await existingStudentWithRole(payload.school_id, Role.SCHOLAR);
-            if (duplicateScholar) {
-                return NextResponse.json(
-                    { error: "A scholar account with this school ID already exists." },
-                    { status: 400 }
-                );
-            }
             const uniqueStudentId = await ensureUniqueStudentId(payload.school_id);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -48,15 +48,6 @@ async function ensureUniqueUsername(base: string): Promise<string> {
     return candidate;
 }
 
-async function ensureUniqueStudentId(value: string): Promise<string> {
-    let id = value;
-    let n = 1;
-    while (await prisma.student.findUnique({ where: { student_id: id } })) {
-        id = `${value}-${n++}`;
-    }
-    return id;
-}
-
 async function ensureUniqueEmployeeId(value: string): Promise<string> {
     let id = value;
     let n = 1;
@@ -207,7 +198,6 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const uniqueStudentId = await ensureUniqueStudentId(trimmedStudentId);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -215,7 +205,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: trimmedStudentId,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,
@@ -247,7 +237,6 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const uniqueStudentId = await ensureUniqueStudentId(trimmedSchoolId);
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -255,7 +244,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: trimmedSchoolId,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,17 +1,8 @@
 import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { ipKey, withRateLimit } from "@/lib/rate-limit";
-
-type MinimalUserRelation = {
-    fname: string;
-    lname: string;
-    user: {
-        user_id: string;
-        role: string;
-        password: string;
-    } | null;
-};
 
 const baseSelect = {
     fname: true,
@@ -23,7 +14,12 @@ const baseSelect = {
             password: true,
         },
     },
-} as const;
+} as const satisfies Pick<Prisma.StudentSelect, "fname" | "lname" | "user">;
+
+type MinimalUserRelation = Pick<
+    Prisma.StudentGetPayload<{ select: typeof baseSelect }>,
+    "fname" | "lname" | "user"
+>;
 
 async function handler(req: Request) {
     try {

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { ipKey, withRateLimit } from "@/lib/rate-limit";
 
-const baseSelect = {
+const studentSelect = {
     fname: true,
     lname: true,
     user: {
@@ -14,10 +14,19 @@ const baseSelect = {
             password: true,
         },
     },
-} as const;
+} satisfies Prisma.StudentSelect;
 
-const studentSelect = Prisma.validator<Prisma.StudentSelect>()(baseSelect);
-const employeeSelect = Prisma.validator<Prisma.EmployeeSelect>()(baseSelect);
+const employeeSelect = {
+    fname: true,
+    lname: true,
+    user: {
+        select: {
+            user_id: true,
+            role: true,
+            password: true,
+        },
+    },
+} satisfies Prisma.EmployeeSelect;
 
 type MinimalUserRelation =
     | Prisma.StudentGetPayload<{ select: typeof studentSelect }>

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -14,12 +14,14 @@ const baseSelect = {
             password: true,
         },
     },
-} as const satisfies Pick<Prisma.StudentSelect, "fname" | "lname" | "user">;
+} as const;
 
-type MinimalUserRelation = Pick<
-    Prisma.StudentGetPayload<{ select: typeof baseSelect }>,
-    "fname" | "lname" | "user"
->;
+const studentSelect = Prisma.validator<Prisma.StudentSelect>()(baseSelect);
+const employeeSelect = Prisma.validator<Prisma.EmployeeSelect>()(baseSelect);
+
+type MinimalUserRelation =
+    | Prisma.StudentGetPayload<{ select: typeof studentSelect }>
+    | Prisma.EmployeeGetPayload<{ select: typeof employeeSelect }>;
 
 async function handler(req: Request) {
     try {
@@ -47,7 +49,7 @@ async function handler(req: Request) {
             }
             userRecord = await prisma.employee.findUnique({
                 where: { employee_id },
-                select: baseSelect,
+                select: employeeSelect,
             });
         } else if (normalizedRole === "SCHOLAR") {
             if (typeof school_id !== "string" || school_id.length === 0) {
@@ -58,7 +60,7 @@ async function handler(req: Request) {
             }
             userRecord = await prisma.student.findUnique({
                 where: { student_id: school_id },
-                select: baseSelect,
+                select: studentSelect,
             });
         } else if (normalizedRole === "PATIENT") {
             if (typeof patient_id !== "string" || patient_id.length === 0) {
@@ -71,11 +73,11 @@ async function handler(req: Request) {
             const [studentRecord, employeeRecord] = await Promise.all([
                 prisma.student.findUnique({
                     where: { student_id: patient_id },
-                    select: baseSelect,
+                    select: studentSelect,
                 }),
                 prisma.employee.findUnique({
                     where: { employee_id: patient_id },
-                    select: baseSelect,
+                    select: employeeSelect,
                 }),
             ]);
 


### PR DESCRIPTION
## Summary
- add role-aware duplicate checks before creating patient, scholar, and staff accounts
- return clear errors when attempting to reuse an ID for the same role while still permitting other roles

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e74dda6bc832788f3b54371ab5651)