### PR TITLE
Sanitize medical history text output

### DIFF
--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -30,7 +30,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { formatManilaDateTime } from "@/lib/time";
 import { BLOOD_TYPES } from "@/lib/patient-records-update";
-import { formatMedicalHistory, parseMedicalHistory } from "@/lib/medical-history";
+import { formatMedicalHistory, parseMedicalHistory, serializeMedicalHistory } from "@/lib/medical-history";
 
 import DoctorPatientsLoading from "./loading";
 
@@ -306,9 +306,13 @@ export default function DoctorPatientsPage() {
 
         setUpdatingPatientId(selectedRecord.id);
         const form = event.currentTarget;
+        const rawMedicalCond = (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value;
+        const medicalHistory = parseMedicalHistory(rawMedicalCond);
+        const serializedMedicalCond = serializeMedicalHistory(medicalHistory) ?? "";
+
         const payload = {
             type: selectedRecord.patientType,
-            medical_cond: (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value,
+            medical_cond: serializedMedicalCond,
             allergies: (form.elements.namedItem("allergies") as HTMLInputElement)?.value,
         };
 
@@ -729,15 +733,16 @@ export default function DoctorPatientsPage() {
                                     <TabsContent value="update" className="space-y-4">
                                         <form onSubmit={handleUpdateInfo} className="space-y-3">
                                             <div>
-                                                <Label className="mb-1 block font-medium" htmlFor="medical_cond">
-                                                    Medical Conditions
-                                                </Label>
-                                                <Input
-                                                    id="medical_cond"
-                                                    name="medical_cond"
-                                                    defaultValue={selectedRecord.medical_cond || ""}
-                                                />
-                                            </div>
+                                            <Label className="mb-1 block font-medium" htmlFor="medical_cond">
+                                                Medical Conditions
+                                            </Label>
+                                            <Input
+                                                id="medical_cond"
+                                                name="medical_cond"
+                                                defaultValue={selectedMedicalHistoryText}
+                                                placeholder="e.g. Asthma, Hypertension, other details"
+                                            />
+                                        </div>
                                             <div>
                                                 <Label className="mb-1 block font-medium" htmlFor="allergies">
                                                     Allergies

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -18,6 +18,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { parseMedicalHistory, serializeMedicalHistory } from "@/lib/medical-history";
 
 import NurseRecordsLoading from "./loading";
 import { PatientDirectoryTable } from "./patient-directory-table";
@@ -137,9 +138,13 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
 
         setUpdatingPatientId(selectedRecord.id);
         const form = event.currentTarget;
+        const rawMedicalCond = (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value;
+        const medicalHistory = parseMedicalHistory(rawMedicalCond);
+        const serializedMedicalCond = serializeMedicalHistory(medicalHistory) ?? "";
+
         const body = {
             type: selectedRecord.patientType,
-            medical_cond: (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value,
+            medical_cond: serializedMedicalCond,
             allergies: (form.elements.namedItem("allergies") as HTMLInputElement)?.value,
         };
 

--- a/src/app/nurse/records/patient-record-dialog.tsx
+++ b/src/app/nurse/records/patient-record-dialog.tsx
@@ -198,7 +198,12 @@ function RecordDetailsDialogComponent({
                                     <Label className="mb-1 block font-medium" htmlFor="medical_cond">
                                         Medical Conditions
                                     </Label>
-                                    <Input id="medical_cond" name="medical_cond" defaultValue={record.medical_cond || ""} />
+                                    <Input
+                                        id="medical_cond"
+                                        name="medical_cond"
+                                        defaultValue={medicalHistoryText}
+                                        placeholder="e.g. Asthma, Hypertension, other details"
+                                    />
                                 </div>
                                 <div>
                                     <Label className="mb-1 block font-medium" htmlFor="allergies">

--- a/src/lib/medical-history.ts
+++ b/src/lib/medical-history.ts
@@ -16,6 +16,14 @@ export type MedicalHistoryValue = {
     other?: string;
 };
 
+function sanitizeFreeText(value: string): string {
+    return value
+        .replace(/<[^>]*>/g, " ")
+        .replace(/[\u0000-\u001F\u007F]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
 function normalizeOptions(options: unknown): MedicalHistoryOption[] {
     if (!Array.isArray(options)) {
         return [];
@@ -45,7 +53,8 @@ export function parseMedicalHistory(raw?: string | null): MedicalHistoryValue {
             other?: unknown;
         };
         const conditions = normalizeOptions(parsed.conditions);
-        const other = typeof parsed.other === "string" ? parsed.other : "";
+        const other =
+            typeof parsed.other === "string" ? sanitizeFreeText(parsed.other) : "";
         return {
             conditions,
             other,
@@ -77,7 +86,7 @@ export function parseMedicalHistory(raw?: string | null): MedicalHistoryValue {
 
     return {
         conditions,
-        other: otherValues.join(", "),
+        other: sanitizeFreeText(otherValues.join(", ")),
     };
 }
 
@@ -87,7 +96,7 @@ export function serializeMedicalHistory(value: MedicalHistoryValue | null | unde
     }
 
     const conditions = normalizeOptions(value.conditions);
-    const other = value.other?.trim() ?? "";
+    const other = value.other ? sanitizeFreeText(value.other) : "";
 
     if (conditions.length === 0 && other.length === 0) {
         return null;
@@ -104,7 +113,7 @@ export function formatMedicalHistory(value: MedicalHistoryValue | null | undefin
         return "";
     }
 
-    const other = value.other?.trim() ?? "";
+    const other = value.other ? sanitizeFreeText(value.other) : "";
     const parts: string[] = [...value.conditions];
     if (other) {
         parts.push(other);


### PR DESCRIPTION
## Summary
- sanitize patient medical history free text by removing HTML tags, control characters, and extra whitespace
- ensure serialization and display of medical history uses sanitized values for consistent frontend output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e9a87ce3c8327b791e995d618c623)