### PR TITLE
Prevent duplicate student IDs when creating accounts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Student {
   emergencyco_name     String?
   emergencyco_num      String?
   emergencyco_relation String?
+  is_working_scholar   Boolean       @default(false)
   status               AccountStatus @default(Active)
   department           Department?
   year_level           YearLevel?

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -58,6 +58,7 @@ export async function POST(req: Request) {
 
         const payload = await req.json();
         const roleEnum = payload.role as Role;
+        const workingScholar = Boolean(payload.workingScholar);
 
         // Determine username
         let username: string;
@@ -156,6 +157,7 @@ export async function POST(req: Request) {
                     data: {
                         user_id: newUser.user_id,
                         student_id: payload.student_id,
+                        is_working_scholar: workingScholar,
                         department,
                         program: payload.program ?? null,
                         year_level: payload.year_level ?? null,

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -42,15 +42,6 @@ async function ensureUniqueUsername(base: string): Promise<string> {
     return candidate;
 }
 
-async function ensureUniqueStudentId(value: string): Promise<string> {
-    let id = value;
-    let n = 1;
-    while (await prisma.student.findUnique({ where: { student_id: id } })) {
-        id = `${value}-${n++}`;
-    }
-    return id;
-}
-
 async function ensureUniqueEmployeeId(value: string): Promise<string> {
     let id = value;
     let n = 1;
@@ -124,7 +115,14 @@ export async function POST(req: Request) {
 
         // Create profile based on role
         if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.student_id);
+            const existingStudent = await prisma.student.findUnique({ where: { student_id: payload.student_id } });
+            if (existingStudent) {
+                return NextResponse.json(
+                    { error: "Student ID already exists. Please use a unique value." },
+                    { status: 400 }
+                );
+            }
+
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -132,7 +130,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: payload.student_id,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,
@@ -164,7 +162,14 @@ export async function POST(req: Request) {
         }
 
         if (roleEnum === Role.SCHOLAR) {
-            const uniqueStudentId = await ensureUniqueStudentId(payload.school_id);
+            const existingStudent = await prisma.student.findUnique({ where: { student_id: payload.school_id } });
+            if (existingStudent) {
+                return NextResponse.json(
+                    { error: "Student ID already exists. Please use a unique value." },
+                    { status: 400 }
+                );
+            }
+
             const department =
                 payload.department && Object.values(Department).includes(payload.department)
                     ? (payload.department as Department)
@@ -172,7 +177,7 @@ export async function POST(req: Request) {
             await prisma.student.create({
                 data: {
                     user_id: newUser.user_id,
-                    student_id: uniqueStudentId,
+                    student_id: payload.school_id,
                     department,
                     program: payload.program ?? null,
                     year_level: payload.year_level ?? null,

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -33,19 +33,19 @@ const bloodTypeEnumMap: Record<string, string> = {
 };
 
 // ---------------- UNIQUE ID HELPERS ----------------
-async function ensureUniqueUsername(base: string): Promise<string> {
+async function ensureUniqueUsername(client: Prisma.TransactionClient, base: string): Promise<string> {
     let candidate = base;
     let n = 1;
-    while (await prisma.users.findUnique({ where: { username: candidate } })) {
+    while (await client.users.findUnique({ where: { username: candidate } })) {
         candidate = `${base}-${n++}`;
     }
     return candidate;
 }
 
-async function ensureUniqueEmployeeId(value: string): Promise<string> {
+async function ensureUniqueEmployeeId(client: Prisma.TransactionClient, value: string): Promise<string> {
     let id = value;
     let n = 1;
-    while (await prisma.employee.findUnique({ where: { employee_id: id } })) {
+    while (await client.employee.findUnique({ where: { employee_id: id } })) {
         id = `${value}-${n++}`;
     }
     return id;
@@ -73,29 +73,40 @@ export async function POST(req: Request) {
             username = `${payload.fname.toLowerCase()}.${payload.lname.toLowerCase()}`;
         }
 
-        const finalUsername = await ensureUniqueUsername(username);
+        const isStudentPatient = roleEnum === Role.PATIENT && payload.patientType === "student";
+        const isScholar = roleEnum === Role.SCHOLAR;
+
+        if (isStudentPatient) {
+            const [existingStudent, existingUser] = await Promise.all([
+                prisma.student.findUnique({ where: { student_id: payload.student_id } }),
+                prisma.users.findUnique({ where: { username } }),
+            ]);
+
+            if (existingStudent || existingUser) {
+                return NextResponse.json(
+                    { error: "Student ID already exists. Please use a unique value." },
+                    { status: 400 }
+                );
+            }
+        }
+
+        if (isScholar) {
+            const [existingStudent, existingUser] = await Promise.all([
+                prisma.student.findUnique({ where: { student_id: payload.school_id } }),
+                prisma.users.findUnique({ where: { username } }),
+            ]);
+
+            if (existingStudent || existingUser) {
+                return NextResponse.json(
+                    { error: "Student ID already exists. Please use a unique value." },
+                    { status: 400 }
+                );
+            }
+        }
 
         // Generate password
         const plainPassword = generatePassword();
         const hashedPassword = await bcrypt.hash(plainPassword, 10);
-
-        // Create the user record, including specialization when provided
-        const newUser = await prisma.users.create({
-            data: {
-                username: finalUsername,
-                password: hashedPassword,
-                role: roleEnum,
-                status: AccountStatus.Active,
-                specialization:
-                    roleEnum === Role.DOCTOR
-                        ? payload.specialization === "Physician"
-                            ? "Physician"
-                            : payload.specialization === "Dentist"
-                                ? "Dentist"
-                                : null
-                        : null,
-            },
-        });
 
         // Shared fields
         const sharedProfileData = {
@@ -113,81 +124,90 @@ export async function POST(req: Request) {
             contactno: payload.phone?.trim() || null,
         };
 
-        // Create profile based on role
-        if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            const existingStudent = await prisma.student.findUnique({ where: { student_id: payload.student_id } });
-            if (existingStudent) {
-                return NextResponse.json(
-                    { error: "Student ID already exists. Please use a unique value." },
-                    { status: 400 }
-                );
+        const { finalUsername } = await prisma.$transaction(async (tx) => {
+            const finalUsername =
+                isStudentPatient || isScholar ? username : await ensureUniqueUsername(tx, username);
+
+            // Create the user record, including specialization when provided
+            const newUser = await tx.users.create({
+                data: {
+                    username: finalUsername,
+                    password: hashedPassword,
+                    role: roleEnum,
+                    status: AccountStatus.Active,
+                    specialization:
+                        roleEnum === Role.DOCTOR
+                            ? payload.specialization === "Physician"
+                                ? "Physician"
+                                : payload.specialization === "Dentist"
+                                    ? "Dentist"
+                                    : null
+                            : null,
+                },
+            });
+
+            // Create profile based on role
+            if (isStudentPatient) {
+                const department =
+                    payload.department && Object.values(Department).includes(payload.department)
+                        ? (payload.department as Department)
+                        : null;
+                await tx.student.create({
+                    data: {
+                        user_id: newUser.user_id,
+                        student_id: payload.student_id,
+                        department,
+                        program: payload.program ?? null,
+                        year_level: payload.year_level ?? null,
+                        ...sharedProfileData,
+                    },
+                });
             }
 
-            const department =
-                payload.department && Object.values(Department).includes(payload.department)
-                    ? (payload.department as Department)
-                    : null;
-            await prisma.student.create({
-                data: {
-                    user_id: newUser.user_id,
-                    student_id: payload.student_id,
-                    department,
-                    program: payload.program ?? null,
-                    year_level: payload.year_level ?? null,
-                    ...sharedProfileData,
-                },
-            });
-        }
-
-        if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
-            await prisma.employee.create({
-                data: {
-                    user_id: newUser.user_id,
-                    employee_id: uniqueEmployeeId,
-                    ...sharedProfileData,
-                },
-            });
-        }
-
-        if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            const uniqueEmployeeId = await ensureUniqueEmployeeId(payload.employee_id);
-            await prisma.employee.create({
-                data: {
-                    user_id: newUser.user_id,
-                    employee_id: uniqueEmployeeId,
-                    ...sharedProfileData,
-                },
-            });
-        }
-
-        if (roleEnum === Role.SCHOLAR) {
-            const existingStudent = await prisma.student.findUnique({ where: { student_id: payload.school_id } });
-            if (existingStudent) {
-                return NextResponse.json(
-                    { error: "Student ID already exists. Please use a unique value." },
-                    { status: 400 }
-                );
+            if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
+                const uniqueEmployeeId = await ensureUniqueEmployeeId(tx, payload.employee_id);
+                await tx.employee.create({
+                    data: {
+                        user_id: newUser.user_id,
+                        employee_id: uniqueEmployeeId,
+                        ...sharedProfileData,
+                    },
+                });
             }
 
-            const department =
-                payload.department && Object.values(Department).includes(payload.department)
-                    ? (payload.department as Department)
-                    : null;
-            await prisma.student.create({
-                data: {
-                    user_id: newUser.user_id,
-                    student_id: payload.school_id,
-                    department,
-                    program: payload.program ?? null,
-                    year_level: payload.year_level ?? null,
-                    ...sharedProfileData,
-                },
-            });
-        }
+            if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
+                const uniqueEmployeeId = await ensureUniqueEmployeeId(tx, payload.employee_id);
+                await tx.employee.create({
+                    data: {
+                        user_id: newUser.user_id,
+                        employee_id: uniqueEmployeeId,
+                        ...sharedProfileData,
+                    },
+                });
+            }
+
+            if (isScholar) {
+                const department =
+                    payload.department && Object.values(Department).includes(payload.department)
+                        ? (payload.department as Department)
+                        : null;
+                await tx.student.create({
+                    data: {
+                        user_id: newUser.user_id,
+                        student_id: payload.school_id,
+                        department,
+                        program: payload.program ?? null,
+                        year_level: payload.year_level ?? null,
+                        ...sharedProfileData,
+                    },
+                });
+            }
+
+            return { finalUsername };
+        });
 
         return NextResponse.json({
-            id: username.replace(/-\d+$/, ""), // hide "-1" suffix if any
+            id: finalUsername.replace(/-\d+$/, ""), // hide "-1" suffix if any
             password: plainPassword,
         });
     } catch (err) {

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -273,6 +273,8 @@ export async function GET() {
                 contactno: u.student?.contactno ?? u.employee?.contactno ?? null,
                 bloodtype: bloodTypeDisplay,
                 specialization: u.specialization,
+                patientType: u.role === Role.PATIENT ? (u.student ? "student" : "employee") : null,
+                isWorkingScholar: u.student?.is_working_scholar ?? false,
             };
         });
 
@@ -290,33 +292,62 @@ export async function PUT(req: Request) {
     try {
         const session = await requireRole([Role.NURSE]);
 
-        const { user_id, newStatus } = await req.json();
+        const { user_id, newStatus, workingScholar } = await req.json();
 
-        if (!user_id || (newStatus !== "Active" && newStatus !== "Inactive")) {
+        if (!user_id) {
             return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
         }
 
-        // Prevent self-deactivation
+        // Prevent self-targeting on status changes
         const currentUser = await prisma.users.findUnique({
             where: { user_id: session.user.id },
             select: { user_id: true },
         });
 
-        if (currentUser && currentUser.user_id === user_id) {
+        if (currentUser && currentUser.user_id === user_id && (newStatus === "Inactive" || newStatus === "Active")) {
             return NextResponse.json(
                 { error: "You cannot deactivate your own account." },
                 { status: 403 }
             );
         }
 
-        // Check if target exists
+        // Check target existence with student profile when needed
         const target = await prisma.users.findUnique({
             where: { user_id },
-            select: { status: true },
+            include: { student: true },
         });
 
         if (!target) {
             return NextResponse.json({ error: "User not found" }, { status: 404 });
+        }
+
+        if (typeof workingScholar === "boolean") {
+            if (target.role !== Role.PATIENT || !target.student) {
+                return NextResponse.json(
+                    { error: "Working scholar access can only be set for student patients." },
+                    { status: 400 }
+                );
+            }
+
+            if (target.student.is_working_scholar === workingScholar) {
+                return NextResponse.json({ message: "No changes made." });
+            }
+
+            await prisma.student.update({
+                where: { user_id },
+                data: { is_working_scholar: workingScholar },
+            });
+
+            return NextResponse.json({
+                message: workingScholar
+                    ? "Working scholar access enabled for this student."
+                    : "Working scholar access removed for this student.",
+                isWorkingScholar: workingScholar,
+            });
+        }
+
+        if (newStatus !== "Active" && newStatus !== "Inactive") {
+            return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
         }
 
         if (target.status === newStatus) {

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -149,15 +149,20 @@ export async function GET() {
         });
 
         if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
-        if (user.role !== Role.SCHOLAR)
+
+        const workingScholar = user.student?.is_working_scholar ?? false;
+        const hasScholarAccess = user.role === Role.SCHOLAR || (user.role === Role.PATIENT && workingScholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Not a scholar" }, { status: 403 });
+        }
 
         return NextResponse.json({
             accountId: user.user_id,
             username: user.username,
-            role: user.role,
+            role: user.role === Role.SCHOLAR ? user.role : Role.SCHOLAR,
             status: user.status,
-            isWorkingScholar: user.student?.is_working_scholar ?? false,
+            isWorkingScholar: workingScholar,
             profile: user.student ?? null,
         });
     } catch (err) {
@@ -185,17 +190,21 @@ export async function PUT(req: Request) {
         });
 
         if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
-        if (user.role !== Role.SCHOLAR)
-            return NextResponse.json({ error: "Not a scholar" }, { status: 403 });
 
         const existingProfile = user.student;
+        const isWorkingScholar = existingProfile?.is_working_scholar ?? false;
+        const hasScholarAccess = user.role === Role.SCHOLAR || (user.role === Role.PATIENT && isWorkingScholar);
+
+        if (!hasScholarAccess)
+            return NextResponse.json({ error: "Not a scholar" }, { status: 403 });
+
         if (!existingProfile)
             return NextResponse.json(
                 { error: "Student profile not found for this scholar" },
                 { status: 404 }
             );
 
-        if (existingProfile.is_working_scholar) {
+        if (isWorkingScholar) {
             return NextResponse.json(
                 {
                     error:

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -157,6 +157,7 @@ export async function GET() {
             username: user.username,
             role: user.role,
             status: user.status,
+            isWorkingScholar: user.student?.is_working_scholar ?? false,
             profile: user.student ?? null,
         });
     } catch (err) {
@@ -193,6 +194,16 @@ export async function PUT(req: Request) {
                 { error: "Student profile not found for this scholar" },
                 { status: 404 }
             );
+
+        if (existingProfile.is_working_scholar) {
+            return NextResponse.json(
+                {
+                    error:
+                        "Working scholar profiles are managed by the clinic. Contact the nurse station for updates.",
+                },
+                { status: 403 }
+            );
+        }
 
         // Prevent changing DOB once set
         const incomingDOB = toDate(profile.date_of_birth);

--- a/src/app/api/scholar/appointments/route.ts
+++ b/src/app/api/scholar/appointments/route.ts
@@ -127,10 +127,14 @@ export async function GET(req: Request) {
 
         const account = await prisma.users.findUnique({
             where: { user_id: session.user.id },
-            select: { role: true },
+            select: { role: true, student: { select: { is_working_scholar: true } } },
         });
 
-        if (!account || account.role !== Role.SCHOLAR) {
+        const hasScholarAccess =
+            account?.role === Role.SCHOLAR ||
+            (account?.role === Role.PATIENT && account.student?.is_working_scholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
@@ -244,10 +248,14 @@ async function postHandler(req: Request) {
 
         const account = await prisma.users.findUnique({
             where: { user_id: session.user.id },
-            select: { role: true },
+            select: { role: true, student: { select: { is_working_scholar: true } } },
         });
 
-        if (!account || account.role !== Role.SCHOLAR) {
+        const hasScholarAccess =
+            account?.role === Role.SCHOLAR ||
+            (account?.role === Role.PATIENT && account.student?.is_working_scholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
@@ -438,10 +446,14 @@ export async function PATCH(req: Request) {
 
         const account = await prisma.users.findUnique({
             where: { user_id: session.user.id },
-            select: { role: true },
+            select: { role: true, student: { select: { is_working_scholar: true } } },
         });
 
-        if (!account || account.role !== Role.SCHOLAR) {
+        const hasScholarAccess =
+            account?.role === Role.SCHOLAR ||
+            (account?.role === Role.PATIENT && account.student?.is_working_scholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 

--- a/src/app/api/scholar/dispense/route.ts
+++ b/src/app/api/scholar/dispense/route.ts
@@ -39,10 +39,18 @@ export async function GET() {
 
         const scholar = await prisma.users.findUnique({
             where: { user_id: session.user.id },
-            select: { user_id: true, role: true },
+            select: {
+                user_id: true,
+                role: true,
+                student: { select: { is_working_scholar: true } },
+            },
         });
 
-        if (!scholar || scholar.role !== Role.SCHOLAR) {
+        const hasScholarAccess =
+            scholar?.role === Role.SCHOLAR ||
+            (scholar?.role === Role.PATIENT && scholar.student?.is_working_scholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 
@@ -84,10 +92,18 @@ export async function POST(req: Request) {
 
         const scholar = await prisma.users.findUnique({
             where: { user_id: session.user.id },
-            select: { user_id: true, role: true },
+            select: {
+                user_id: true,
+                role: true,
+                student: { select: { is_working_scholar: true } },
+            },
         });
 
-        if (!scholar || scholar.role !== Role.SCHOLAR) {
+        const hasScholarAccess =
+            scholar?.role === Role.SCHOLAR ||
+            (scholar?.role === Role.PATIENT && scholar.student?.is_working_scholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 

--- a/src/app/api/scholar/patients/route.ts
+++ b/src/app/api/scholar/patients/route.ts
@@ -20,10 +20,14 @@ export async function GET(req: Request) {
 
         const account = await prisma.users.findUnique({
             where: { user_id: session.user.id },
-            select: { role: true },
+            select: { role: true, student: { select: { is_working_scholar: true } } },
         });
 
-        if (!account || account.role !== Role.SCHOLAR) {
+        const hasScholarAccess =
+            account?.role === Role.SCHOLAR ||
+            (account?.role === Role.PATIENT && account.student?.is_working_scholar);
+
+        if (!hasScholarAccess) {
             return NextResponse.json({ error: "Access denied" }, { status: 403 });
         }
 

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -6,6 +6,7 @@ import { ipKey, withRateLimit } from "@/lib/rate-limit";
 type MinimalUserRelation = {
     fname: string;
     lname: string;
+    is_working_scholar?: boolean;
     user: {
         user_id: string;
         role: string;
@@ -25,17 +26,22 @@ const baseSelect = {
     },
 } as const;
 
+const studentSelect = {
+    ...baseSelect,
+    is_working_scholar: true,
+} as const;
+
 async function findStudentByBaseId(candidateId: string) {
     const exact = await prisma.student.findUnique({
         where: { student_id: candidateId },
-        select: baseSelect,
+        select: studentSelect,
     });
 
     if (exact) return exact;
 
     return prisma.student.findFirst({
         where: { student_id: { startsWith: `${candidateId}-` } },
-        select: baseSelect,
+        select: studentSelect,
     });
 }
 
@@ -75,6 +81,17 @@ async function handler(req: Request) {
                 );
             }
             userRecord = await findStudentByBaseId(school_id);
+
+            if (
+                userRecord?.user &&
+                userRecord.user.role === "PATIENT" &&
+                userRecord.is_working_scholar
+            ) {
+                userRecord = {
+                    ...userRecord,
+                    user: { ...userRecord.user, role: "SCHOLAR" },
+                };
+            }
         } else if (normalizedRole === "PATIENT") {
             if (typeof patient_id !== "string" || patient_id.length === 0) {
                 return NextResponse.json(

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -25,6 +25,20 @@ const baseSelect = {
     },
 } as const;
 
+async function findStudentByBaseId(candidateId: string) {
+    const exact = await prisma.student.findUnique({
+        where: { student_id: candidateId },
+        select: baseSelect,
+    });
+
+    if (exact) return exact;
+
+    return prisma.student.findFirst({
+        where: { student_id: { startsWith: `${candidateId}-` } },
+        select: baseSelect,
+    });
+}
+
 async function handler(req: Request) {
     try {
         const { role, employee_id, school_id, patient_id, password } =
@@ -60,10 +74,7 @@ async function handler(req: Request) {
                     { status: 400 }
                 );
             }
-            userRecord = await prisma.student.findUnique({
-                where: { student_id: school_id },
-                select: baseSelect,
-            });
+            userRecord = await findStudentByBaseId(school_id);
         } else if (normalizedRole === "PATIENT") {
             if (typeof patient_id !== "string" || patient_id.length === 0) {
                 return NextResponse.json(
@@ -73,10 +84,7 @@ async function handler(req: Request) {
             }
 
             const [studentRecord, employeeRecord] = await Promise.all([
-                prisma.student.findUnique({
-                    where: { student_id: patient_id },
-                    select: baseSelect,
-                }),
+                findStudentByBaseId(patient_id),
                 prisma.employee.findUnique({
                     where: { employee_id: patient_id },
                     select: baseSelect,

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -332,6 +332,11 @@ export function NurseAccountsPageClient({
         }
     }, [usersLoaded, loadUsers]);
 
+    // Always refresh once on mount to ensure working scholar flags reflect latest server state
+    useEffect(() => {
+        void loadUsers({ silent: true });
+    }, [loadUsers]);
+
     useEffect(() => {
         if (role !== "PATIENT") {
             setPatientType("");
@@ -674,6 +679,9 @@ export function NurseAccountsPageClient({
                         : u
                 )
             );
+
+            // Ensure list stays in sync even if other attributes change on the server
+            await loadUsers({ silent: true });
         } catch (err) {
             console.error("Error updating working scholar access", err);
             const message = err instanceof Error ? err.message : "Failed to update working scholar access";
@@ -1593,17 +1601,17 @@ export function NurseAccountsPageClient({
                                                                         </span>
                                                                     )
                                                                 )}
+                                                                {user.role === "PATIENT" && user.patientType ? (
+                                                                    <span className="mt-1 inline-flex w-fit items-center gap-2 rounded-full bg-slate-50 px-2 py-1 text-[11px] font-medium text-slate-700">
+                                                                        <UserRound className="h-3 w-3" />
+                                                                        {user.patientType === "student" ? "Student patient" : "Employee patient"}
+                                                                    </span>
+                                                                ) : null}
                                                             </div>
                                                         </TableCell>
                                                         <TableCell>
                                                             <div className="flex flex-col gap-1">
                                                                 <span className="font-semibold text-gray-900">{user.fullName}</span>
-                                                                {user.patientType ? (
-                                                                    <span className="inline-flex w-fit items-center gap-2 rounded-full bg-slate-50 px-2 py-1 text-[11px] font-medium text-slate-700">
-                                                                        <UserRound className="h-3 w-3" />
-                                                                        {user.patientType === "student" ? "Student patient" : "Employee patient"}
-                                                                    </span>
-                                                                ) : null}
                                                             </div>
                                                         </TableCell>
                                                         <TableCell>

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -1474,64 +1474,82 @@ export function NurseAccountsPageClient({
 
 
                 {/* Manage Users */}
-                <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/80 shadow-sm transition hover:-translate-y-px hover:shadow-md">
-                    <CardHeader className="flex flex-col gap-4">
-                        <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                            <CardTitle className="text-xl sm:text-2xl font-bold text-green-600">
-                                Manage Existing Users
-                            </CardTitle>
-                            <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row md:items-center md:justify-end ml-auto">
-                                <div className="relative w-full md:w-60 lg:w-72">
-                                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
-                                    <Input
-                                        placeholder="Search by ID, role, or name..."
-                                        value={search}
-                                        onChange={(e) => {
-                                            setSearch(e.target.value);
-                                            setCurrentPage(1);
-                                        }}
-                                        className="pl-8"
-                                        disabled={loading || isRefreshingUsers}
-                                    />
-                                </div>
-                                <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                                    <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-                                        <Select
-                                            value={roleFilter}
-                                            onValueChange={(val) => setRoleFilter(val as RoleFilterValue)}
-                                        >
-                                            <SelectTrigger className="h-10 border-green-200">
-                                                <SelectValue placeholder="All roles" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="ALL">All roles</SelectItem>
-                                                <SelectItem value="DOCTOR">Doctor</SelectItem>
-                                                <SelectItem value="NURSE">Nurse</SelectItem>
-                                                <SelectItem value="PATIENT">Patient</SelectItem>
-                                                <SelectItem value="SCHOLAR">Working Scholar</SelectItem>
-                                            </SelectContent>
-                                        </Select>
-                                        <Select
-                                            value={statusFilter}
-                                            onValueChange={(val) => setStatusFilter(val as StatusFilterValue)}
-                                        >
-                                            <SelectTrigger className="h-10 border-green-200">
-                                                <SelectValue placeholder="All statuses" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="ALL">All statuses</SelectItem>
-                                                <SelectItem value="Active">Active</SelectItem>
-                                                <SelectItem value="Inactive">Inactive</SelectItem>
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-
-                                </div>
+                <Card className="flex flex-col rounded-3xl border border-green-100/70 bg-white/90 shadow-sm transition hover:-translate-y-px hover:shadow-md">
+                    <CardHeader className="flex flex-col gap-4 border-b bg-gradient-to-r from-emerald-50/80 via-white to-emerald-50/80">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="space-y-1">
+                                <CardTitle className="text-xl sm:text-2xl font-bold text-green-700">
+                                    Manage Existing Users
+                                </CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Review current accounts, filter by role or status, and grant working scholar access to student patients.
+                                </p>
                             </div>
+                            <div className="flex flex-wrap items-center gap-2 text-xs sm:text-sm font-medium text-emerald-800">
+                                <span className="rounded-full bg-emerald-100 px-3 py-1 shadow-xs">
+                                    {filteredUsers.length} showing
+                                </span>
+                                <span className="rounded-full bg-amber-50 px-3 py-1 shadow-xs">
+                                    {inactiveAccounts} inactive
+                                </span>
+                            </div>
+                        </div>
+                        <div className="grid gap-3 md:grid-cols-3">
+                            <div className="relative">
+                                <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
+                                <Input
+                                    placeholder="Search by ID, role, or name..."
+                                    value={search}
+                                    onChange={(e) => {
+                                        setSearch(e.target.value);
+                                        setCurrentPage(1);
+                                    }}
+                                    className="pl-8"
+                                    disabled={loading || isRefreshingUsers}
+                                />
+                            </div>
+                            <Select
+                                value={roleFilter}
+                                onValueChange={(val) => setRoleFilter(val as RoleFilterValue)}
+                            >
+                                <SelectTrigger className="h-10 border-green-200">
+                                    <SelectValue placeholder="All roles" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="ALL">All roles</SelectItem>
+                                    <SelectItem value="DOCTOR">Doctor</SelectItem>
+                                    <SelectItem value="NURSE">Nurse</SelectItem>
+                                    <SelectItem value="PATIENT">Patient</SelectItem>
+                                    <SelectItem value="SCHOLAR">Working Scholar</SelectItem>
+                                </SelectContent>
+                            </Select>
+                            <Select
+                                value={statusFilter}
+                                onValueChange={(val) => setStatusFilter(val as StatusFilterValue)}
+                            >
+                                <SelectTrigger className="h-10 border-green-200">
+                                    <SelectValue placeholder="All statuses" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="ALL">All statuses</SelectItem>
+                                    <SelectItem value="Active">Active</SelectItem>
+                                    <SelectItem value="Inactive">Inactive</SelectItem>
+                                </SelectContent>
+                            </Select>
                         </div>
                     </CardHeader>
 
                     <CardContent className="flex-1 flex flex-col">
+                        <div className="flex flex-wrap items-center gap-3 py-3 text-xs sm:text-sm text-muted-foreground">
+                            <span className="flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-emerald-700">
+                                <ShieldCheck className="h-4 w-4" />
+                                Student patients can be granted scholar access below.
+                            </span>
+                            <span className="flex items-center gap-2 rounded-full bg-slate-50 px-3 py-1">
+                                <Loader2 className={cn("h-4 w-4", isRefreshingUsers ? "animate-spin" : "")} />
+                                {isRefreshingUsers ? "Refreshing list…" : "Updates apply instantly"}
+                            </span>
+                        </div>
                         <div className="overflow-x-auto w-full">
                             <Table className="min-w-full text-sm">
                                 <TableHeader>
@@ -1559,8 +1577,8 @@ export function NurseAccountsPageClient({
                                             .map((user) => {
                                                 const isStatusUpdating = pendingStatusIds.includes(user.accountId);
                                                 return (
-                                                    <TableRow key={`${user.accountId}-${user.role}`} className="hover:bg-green-50 transition">
-                                                        <TableCell className="whitespace-nowrap text-xs sm:text-sm">{user.user_id}</TableCell>
+                                                    <TableRow key={`${user.accountId}-${user.role}`} className="hover:bg-emerald-50/60 transition">
+                                                        <TableCell className="whitespace-nowrap text-xs sm:text-sm font-semibold text-emerald-900">{user.user_id}</TableCell>
                                                         <TableCell className="whitespace-nowrap">
                                                             <div className="flex flex-col">
                                                                 <span className="font-medium text-gray-900">{user.role}</span>
@@ -1577,7 +1595,17 @@ export function NurseAccountsPageClient({
                                                                 )}
                                                             </div>
                                                         </TableCell>
-                                                        <TableCell>{user.fullName}</TableCell>
+                                                        <TableCell>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span className="font-semibold text-gray-900">{user.fullName}</span>
+                                                                {user.patientType ? (
+                                                                    <span className="inline-flex w-fit items-center gap-2 rounded-full bg-slate-50 px-2 py-1 text-[11px] font-medium text-slate-700">
+                                                                        <UserRound className="h-3 w-3" />
+                                                                        {user.patientType === "student" ? "Student patient" : "Employee patient"}
+                                                                    </span>
+                                                                ) : null}
+                                                            </div>
+                                                        </TableCell>
                                                         <TableCell>
                                                             <Badge
                                                                 variant="outline"
@@ -1591,23 +1619,25 @@ export function NurseAccountsPageClient({
                                                         </TableCell>
                                                         <TableCell>
                                                             {user.role === "PATIENT" && user.patientType === "student" ? (
-                                                                <div className="flex items-center justify-center gap-3">
+                                                                <div className="flex flex-col items-center justify-center gap-2">
                                                                     <Badge
                                                                         variant="secondary"
                                                                         className="rounded-full bg-emerald-50 text-emerald-700"
                                                                     >
                                                                         Student patient
                                                                     </Badge>
-                                                                    <div className="flex items-center gap-2">
+                                                                    <div className="flex items-center gap-3 rounded-full border border-emerald-100 bg-emerald-50/60 px-3 py-2">
                                                                         <Switch
+                                                                            className="data-[state=checked]:bg-emerald-500 data-[state=checked]:border-emerald-500"
                                                                             checked={user.isWorkingScholar}
                                                                             onCheckedChange={() => handleWorkingScholarToggle(user)}
                                                                             disabled={pendingScholarIds.includes(user.accountId)}
                                                                             aria-label="Toggle working scholar access"
                                                                         />
-                                                                        <span className="text-xs font-semibold text-gray-700">
-                                                                            Working scholar
-                                                                        </span>
+                                                                        <div className="flex flex-col leading-tight">
+                                                                            <span className="text-xs font-semibold text-emerald-900">Working scholar access</span>
+                                                                            <span className="text-[11px] text-slate-600">Allows scholar portal sign-in</span>
+                                                                        </div>
                                                                     </div>
                                                                 </div>
                                                             ) : user.role === "SCHOLAR" ? (
@@ -1704,26 +1734,26 @@ export function NurseAccountsPageClient({
                         </div>
 
                         {/* Pagination */}
-                        <div className="flex justify-between items-center mt-4 pt-4 border-t text-sm sm:text-base">
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
-                                disabled={currentPage === 1}
-                            >
-                                Previous
-                            </Button>
-                            <span className="text-gray-600">
-                                Page {currentPage} of {Math.ceil(filteredUsers.length / 8) || 1}
-                            </span>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => setCurrentPage((prev) => Math.min(prev + 1, Math.ceil(filteredUsers.length / 8)))}
-                                disabled={currentPage === Math.ceil(filteredUsers.length / 8) || filteredUsers.length === 0}
-                            >
-                                Next
-                            </Button>
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mt-4 pt-4 border-t text-sm sm:text-base">
+                            <span className="text-muted-foreground">Page {currentPage} of {Math.ceil(filteredUsers.length / 8) || 1}</span>
+                            <div className="flex gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+                                    disabled={currentPage === 1}
+                                >
+                                    Previous
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setCurrentPage((prev) => Math.min(prev + 1, Math.ceil(filteredUsers.length / 8)))}
+                                    disabled={currentPage === Math.ceil(filteredUsers.length / 8) || filteredUsers.length === 0}
+                                >
+                                    Next
+                                </Button>
+                            </div>
                         </div>
                     </CardContent>
                 </Card>

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -371,7 +371,9 @@ export function NurseAccountsPageClient({
                 (u.patientType ? u.patientType.includes(lowerQuery) : false) ||
                 (lowerQuery.includes("scholar") && u.isWorkingScholar);
 
-            const matchesRole = roleFilter === "ALL" || u.role === roleFilter;
+            const isScholarFilteredPatient =
+                roleFilter === "SCHOLAR" && u.role === "PATIENT" && u.patientType === "student" && u.isWorkingScholar;
+            const matchesRole = roleFilter === "ALL" || u.role === roleFilter || isScholarFilteredPatient;
             const matchesStatus = statusFilter === "ALL" || u.status === statusFilter;
 
             return matchesQuery && matchesRole && matchesStatus;
@@ -1528,7 +1530,7 @@ export function NurseAccountsPageClient({
                                     <SelectItem value="DOCTOR">Doctor</SelectItem>
                                     <SelectItem value="NURSE">Nurse</SelectItem>
                                     <SelectItem value="PATIENT">Patient</SelectItem>
-                                    <SelectItem value="SCHOLAR">Working Scholar</SelectItem>
+                                    <SelectItem value="SCHOLAR">Working Scholar (incl. student access)</SelectItem>
                                 </SelectContent>
                             </Select>
                             <Select
@@ -1602,9 +1604,15 @@ export function NurseAccountsPageClient({
                                                                     )
                                                                 )}
                                                                 {user.role === "PATIENT" && user.patientType ? (
-                                                                    <span className="mt-1 inline-flex w-fit items-center gap-2 rounded-full bg-slate-50 px-2 py-1 text-[11px] font-medium text-slate-700">
-                                                                        <UserRound className="h-3 w-3" />
-                                                                        {user.patientType === "student" ? "Student patient" : "Employee patient"}
+                                                                    <span
+                                                                        className={cn(
+                                                                            "mt-1 inline-flex w-fit items-center rounded-full border px-3 py-1 text-[11px]",
+                                                                            user.patientType === "student"
+                                                                                ? "border-emerald-200 bg-emerald-50 font-bold tracking-wide text-emerald-700"
+                                                                                : "border-slate-200 bg-slate-50 font-medium text-slate-700"
+                                                                        )}
+                                                                    >
+                                                                        {user.patientType === "student" ? "STUDENT" : "Employee patient"}
                                                                     </span>
                                                                 ) : null}
                                                             </div>
@@ -1630,9 +1638,9 @@ export function NurseAccountsPageClient({
                                                                 <div className="flex flex-col items-center justify-center gap-2">
                                                                     <Badge
                                                                         variant="secondary"
-                                                                        className="rounded-full bg-emerald-50 text-emerald-700"
+                                                                        className="rounded-full border border-emerald-200 bg-emerald-50 font-bold tracking-wide text-emerald-700"
                                                                     >
-                                                                        Student patient
+                                                                        STUDENT
                                                                     </Badge>
                                                                     <div className="flex items-center gap-3 rounded-full border border-emerald-100 bg-emerald-50/60 px-3 py-2">
                                                                         <Switch

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -1606,13 +1606,13 @@ export function NurseAccountsPageClient({
                                                                 {user.role === "PATIENT" && user.patientType ? (
                                                                     <span
                                                                         className={cn(
-                                                                            "mt-1 inline-flex w-fit items-center rounded-full border px-3 py-1 text-[11px]",
+                                                                            "mt-1 text-xs font-medium",
                                                                             user.patientType === "student"
-                                                                                ? "border-emerald-200 bg-emerald-50 font-bold tracking-wide text-emerald-700"
-                                                                                : "border-slate-200 bg-slate-50 font-medium text-slate-700"
+                                                                                ? "text-emerald-700"
+                                                                                : "text-slate-600"
                                                                         )}
                                                                     >
-                                                                        {user.patientType === "student" ? "STUDENT" : "Employee patient"}
+                                                                        {user.patientType === "student" ? "Student" : "Employee patient"}
                                                                     </span>
                                                                 ) : null}
                                                             </div>
@@ -1636,12 +1636,6 @@ export function NurseAccountsPageClient({
                                                         <TableCell>
                                                             {user.role === "PATIENT" && user.patientType === "student" ? (
                                                                 <div className="flex flex-col items-center justify-center gap-2">
-                                                                    <Badge
-                                                                        variant="secondary"
-                                                                        className="rounded-full border border-emerald-200 bg-emerald-50 font-bold tracking-wide text-emerald-700"
-                                                                    >
-                                                                        STUDENT
-                                                                    </Badge>
                                                                     <div className="flex items-center gap-3 rounded-full border border-emerald-100 bg-emerald-50/60 px-3 py-2">
                                                                         <Switch
                                                                             className="data-[state=checked]:bg-emerald-500 data-[state=checked]:border-emerald-500"

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -59,6 +59,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { AccountCard } from "@/components/account/account-card";
 import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
@@ -95,6 +96,7 @@ type CreateUserPayload = {
     student_id?: string | null;
     school_id?: string | null;
     patientType?: "student" | "employee" | null;
+    workingScholar?: boolean;
     specialization?: "Physician" | "Dentist" | null;
 };
 
@@ -124,6 +126,7 @@ export function NurseAccountsPageClient({
 
     const [role, setRole] = useState("");
     const [patientType, setPatientType] = useState<"student" | "employee" | "">("");
+    const [workingScholar, setWorkingScholar] = useState(false);
     const [roleFilter, setRoleFilter] = useState<RoleFilterValue>("ALL");
     const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("ALL");
 
@@ -153,6 +156,12 @@ export function NurseAccountsPageClient({
 
     const [isRefreshingUsers, startUsersTransition] = useTransition();
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+
+    useEffect(() => {
+        if (role !== "PATIENT" || patientType !== "student") {
+            setWorkingScholar(false);
+        }
+    }, [role, patientType]);
 
     const initializing = !(profileLoaded && usersLoaded);
 
@@ -412,6 +421,7 @@ export function NurseAccountsPageClient({
                 role === "PATIENT" && patientType === "student" ? (studentId || null) : null,
             school_id: role === "SCHOLAR" ? (schoolId || null) : null,
             patientType: patientType || null,
+            workingScholar: role === "PATIENT" && patientType === "student" ? workingScholar : false,
             specialization: role === "DOCTOR" ? specialization : null,
         };
 
@@ -467,6 +477,7 @@ export function NurseAccountsPageClient({
             formRef.current?.reset();
             setRole("");
             setPatientType("");
+            setWorkingScholar(false);
             setSpecialization(null);
             setPendingPayload(null);
             setShowCreateConfirm(false);
@@ -670,6 +681,11 @@ export function NurseAccountsPageClient({
             ? "Student"
             : "Employee"
         : null;
+
+    const pendingScholarLabel =
+        pendingPayload?.workingScholar && pendingPayload.patientType === "student"
+            ? "Also marked as working scholar"
+            : null;
 
     if (initializing) {
         return <NurseAccountsLoading />;
@@ -1228,6 +1244,23 @@ export function NurseAccountsPageClient({
                                 </div>
                             )}
 
+                            {role === "PATIENT" && patientType === "student" && (
+                                <div className="flex items-center justify-between rounded-xl border p-4">
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-900">Enable working scholar access</p>
+                                        <p className="text-xs text-gray-500">
+                                            Allows this student patient to log in as a working scholar using the same ID and
+                                            credentials.
+                                        </p>
+                                    </div>
+                                    <Switch
+                                        checked={workingScholar}
+                                        onCheckedChange={setWorkingScholar}
+                                        aria-label="Mark student patient as working scholar"
+                                    />
+                                </div>
+                            )}
+
                             {/* Student/Employee ID for patient */}
                             {role === "PATIENT" && patientType === "student" && (
                                 <div className="space-y-2">
@@ -1295,6 +1328,12 @@ export function NurseAccountsPageClient({
                                                 <div className="flex items-center justify-between gap-4">
                                                     <dt className="text-gray-500">Patient Type</dt>
                                                     <dd className="font-medium text-gray-900">{pendingPatientTypeLabel}</dd>
+                                                </div>
+                                            )}
+                                            {pendingScholarLabel && (
+                                                <div className="flex items-center justify-between gap-4">
+                                                    <dt className="text-gray-500">Working scholar</dt>
+                                                    <dd className="font-medium text-gray-900">{pendingScholarLabel}</dd>
                                                 </div>
                                             )}
                                             {pendingPayload.role === "DOCTOR" && (

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -121,6 +121,7 @@ export function NurseAccountsPageClient({
 }: NurseAccountsPageClientProps) {
     const [users, setUsers] = useState<NurseAccountUser[]>(() => [...initialUsers]);
     const [pendingStatusIds, setPendingStatusIds] = useState<string[]>([]);
+    const [pendingScholarIds, setPendingScholarIds] = useState<string[]>([]);
     const [search, setSearch] = useState("");
     const [loading, setLoading] = useState(false);
 
@@ -356,11 +357,14 @@ export function NurseAccountsPageClient({
         }
 
         return users.filter((u) => {
+            const lowerQuery = deferredSearch;
             const matchesQuery =
-                !deferredSearch ||
-                u.user_id.toLowerCase().includes(deferredSearch) ||
-                u.role.toLowerCase().includes(deferredSearch) ||
-                u.fullName.toLowerCase().includes(deferredSearch);
+                !lowerQuery ||
+                u.user_id.toLowerCase().includes(lowerQuery) ||
+                u.role.toLowerCase().includes(lowerQuery) ||
+                u.fullName.toLowerCase().includes(lowerQuery) ||
+                (u.patientType ? u.patientType.includes(lowerQuery) : false) ||
+                (lowerQuery.includes("scholar") && u.isWorkingScholar);
 
             const matchesRole = roleFilter === "ALL" || u.role === roleFilter;
             const matchesStatus = statusFilter === "ALL" || u.status === statusFilter;
@@ -639,6 +643,43 @@ export function NurseAccountsPageClient({
             toast.error(message, { position: "top-center" });
         } finally {
             setPendingStatusIds((prev) => prev.filter((id) => id !== user_id));
+        }
+    }
+
+    async function handleWorkingScholarToggle(user: NurseAccountUser) {
+        if (user.role !== "PATIENT" || user.patientType !== "student") return;
+
+        const user_id = user.accountId;
+        const nextValue = !user.isWorkingScholar;
+
+        setPendingScholarIds((prev) => (prev.includes(user_id) ? prev : [...prev, user_id]));
+        try {
+            const res = await fetch("/api/nurse/accounts", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ user_id, workingScholar: nextValue }),
+            });
+
+            const data = await res.json();
+
+            if (!res.ok) {
+                throw new Error((data && data.error) || "Failed to update working scholar access");
+            }
+
+            toast.success(data.message || "Working scholar access updated.", { position: "top-center" });
+            setUsers((prev) =>
+                prev.map((u) =>
+                    u.accountId === user_id
+                        ? { ...u, isWorkingScholar: Boolean(data.isWorkingScholar ?? nextValue) }
+                        : u
+                )
+            );
+        } catch (err) {
+            console.error("Error updating working scholar access", err);
+            const message = err instanceof Error ? err.message : "Failed to update working scholar access";
+            toast.error(message, { position: "top-center" });
+        } finally {
+            setPendingScholarIds((prev) => prev.filter((id) => id !== user_id));
         }
     }
 
@@ -1499,6 +1540,7 @@ export function NurseAccountsPageClient({
                                         <TableHead>Role</TableHead>
                                         <TableHead>Full Name</TableHead>
                                         <TableHead>Status</TableHead>
+                                        <TableHead className="text-center">Scholar Access</TableHead>
                                         <TableHead className="text-right">Actions</TableHead>
                                     </TableRow>
                                 </TableHeader>
@@ -1546,6 +1588,40 @@ export function NurseAccountsPageClient({
                                                             >
                                                                 {user.status}
                                                             </Badge>
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            {user.role === "PATIENT" && user.patientType === "student" ? (
+                                                                <div className="flex items-center justify-center gap-3">
+                                                                    <Badge
+                                                                        variant="secondary"
+                                                                        className="rounded-full bg-emerald-50 text-emerald-700"
+                                                                    >
+                                                                        Student patient
+                                                                    </Badge>
+                                                                    <div className="flex items-center gap-2">
+                                                                        <Switch
+                                                                            checked={user.isWorkingScholar}
+                                                                            onCheckedChange={() => handleWorkingScholarToggle(user)}
+                                                                            disabled={pendingScholarIds.includes(user.accountId)}
+                                                                            aria-label="Toggle working scholar access"
+                                                                        />
+                                                                        <span className="text-xs font-semibold text-gray-700">
+                                                                            Working scholar
+                                                                        </span>
+                                                                    </div>
+                                                                </div>
+                                                            ) : user.role === "SCHOLAR" ? (
+                                                                <div className="flex justify-center">
+                                                                    <Badge
+                                                                        variant="secondary"
+                                                                        className="rounded-full bg-blue-50 text-blue-700"
+                                                                    >
+                                                                        Scholar
+                                                                    </Badge>
+                                                                </div>
+                                                            ) : (
+                                                                <div className="text-center text-xs text-gray-500">—</div>
+                                                            )}
                                                         </TableCell>
                                                         <TableCell className="text-right">
                                                             <AlertDialog>

--- a/src/app/nurse/accounts/types.ts
+++ b/src/app/nurse/accounts/types.ts
@@ -17,6 +17,8 @@ export type NurseAccountsUserApi = {
     mname?: string | null;
     lname?: string;
     specialization?: "Physician" | "Dentist" | null;
+    patientType?: "student" | "employee" | null;
+    isWorkingScholar?: boolean;
 };
 
 export type NurseAccountProfileApi = {
@@ -50,6 +52,8 @@ export type NurseAccountUser = {
     status: "Active" | "Inactive";
     fullName: string;
     specialization: "Physician" | "Dentist" | null;
+    patientType: "student" | "employee" | null;
+    isWorkingScholar: boolean;
 };
 
 export type NurseAccountProfile = {
@@ -118,6 +122,8 @@ export function normalizeNurseAccountUsers(
                 [user.fname, user.mname, user.lname].filter(Boolean).join(" ") ||
                 "Unnamed",
             specialization: user.specialization ?? null,
+            patientType: (user.patientType as NurseAccountUser["patientType"]) ?? null,
+            isWorkingScholar: Boolean(user.isWorkingScholar),
         });
     }
 

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -156,6 +156,7 @@ type Profile = {
     fname: string;
     mname?: string | null;
     lname: string;
+    isWorkingScholar: boolean;
     date_of_birth?: string;
     email?: string;
     contactno?: string | null;
@@ -181,6 +182,7 @@ function normalizeProfile(
         username: String(response.username ?? ""),
         role: String(response.role ?? ""),
         status: (response.status as Profile["status"]) ?? "Active",
+        isWorkingScholar: Boolean(response.isWorkingScholar),
         fname: String(profile?.fname ?? ""),
         mname: (profile?.mname as string | null) ?? "",
         lname: String(profile?.lname ?? ""),
@@ -617,6 +619,116 @@ export default function ScholarAccountPage() {
 
     if (initializing) {
         return <ScholarAccountLoading />;
+    }
+
+    if (!profile) {
+        return (
+            <ScholarLayout
+                title="Account Management"
+                description="Review your personal information, keep emergency contacts current, and manage your clinic credentials."
+                actions={
+                    <div className="flex items-center gap-3">
+                        <AccountRefreshButton
+                            onClick={() => void loadProfile()}
+                            disabled={profileLoading}
+                            isRefreshing={profileLoading}
+                        />
+                    </div>
+                }
+            >
+                <div className="mx-auto w-full max-w-3xl space-y-6">
+                    <Card className="rounded-[28px] border border-emerald-100/70 bg-white/95 px-6 py-8 shadow-sm backdrop-blur">
+                        <div className="space-y-2 text-center text-emerald-900">
+                            <p className="text-base font-semibold">We couldn’t load your profile.</p>
+                            <p className="text-sm text-muted-foreground">
+                                Please refresh to try again. If the issue persists, contact the clinic team.
+                            </p>
+                        </div>
+                    </Card>
+                </div>
+            </ScholarLayout>
+        );
+    }
+
+    if (profile.isWorkingScholar) {
+        const cleanedId = profile.username.replace(/-\d+$/, "");
+
+        return (
+            <ScholarLayout
+                title="Account Management"
+                description="Your working scholar access is linked to your patient student record."
+                actions={
+                    <div className="flex items-center gap-3">
+                        {statusBadge ? (
+                            <span
+                                className={`hidden items-center gap-2 rounded-2xl border px-4 py-2 text-xs font-semibold uppercase tracking-wide shadow-sm md:inline-flex ${statusBadge === "Active"
+                                    ? "border-emerald-200 bg-emerald-50/80 text-emerald-700"
+                                    : "border-rose-200 bg-rose-50/80 text-rose-600"}`}
+                            >
+                                <span
+                                    className={`h-2 w-2 rounded-full ${statusBadge === "Active" ? "bg-emerald-500" : "bg-rose-500"}`}
+                                />
+                                Status: {statusBadge}
+                            </span>
+                        ) : null}
+                        <AccountRefreshButton
+                            onClick={() => void loadProfile()}
+                            disabled={profileLoading}
+                            isRefreshing={profileLoading}
+                        />
+                    </div>
+                }
+            >
+                <div className="mx-auto w-full max-w-5xl space-y-6">
+                    <div className="rounded-2xl border border-amber-100 bg-amber-50/70 px-6 py-5 text-amber-900">
+                        <p className="text-sm font-semibold">Linked to your patient student profile</p>
+                        <p className="text-sm text-amber-800">
+                            Core details come from your patient record. To change them, please ask the clinic nurse to update your
+                            student profile.
+                        </p>
+                    </div>
+
+                    <AccountSummaryGrid items={summaryItems} />
+
+                    <AccountSection
+                        icon={UserRound}
+                        title="Basic details"
+                        description="View the information shared from your patient student account."
+                    >
+                        <dl className="grid gap-4 sm:grid-cols-2">
+                            <div className="rounded-xl border p-4">
+                                <dt className="text-xs uppercase tracking-wide text-gray-500">Student ID</dt>
+                                <dd className="text-sm font-semibold text-gray-900">{cleanedId || "—"}</dd>
+                            </div>
+                            <div className="rounded-xl border p-4">
+                                <dt className="text-xs uppercase tracking-wide text-gray-500">Full name</dt>
+                                <dd className="text-sm font-semibold text-gray-900">
+                                    {[profile.fname, profile.mname, profile.lname].filter(Boolean).join(" ") || "—"}
+                                </dd>
+                            </div>
+                            <div className="rounded-xl border p-4">
+                                <dt className="text-xs uppercase tracking-wide text-gray-500">Department</dt>
+                                <dd className="text-sm font-semibold text-gray-900">{profile.department || "—"}</dd>
+                            </div>
+                            <div className="rounded-xl border p-4">
+                                <dt className="text-xs uppercase tracking-wide text-gray-500">Program & Year</dt>
+                                <dd className="text-sm font-semibold text-gray-900">
+                                    {[profile.program, profile.year_level].filter(Boolean).join(" • ") || "—"}
+                                </dd>
+                            </div>
+                            <div className="rounded-xl border p-4">
+                                <dt className="text-xs uppercase tracking-wide text-gray-500">Contact number</dt>
+                                <dd className="text-sm font-semibold text-gray-900">{profile.contactno || "—"}</dd>
+                            </div>
+                            <div className="rounded-xl border p-4">
+                                <dt className="text-xs uppercase tracking-wide text-gray-500">Email</dt>
+                                <dd className="text-sm font-semibold text-gray-900">{profile.email || "—"}</dd>
+                            </div>
+                        </dl>
+                    </AccountSection>
+                </div>
+            </ScholarLayout>
+        );
     }
 
     return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -47,6 +47,15 @@ interface AppSession extends Session {
     };
 }
 
+type FoundUser = {
+    user_id: string;
+    password: string;
+    role: Role;
+    status: AccountStatus;
+    student: { fname: string; lname: string } | null;
+    employee: { fname: string; lname: string } | null;
+};
+
 /** Main NextAuth configuration. */
 export const authOptions: NextAuthOptions = {
     providers: [
@@ -71,7 +80,7 @@ export const authOptions: NextAuthOptions = {
                 const role = roleStr as Role;
 
                 // Find user (indexed query)
-                const user = await withDb(() =>
+                let user: FoundUser | null = await withDb(() =>
                     prisma.users.findFirst({
                         where: {
                             role,
@@ -92,6 +101,43 @@ export const authOptions: NextAuthOptions = {
                         },
                     })
                 );
+
+                if (!user && role === Role.SCHOLAR) {
+                    const workingScholar = await withDb(() =>
+                        prisma.student.findFirst({
+                            where: {
+                                is_working_scholar: true,
+                                OR: [
+                                    { student_id: id },
+                                    { student_id: { startsWith: `${id}-` } },
+                                ],
+                            },
+                            select: {
+                                fname: true,
+                                lname: true,
+                                user: {
+                                    select: {
+                                        user_id: true,
+                                        password: true,
+                                        role: true,
+                                        status: true,
+                                    },
+                                },
+                            },
+                        })
+                    );
+
+                    if (workingScholar?.user) {
+                        user = {
+                            user_id: workingScholar.user.user_id,
+                            password: workingScholar.user.password,
+                            role: Role.SCHOLAR,
+                            status: workingScholar.user.status,
+                            student: { fname: workingScholar.fname, lname: workingScholar.lname },
+                            employee: null,
+                        };
+                    }
+                }
 
                 if (!user) throw new Error("No account found with these credentials.");
                 if (user.status === AccountStatus.Inactive)


### PR DESCRIPTION
## Summary
- stop auto-appending suffixes to student IDs when creating student patients or scholars
- return a clear error if the supplied student or school ID already exists
- persist the provided ID as-is for new student records

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea1981c2c8327ac930111ac75bdb2)