### PR TITLE
Fix nurse account numeric ID validation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,25 +18,25 @@ model Clinic {
 }
 
 model Users {
-  user_id             String                @id @unique @default(dbgenerated("concat('USER_', (floor((random() * (1000000)::double precision)))::integer)"))
-  username            String                @unique
+  user_id             String               @id @unique @default(dbgenerated("concat('USER_', (floor((random() * (1000000)::double precision)))::integer)"))
+  username            String               @unique
   password            String
-  status              AccountStatus         @default(Active)
+  status              AccountStatus        @default(Active)
   role                Role
-  createdAt           DateTime              @default(now())
-  updatedAt           DateTime              @updatedAt
-  appointmentsCreated Appointment[]         @relation("CreatedAppointments")
-  appointmentsDoctor  Appointment[]         @relation("DoctorAppointments")
-  appointmentsPatient Appointment[]         @relation("PatientAppointments")
-  consultationsDoctor Consultation[]        @relation("ConsultationDoctor")
-  consultationsNurse  Consultation[]        @relation("ConsultationNurse")
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
+  appointmentsCreated Appointment[]        @relation("CreatedAppointments")
+  appointmentsDoctor  Appointment[]        @relation("DoctorAppointments")
+  appointmentsPatient Appointment[]        @relation("PatientAppointments")
+  consultationsDoctor Consultation[]       @relation("ConsultationDoctor")
+  consultationsNurse  Consultation[]       @relation("ConsultationNurse")
   doctorAvail         DoctorAvailability[]
   employee            Employee?
-  medcertIssued       MedCert[]             @relation("IssuedCertificates")
-  medcertPatient      MedCert[]             @relation("PatientCertificates")
+  medcertIssued       MedCert[]            @relation("IssuedCertificates")
+  medcertPatient      MedCert[]            @relation("PatientCertificates")
   passwordResetTokens PasswordResetToken[]
   student             Student?
-  scholarDispenses    MedDispense[]         @relation("ScholarDispenses")
+  scholarDispenses    MedDispense[]        @relation("ScholarDispenses")
 
   @@index([role, status])
   @@index([username])
@@ -69,27 +69,27 @@ model Student {
 }
 
 model Employee {
-  emp_id               String        @id @default(dbgenerated("concat('EMP_', (floor((random() * (1000000)::double precision)))::integer)"))
-  user_id              String        @unique
-  employee_id          String        @unique
+  emp_id               String                @id @default(dbgenerated("concat('EMP_', (floor((random() * (1000000)::double precision)))::integer)"))
+  user_id              String                @unique
+  employee_id          String                @unique
   fname                String
   mname                String?
   lname                String
   date_of_birth        DateTime?
   gender               Gender?
   department_office    String?
-  contactno            String?       @unique
+  contactno            String?               @unique
   address              String?
   allergies            String?
   medical_cond         String?
   emergencyco_name     String?
   emergencyco_num      String?
   emergencyco_relation String?
-  status               AccountStatus @default(Active)
+  status               AccountStatus         @default(Active)
   bloodtype            BloodType?
-  email                String?       @unique
+  email                String?               @unique
   specialization       DoctorSpecialization?
-  user                 Users         @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+  user                 Users                 @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
 }
 
 model MedInventory {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,6 @@ model Users {
   password            String
   status              AccountStatus         @default(Active)
   role                Role
-  specialization      DoctorSpecialization?
   createdAt           DateTime              @default(now())
   updatedAt           DateTime              @updatedAt
   appointmentsCreated Appointment[]         @relation("CreatedAppointments")
@@ -78,6 +77,7 @@ model Employee {
   lname                String
   date_of_birth        DateTime?
   gender               Gender?
+  department_office    String?
   contactno            String?       @unique
   address              String?
   allergies            String?
@@ -88,6 +88,7 @@ model Employee {
   status               AccountStatus @default(Active)
   bloodtype            BloodType?
   email                String?       @unique
+  specialization       DoctorSpecialization?
   user                 Users         @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
 }
 

--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -71,6 +71,7 @@ function buildEmployeeUpdateInput(
     data.emergencyco_name = stringField("emergencyco_name");
     data.emergencyco_num = stringField("emergencyco_num");
     data.emergencyco_relation = stringField("emergencyco_relation");
+    data.department_office = stringField("department_office");
 
     if (isGender(raw.gender)) data.gender = raw.gender;
 
@@ -105,7 +106,7 @@ export async function GET() {
             username: user.username,
             role: user.role,
             status: user.status,
-            specialization: user.specialization ?? null,
+            specialization: user.employee?.specialization ?? null,
             profile: user.employee ?? null,
         });
     } catch (err) {

--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -666,7 +666,6 @@ export async function GET(
           select: {
             user_id: true,
             username: true,
-            specialization: true,
             employee: {
               select: {
                 fname: true,
@@ -674,6 +673,7 @@ export async function GET(
                 lname: true,
                 employee_id: true,
                 contactno: true,
+                specialization: true,
               },
             },
           },
@@ -748,7 +748,7 @@ export async function GET(
       );
     }
 
-    const specialization = appointment.doctor.specialization;
+    const specialization = appointment.doctor.employee?.specialization;
     if (
       !specialization ||
       ![DoctorSpecialization.Physician, DoctorSpecialization.Dentist].includes(

--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -78,6 +78,7 @@ export async function GET(req: Request) {
 
         const doctor = await prisma.users.findUnique({
             where: { user_id: session.user.id },
+            include: { employee: { select: { specialization: true } } },
         });
 
         if (!doctor || doctor.role !== Role.DOCTOR) {
@@ -218,7 +219,7 @@ async function postHandler(req: Request) {
         }
 
         const allowedDays = new Set<number>(
-            doctor.specialization === DoctorSpecialization.Dentist
+            doctor.employee?.specialization === DoctorSpecialization.Dentist
                 ? [1, 2, 3, 4, 5, 6]
                 : [1, 2, 3, 4, 5]
         );

--- a/src/app/api/doctor/consultation/route.ts
+++ b/src/app/api/doctor/consultation/route.ts
@@ -160,6 +160,7 @@ async function postHandler(req: Request) {
 
         const doctor = await prisma.users.findUnique({
             where: { user_id: session.user.id },
+            include: { employee: { select: { specialization: true } } },
         });
 
         if (!doctor || doctor.role !== Role.DOCTOR) {
@@ -282,8 +283,8 @@ async function postHandler(req: Request) {
         const rangeEnd = lastGeneratedDate
             ? endOfManilaDay(lastGeneratedDate)
             : endOfManilaDay(
-                  formatManilaISODate(new Date(endExclusive.getTime() - DAY_IN_MS))
-              );
+                formatManilaISODate(new Date(endExclusive.getTime() - DAY_IN_MS))
+            );
 
         const existingForYear = await prisma.doctorAvailability.count({
             where: {
@@ -371,9 +372,8 @@ async function postHandler(req: Request) {
             formatManilaISODate(new Date(endExclusive.getTime() - DAY_IN_MS));
 
         return NextResponse.json({
-            message: `Duty hours generated for ${generatedDates.length} day${
-                generatedDates.length === 1 ? "" : "s"
-            } (${firstDay} to ${lastDay}).`,
+            message: `Duty hours generated for ${generatedDates.length} day${generatedDates.length === 1 ? "" : "s"
+                } (${firstDay} to ${lastDay}).`,
             createdCount: generatedDates.length,
         });
     } catch (err) {

--- a/src/app/api/meta/doctors/route.ts
+++ b/src/app/api/meta/doctors/route.ts
@@ -40,6 +40,7 @@ async function handler(req: Request) {
                     employee: {
                         is: {
                             status: AccountStatus.Active,
+                            ...(specializationFilter && { specialization: specializationFilter }),
                         },
                     },
                     doctorAvail: {
@@ -47,13 +48,11 @@ async function handler(req: Request) {
                             clinic_id,
                         },
                     },
-                    ...(specializationFilter && { specialization: specializationFilter }),
                 },
                 select: {
                     user_id: true,
                     username: true,
-                    specialization: true,
-                    employee: { select: { fname: true, lname: true } },
+                    employee: { select: { fname: true, lname: true, specialization: true } },
                 },
                 orderBy: { username: "asc" },
             })
@@ -66,7 +65,7 @@ async function handler(req: Request) {
                 d.employee?.fname && d.employee?.lname
                     ? `${d.employee.fname} ${d.employee.lname}`
                     : d.username,
-            specialization: d.specialization ?? null, // 👈 send to frontend
+            specialization: d.employee?.specialization ?? null, // 👈 send to frontend
         }));
 
         return NextResponse.json(shaped);

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -123,27 +123,20 @@ export async function POST(req: Request) {
             emergencyco_relation: payload.emergencyco_relation ?? null,
             email: payload.email?.trim() || null,
             contactno: payload.phone?.trim() || null,
+            department_office: payload.department_office?.trim() || null,
         };
 
         const { finalUsername } = await prisma.$transaction(async (tx) => {
             const finalUsername =
                 isStudentPatient || isScholar ? username : await ensureUniqueUsername(tx, username);
 
-            // Create the user record, including specialization when provided
+            // Create the user record
             const newUser = await tx.users.create({
                 data: {
                     username: finalUsername,
                     password: hashedPassword,
                     role: roleEnum,
                     status: AccountStatus.Active,
-                    specialization:
-                        roleEnum === Role.DOCTOR
-                            ? payload.specialization === "Physician"
-                                ? "Physician"
-                                : payload.specialization === "Dentist"
-                                    ? "Dentist"
-                                    : null
-                            : null,
                 },
             });
 
@@ -183,6 +176,14 @@ export async function POST(req: Request) {
                     data: {
                         user_id: newUser.user_id,
                         employee_id: uniqueEmployeeId,
+                        specialization:
+                            roleEnum === Role.DOCTOR
+                                ? payload.specialization === "Physician"
+                                    ? "Physician"
+                                    : payload.specialization === "Dentist"
+                                        ? "Dentist"
+                                        : null
+                                : null,
                         ...sharedProfileData,
                     },
                 });
@@ -272,7 +273,7 @@ export async function GET() {
                 email: u.student?.email ?? u.employee?.email ?? null,
                 contactno: u.student?.contactno ?? u.employee?.contactno ?? null,
                 bloodtype: bloodTypeDisplay,
-                specialization: u.specialization,
+                specialization: u.employee?.specialization ?? null,
                 patientType: u.role === Role.PATIENT ? (u.student ? "student" : "employee") : null,
                 isWorkingScholar: u.student?.is_working_scholar ?? false,
             };

--- a/src/app/api/patient/appointments/route.ts
+++ b/src/app/api/patient/appointments/route.ts
@@ -155,7 +155,7 @@ async function postHandler(req: Request) {
 
         const doctor = await prisma.users.findUnique({
             where: { user_id: doctor_user_id },
-            select: { role: true, specialization: true },
+            select: { role: true, employee: { select: { specialization: true } } },
         });
         if (!doctor || doctor.role !== Role.DOCTOR)
             return NextResponse.json({ message: "Doctor not found" }, { status: 404 });
@@ -169,7 +169,7 @@ async function postHandler(req: Request) {
         const now = manilaNow();
         const earliestBookingStart = computeDoctorEarliestBookingStart(
             now,
-            doctor.specialization,
+            doctor.employee?.specialization,
             DEFAULT_MIN_BOOKING_LEAD_DAYS,
         );
 
@@ -316,7 +316,7 @@ async function patchHandler(req: Request) {
 
         const doctor = await prisma.users.findUnique({
             where: { user_id: appointment.doctor_user_id },
-            select: { specialization: true },
+            select: { employee: { select: { specialization: true } } },
         });
 
         if (!doctor) {
@@ -346,7 +346,7 @@ async function patchHandler(req: Request) {
         const appointment_timeend = buildManilaDate(date, time_end);
         const earliestBookingStart = computeDoctorEarliestBookingStart(
             now,
-            doctor.specialization,
+            doctor.employee?.specialization,
             DEFAULT_MIN_BOOKING_LEAD_DAYS,
         );
 

--- a/src/app/api/scholar/appointments/route.ts
+++ b/src/app/api/scholar/appointments/route.ts
@@ -316,7 +316,7 @@ async function postHandler(req: Request) {
 
         const doctor = await prisma.users.findUnique({
             where: { user_id: doctor_user_id },
-            select: { role: true, specialization: true },
+            select: { role: true, employee: { select: { specialization: true } } },
         });
 
         if (!doctor || doctor.role !== Role.DOCTOR) {
@@ -334,7 +334,7 @@ async function postHandler(req: Request) {
         const now = manilaNow();
         const earliestBookingStart = computeDoctorEarliestBookingStart(
             now,
-            doctor.specialization,
+            doctor.employee?.specialization,
             DEFAULT_MIN_BOOKING_LEAD_DAYS,
         );
 

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -1265,7 +1265,7 @@ export function NurseAccountsPageClient({
                             {(role === "NURSE" || role === "DOCTOR") && (
                                 <div className="space-y-2">
                                     <Label>Employee ID</Label>
-                                    <Input name="employee_id" required inputMode="numeric" pattern="\\d*" />
+                                    <Input name="employee_id" required inputMode="numeric" />
                                 </div>
                             )}
 
@@ -1310,13 +1310,13 @@ export function NurseAccountsPageClient({
                             {role === "PATIENT" && patientType === "student" && (
                                 <div className="space-y-2">
                                     <Label>Student ID</Label>
-                                    <Input name="student_id" required inputMode="numeric" pattern="\\d*" />
+                                    <Input name="student_id" required inputMode="numeric" />
                                 </div>
                             )}
                             {role === "PATIENT" && patientType === "employee" && (
                                 <div className="space-y-2">
                                     <Label>Employee ID</Label>
-                                    <Input name="employee_id" required inputMode="numeric" pattern="\\d*" />
+                                    <Input name="employee_id" required inputMode="numeric" />
                                 </div>
                             )}
 

--- a/src/app/scholar/account/page.tsx
+++ b/src/app/scholar/account/page.tsx
@@ -683,8 +683,7 @@ export default function ScholarAccountPage() {
                     <div className="rounded-2xl border border-amber-100 bg-amber-50/70 px-6 py-5 text-amber-900">
                         <p className="text-sm font-semibold">Linked to your patient student profile</p>
                         <p className="text-sm text-amber-800">
-                            Core details come from your patient record. To change them, please ask the clinic nurse to update your
-                            student profile.
+                            Core details come from your patient record. To change them, open your student account.
                         </p>
                     </div>
 
@@ -698,7 +697,7 @@ export default function ScholarAccountPage() {
                         <dl className="grid gap-4 sm:grid-cols-2">
                             <div className="rounded-xl border p-4">
                                 <dt className="text-xs uppercase tracking-wide text-gray-500">Student ID</dt>
-                                <dd className="text-sm font-semibold text-gray-900">{cleanedId || "—"}</dd>
+                                <dd className="text-sm font-semibold text-green-900">{cleanedId || "—"}</dd>
                             </div>
                             <div className="rounded-xl border p-4">
                                 <dt className="text-xs uppercase tracking-wide text-gray-500">Full name</dt>


### PR DESCRIPTION
## Summary
- remove strict HTML patterns from nurse account ID fields to prevent unwanted format errors
- retain numeric-only validation via existing client-side checks for employee and student IDs

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef631773883278ae19ab8f7fcfcf7)