### PR TITLE
Refresh marketing pages to match application branding

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -48,22 +48,22 @@ export default function AboutPage() {
     ];
 
     return (
-        <div className="flex flex-col min-h-screen bg-linear-to-b from-green-50 via-white to-green-50">
+        <div className="flex flex-col min-h-screen bg-linear-to-b from-primary/10 via-white to-primary/5">
             <SiteHeader navigation={navigation} />
 
             {/* Hero Section */}
             <section className="relative overflow-hidden">
-                <div className="absolute inset-0 -z-10 bg-linear-to-br from-green-100 via-white to-green-50" />
-                <div className="absolute -right-10 -top-10 h-64 w-64 rounded-full bg-green-200/40 blur-3xl" />
+                <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/15 via-white to-primary/5" />
+                <div className="absolute -right-10 -top-10 h-64 w-64 rounded-full bg-primary/20 blur-3xl" />
                 <div className="max-w-6xl mx-auto px-6 md:px-12 py-20 md:py-24">
                     <div className="max-w-3xl space-y-6 text-center md:text-left">
-                        <span className="inline-flex items-center justify-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                        <span className="inline-flex items-center justify-center rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
                             Our Story
                         </span>
-                        <h1 className="text-3xl md:text-5xl font-bold text-green-600 leading-tight">
+                        <h1 className="text-3xl md:text-5xl font-bold text-primary leading-tight">
                             Caring for the Holy Name University community with compassion and technology.
                         </h1>
-                        <p className="text-gray-700 text-base md:text-lg leading-relaxed">
+                        <p className="text-muted-foreground text-base md:text-lg leading-relaxed">
                             HNU Clinic is the dedicated health partner for students, faculty, and staff. We blend professional expertise with digital tools that make every visit organized, respectful, and centered on well-being.
                         </p>
                     </div>
@@ -78,9 +78,9 @@ export default function AboutPage() {
                             title: "Guided by Care",
                             description: "Every interaction anchored in safety and respect.",
                         }].map((item) => (
-                            <div key={item.title} className="rounded-2xl border border-green-100 bg-white/80 p-5 text-center shadow-sm">
-                                <p className="text-sm font-semibold text-green-600">{item.title}</p>
-                                <p className="mt-2 text-sm text-gray-600 leading-relaxed">{item.description}</p>
+                            <div key={item.title} className="rounded-2xl border border-primary/20 bg-white/80 p-5 text-center shadow-sm">
+                                <p className="text-sm font-semibold text-primary">{item.title}</p>
+                                <p className="mt-2 text-sm text-muted-foreground leading-relaxed">{item.description}</p>
                             </div>
                         ))}
                     </div>
@@ -104,14 +104,14 @@ export default function AboutPage() {
                             icon: ShieldCheck,
                         },
                     ].map(({ title, description, icon: Icon }) => (
-                        <Card key={title} className="rounded-3xl border-green-100 shadow-lg hover:shadow-xl transition">
+                        <Card key={title} className="rounded-3xl border-primary/20 shadow-lg hover:-translate-y-1 hover:shadow-xl transition">
                             <CardHeader className="flex flex-col gap-4">
-                                <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
+                                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
                                     <Icon className="h-6 w-6" />
                                 </span>
-                                <CardTitle className="text-2xl font-semibold text-green-700">{title}</CardTitle>
+                                <CardTitle className="text-2xl font-semibold text-primary">{title}</CardTitle>
                             </CardHeader>
-                            <CardContent className="pt-0 text-gray-700 leading-relaxed">
+                            <CardContent className="pt-0 text-muted-foreground leading-relaxed">
                                 {description}
                             </CardContent>
                         </Card>
@@ -122,11 +122,11 @@ export default function AboutPage() {
             {/* Values */}
             <section className="px-6 md:px-12 py-20 bg-white/60">
                 <div className="max-w-6xl mx-auto text-center space-y-6">
-                    <span className="inline-flex items-center justify-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                    <span className="inline-flex items-center justify-center rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
                         Our Pillars
                     </span>
-                    <h2 className="text-2xl md:text-3xl font-bold text-green-600">How we deliver patient-centered care</h2>
-                    <p className="text-gray-600 max-w-3xl mx-auto">
+                    <h2 className="text-2xl md:text-3xl font-bold text-primary">How we deliver patient-centered care</h2>
+                    <p className="text-muted-foreground max-w-3xl mx-auto">
                         Every initiative at HNU Clinic is grounded in empathy, collaboration, and proactive wellness support for the campus.
                     </p>
                     <div className="grid gap-6 md:grid-cols-3">
@@ -143,14 +143,14 @@ export default function AboutPage() {
                             description: "Collaborating across disciplines to ensure continuous, safe care.",
                             icon: UsersRound,
                         }].map(({ title, description, icon: Icon }) => (
-                            <Card key={title} className="rounded-2xl border-green-100 shadow-md hover:shadow-lg transition">
+                            <Card key={title} className="rounded-2xl border-primary/20 shadow-md hover:-translate-y-1 hover:shadow-lg transition">
                                 <CardHeader className="flex flex-col items-center gap-4 text-center">
-                                    <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
+                                    <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
                                         <Icon className="h-6 w-6" />
                                     </span>
-                                    <CardTitle className="text-xl font-semibold text-green-700">{title}</CardTitle>
+                                    <CardTitle className="text-xl font-semibold text-primary">{title}</CardTitle>
                                 </CardHeader>
-                                <CardContent className="pt-0 text-sm text-gray-600 leading-relaxed">
+                                <CardContent className="pt-0 text-sm text-muted-foreground leading-relaxed">
                                     {description}
                                 </CardContent>
                             </Card>
@@ -160,16 +160,16 @@ export default function AboutPage() {
             </section>
 
             {/* Team Section */}
-            <section className="px-6 md:px-12 py-20 bg-green-50/60">
+            <section className="px-6 md:px-12 py-20 bg-primary/5">
                 <div className="max-w-6xl mx-auto space-y-12">
                     <div className="text-center space-y-4">
-                        <span className="inline-flex items-center justify-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                        <span className="inline-flex items-center justify-center rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
                             Health Services Department
                         </span>
-                        <h2 className="text-2xl md:text-3xl font-bold text-green-600">
+                        <h2 className="text-2xl md:text-3xl font-bold text-primary">
                             The team behind every HNU Clinic visit
                         </h2>
-                        <p className="text-gray-600 max-w-2xl mx-auto">
+                        <p className="text-muted-foreground max-w-2xl mx-auto">
                             Our doctors, dentists, and nurses work side-by-side to deliver coordinated care and supportive guidance for the HNU community.
                         </p>
                     </div>
@@ -177,14 +177,14 @@ export default function AboutPage() {
                     <div className="space-y-12">
                         <div className="space-y-6">
                             <div className="flex items-center justify-between gap-4">
-                                <h3 className="text-xl font-semibold text-green-700 flex items-center gap-2">
+                                <h3 className="text-xl font-semibold text-primary flex items-center gap-2">
                                     <Stethoscope className="h-5 w-5" /> Clinic Leadership
                                 </h3>
-                                <span className="hidden text-sm text-green-600 md:block">Guiding daily health operations</span>
+                                <span className="hidden text-sm text-primary md:block">Guiding daily health operations</span>
                             </div>
                             <div className="grid gap-6 md:grid-cols-2">
                                 {leadership.map((member) => (
-                                    <Card key={member.name} className="rounded-2xl border-green-100 bg-white/90 shadow-md">
+                                    <Card key={member.name} className="rounded-2xl border-primary/20 bg-white/90 shadow-md">
                                         <CardContent className="flex items-center gap-4 p-6">
                                             <Image
                                                 src={member.img}
@@ -194,8 +194,8 @@ export default function AboutPage() {
                                                 className="h-24 w-24 rounded-full object-cover shadow"
                                             />
                                             <div className="space-y-1 text-left">
-                                                <p className="text-base font-semibold text-green-700">{member.name}</p>
-                                                <p className="text-sm text-gray-600">{member.role}</p>
+                                                <p className="text-base font-semibold text-primary">{member.name}</p>
+                                                <p className="text-sm text-muted-foreground">{member.role}</p>
                                             </div>
                                         </CardContent>
                                     </Card>
@@ -204,10 +204,10 @@ export default function AboutPage() {
                         </div>
 
                         <div className="space-y-6">
-                            <h3 className="text-xl font-semibold text-green-700">Dental Care</h3>
+                            <h3 className="text-xl font-semibold text-primary">Dental Care</h3>
                             <div className="grid gap-6 sm:grid-cols-2">
                                 {dentists.map((member) => (
-                                    <Card key={member.name} className="rounded-2xl border-green-100 bg-white/90 shadow-sm">
+                                    <Card key={member.name} className="rounded-2xl border-primary/20 bg-white/90 shadow-sm">
                                         <CardContent className="flex flex-col items-center gap-4 p-6">
                                             <Image
                                                 src={member.img}
@@ -217,8 +217,8 @@ export default function AboutPage() {
                                                 className="h-24 w-24 rounded-full object-cover shadow"
                                             />
                                             <div className="text-center space-y-1">
-                                                <p className="text-base font-semibold text-green-700">{member.name}</p>
-                                                <p className="text-sm text-gray-600">{member.role}</p>
+                                                <p className="text-base font-semibold text-primary">{member.name}</p>
+                                                <p className="text-sm text-muted-foreground">{member.role}</p>
                                             </div>
                                         </CardContent>
                                     </Card>
@@ -227,10 +227,10 @@ export default function AboutPage() {
                         </div>
 
                         <div className="space-y-6">
-                            <h3 className="text-xl font-semibold text-green-700">Nursing Team</h3>
+                            <h3 className="text-xl font-semibold text-primary">Nursing Team</h3>
                             <div className="grid gap-6 sm:grid-cols-3">
                                 {nurses.map((member) => (
-                                    <Card key={member.name} className="rounded-2xl border-green-100 bg-white/90 shadow-sm">
+                                    <Card key={member.name} className="rounded-2xl border-primary/20 bg-white/90 shadow-sm">
                                         <CardContent className="flex flex-col items-center gap-4 p-6">
                                             <Image
                                                 src={member.img}
@@ -240,8 +240,8 @@ export default function AboutPage() {
                                                 className="h-24 w-24 rounded-full object-cover shadow"
                                             />
                                             <div className="text-center space-y-1">
-                                                <p className="text-base font-semibold text-green-700">{member.name}</p>
-                                                <p className="text-sm text-gray-600">{member.role}</p>
+                                                <p className="text-base font-semibold text-primary">{member.name}</p>
+                                                <p className="text-sm text-muted-foreground">{member.role}</p>
                                             </div>
                                         </CardContent>
                                     </Card>
@@ -257,11 +257,11 @@ export default function AboutPage() {
             <section className="px-6 md:px-12 py-20 bg-white">
                 <div className="max-w-6xl mx-auto space-y-12">
                     <div className="text-center space-y-4">
-                        <span className="inline-flex items-center justify-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                        <span className="inline-flex items-center justify-center rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
                             Core Programs
                         </span>
-                        <h2 className="text-2xl md:text-3xl font-bold text-green-600">Services that support the HNU community</h2>
-                        <p className="text-gray-600 max-w-2xl mx-auto">
+                        <h2 className="text-2xl md:text-3xl font-bold text-primary">Services that support the HNU community</h2>
+                        <p className="text-muted-foreground max-w-2xl mx-auto">
                             Our multidisciplinary team delivers coordinated services that cover assessments, preventive care, and responsive support.
                         </p>
                     </div>
@@ -277,15 +277,15 @@ export default function AboutPage() {
                             title: "Primary Care Program",
                             points: ["Support for urgent medical needs", "Care for minor injuries", "Assistance with sudden illnesses"],
                         }].map((service) => (
-                            <Card key={service.title} className="rounded-3xl border-green-100 bg-white/90 shadow-lg hover:shadow-xl transition">
+                            <Card key={service.title} className="rounded-3xl border-primary/20 bg-white/90 shadow-lg hover:-translate-y-1 hover:shadow-xl transition">
                                 <CardHeader>
-                                    <CardTitle className="text-xl font-semibold text-green-700">{service.title}</CardTitle>
+                                    <CardTitle className="text-xl font-semibold text-primary">{service.title}</CardTitle>
                                 </CardHeader>
-                                <CardContent className="text-sm text-gray-600 leading-relaxed">
+                                <CardContent className="text-sm text-muted-foreground leading-relaxed">
                                     <ul className="space-y-2">
                                         {service.points.map((point) => (
                                             <li key={point} className="flex items-start gap-2">
-                                                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-green-500" />
+                                                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
                                                 <span>{point}</span>
                                             </li>
                                         ))}
@@ -298,20 +298,20 @@ export default function AboutPage() {
             </section>
 
             {/* Footer */}
-            <footer className="bg-green-900 text-green-50">
+            <footer className="bg-primary text-primary-foreground">
                 <div className="max-w-7xl mx-auto px-6 md:px-12 py-12 grid gap-8 md:grid-cols-3">
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">HNU Clinic</p>
-                        <p className="text-sm text-green-100 leading-relaxed">
+                        <p className="text-sm text-primary-foreground/80 leading-relaxed">
                             Dedicated to providing a safe and welcoming health experience for the Holy Name University community.
                         </p>
                     </div>
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">Quick Links</p>
-                        <ul className="space-y-2 text-sm text-green-100">
+                        <ul className="space-y-2 text-sm text-primary-foreground/80">
                             {navigation.map((item) => (
                                 <li key={item.label}>
-                                    <Link href={item.href} className="hover:text-white transition">
+                                    <Link href={item.href} className="hover:text-primary-foreground transition">
                                         {item.label}
                                     </Link>
                                 </li>
@@ -320,15 +320,15 @@ export default function AboutPage() {
                     </div>
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">Connect with Us</p>
-                        <p className="text-sm text-green-100 leading-relaxed">
+                        <p className="text-sm text-primary-foreground/80 leading-relaxed">
                             Reach out to the clinic staff for guidance on scheduling, records, or wellness programs tailored to campus needs.
                         </p>
-                        <Link href="/learn-more" className="inline-flex text-sm text-white font-medium underline-offset-4 hover:underline">
+                        <Link href="/learn-more" className="inline-flex text-sm text-primary-foreground font-medium underline-offset-4 hover:underline">
                             Learn more about the system
                         </Link>
                     </div>
                 </div>
-                <div className="border-t border-green-700/60 text-center py-4 text-xs text-green-200">
+                <div className="border-t border-primary-foreground/20 text-center py-4 text-xs text-primary-foreground/80">
                     © {new Date().getFullYear()} HNU Clinic Health Record &amp; Appointment System
                 </div>
             </footer>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -112,9 +112,9 @@ export default function LearnMorePage() {
                             <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
                                 From streamlined appointment requests to comprehensive visit documentation, the platform supports every stage of the patient journey for students, faculty, and staff.
                             </p>
-                            <div className="flex flex-col items-center gap-4 sm:flex-row md:items-start">
+                            <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-start">
                                 <Link href="/login">
-                                    <Button size="lg" className="w-full rounded-xl bg-primary text-primary-foreground shadow-md hover:bg-primary/90 sm:w-auto">
+                                    <Button size="lg" className="w-full sm:w-auto rounded-xl bg-primary text-primary-foreground shadow-md hover:bg-primary/90">
                                         Go to Portal
                                     </Button>
                                 </Link>
@@ -278,9 +278,9 @@ export default function LearnMorePage() {
                         <p className="mx-auto mt-4 max-w-2xl text-muted-foreground">
                             Log in to the HNU Clinic portal to manage appointments, update records, and keep your team aligned with the latest patient information.
                         </p>
-                        <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-                            <Link href="/login">
-                                <Button size="lg" className="rounded-xl bg-primary text-primary-foreground shadow-md hover:bg-primary/90">
+                        <div className="mt-8 flex flex-col items-stretch justify-center gap-4 sm:flex-row sm:items-center">
+                            <Link href="/login" className="w-full sm:w-auto">
+                                <Button size="lg" className="w-full sm:w-auto rounded-xl bg-primary text-primary-foreground shadow-md hover:bg-primary/90">
                                     Access the portal
                                 </Button>
                             </Link>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -276,7 +276,7 @@ export default function LearnMorePage() {
                     <div className="mx-auto max-w-5xl rounded-3xl border border-primary/20 bg-linear-to-br from-primary/10 via-white to-primary/5 p-10 text-center shadow-lg">
                         <h3 className="text-2xl font-bold text-primary md:text-3xl">Ready to streamline clinic operations?</h3>
                         <p className="mx-auto mt-4 max-w-2xl text-muted-foreground">
-                            Log in to the HNU Clinic portal to manage appointments, update records, and keep your team aligned with the latest patient information.
+                            Log in to the HNU Clinic portal to manage appointments, update records, and keep your patient data secured.
                         </p>
                         <div className="mt-8 flex flex-col items-stretch justify-center gap-4 sm:flex-row sm:items-center">
                             <Link href="/login" className="w-full sm:w-auto">

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -189,7 +189,7 @@ export default function LearnMorePage() {
                                 ))}
                             </div>
                         </div>
-                        <Card className="rounded-3xl border-none bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-xl">
+                        <Card className="rounded-3xl border-none bg-linear-to-br bg-emerald-600 text-primary-foreground shadow-xl">
                             <CardContent className="space-y-5 p-8">
                                 <h4 className="text-2xl font-semibold">Designed for confident clinic operations</h4>
                                 <p className="text-sm text-primary-foreground/90 md:text-base leading-relaxed">

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -94,33 +94,33 @@ const developers = [
 
 export default function LearnMorePage() {
     return (
-        <div className="flex min-h-screen flex-col bg-linear-to-b from-green-50 via-white to-green-50">
+        <div className="flex min-h-screen flex-col bg-linear-to-b from-primary/10 via-white to-primary/5">
             <SiteHeader navigation={navigation} />
 
             <main className="flex-1">
                 <section className="relative overflow-hidden">
-                    <div className="absolute inset-0 -z-10 bg-linear-to-br from-green-100 via-white to-green-50" />
-                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,rgba(34,197,94,0.12),transparent_65%)]" />
+                    <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/15 via-white to-primary/5" />
+                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,rgba(22,163,74,0.15),transparent_65%)]" />
                     <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-12 px-6 py-16 md:flex-row md:px-12 md:py-24">
                         <div className="max-w-xl space-y-6 text-center md:text-left">
-                            <span className="inline-flex items-center rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                            <span className="inline-flex items-center rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
                                 Platform Overview
                             </span>
-                            <h2 className="text-3xl font-bold leading-tight text-green-600 md:text-5xl">
+                            <h2 className="text-3xl font-bold leading-tight text-primary md:text-5xl">
                                 HNU Clinic’s digital system keeps campus healthcare organized, secure, and accessible.
                             </h2>
-                            <p className="text-base leading-relaxed text-gray-700 md:text-lg">
+                            <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
                                 From streamlined appointment requests to comprehensive visit documentation, the platform supports every stage of the patient journey for students, faculty, and staff.
                             </p>
                             <div className="flex flex-col items-center gap-4 sm:flex-row md:items-start">
                                 <Link href="/login">
-                                    <Button size="lg" className="w-full bg-green-600 text-white shadow-md hover:bg-green-700 sm:w-auto">
+                                    <Button size="lg" className="w-full rounded-xl bg-primary text-primary-foreground shadow-md hover:bg-primary/90 sm:w-auto">
                                         Go to Portal
                                     </Button>
                                 </Link>
                                 <Link
                                     href="/about"
-                                    className="flex items-center gap-2 text-sm font-medium text-green-700 hover:text-green-800"
+                                    className="flex items-center gap-2 text-sm font-medium text-primary hover:text-primary/80"
                                 >
                                     <span>Discover our clinic team</span>
                                     <ArrowRight className="h-4 w-4" />
@@ -143,21 +143,21 @@ export default function LearnMorePage() {
                 <section className="px-6 py-16 md:px-12 md:py-20">
                     <div className="mx-auto max-w-6xl space-y-12">
                         <div className="mx-auto max-w-3xl space-y-4 text-center">
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">What the system delivers</h3>
-                            <p className="text-gray-600">
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">What the system delivers</h3>
+                            <p className="text-muted-foreground">
                                 Purpose-built modules ensure everyone at HNU Clinic works from the same, up-to-date information while maintaining confidentiality.
                             </p>
                         </div>
                         <div className="grid gap-8 md:grid-cols-3">
                             {highlights.map(({ title, description, icon: Icon }) => (
-                                <Card key={title} className="rounded-2xl border-green-100 bg-white/90 shadow-lg transition hover:shadow-xl">
+                                <Card key={title} className="rounded-2xl border-primary/20 bg-white/90 shadow-lg transition hover:-translate-y-1 hover:shadow-xl">
                                     <CardHeader className="flex flex-col gap-4">
-                                        <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
+                                        <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
                                             <Icon className="h-6 w-6" />
                                         </span>
-                                        <CardTitle className="text-xl font-semibold text-green-700">{title}</CardTitle>
+                                        <CardTitle className="text-xl font-semibold text-primary">{title}</CardTitle>
                                     </CardHeader>
-                                    <CardContent className="pt-0 text-sm leading-relaxed text-gray-600">{description}</CardContent>
+                                    <CardContent className="pt-0 text-sm leading-relaxed text-muted-foreground">{description}</CardContent>
                                 </Card>
                             ))}
                         </div>
@@ -166,36 +166,36 @@ export default function LearnMorePage() {
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
                     <div className="mx-auto grid max-w-6xl gap-10 md:grid-cols-[1.1fr_0.9fr] items-center">
                         <div className="space-y-6">
-                            <span className="inline-flex items-center gap-2 rounded-full border border-green-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-green-700">
+                            <span className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
                                 <Workflow className="h-4 w-4" /> Workflow Snapshot
                             </span>
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">How an appointment moves through the system</h3>
-                            <p className="text-gray-600 leading-relaxed">
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">How an appointment moves through the system</h3>
+                            <p className="text-muted-foreground leading-relaxed">
                                 A guided process keeps everyone aligned—from the moment a request is submitted to the final follow-up instructions documented by clinic staff.
                             </p>
                             <div className="space-y-4">
                                 {process.map((step, index) => (
-                                    <Card key={step.title} className="rounded-2xl border-green-100 bg-white/90 shadow-sm">
+                                    <Card key={step.title} className="rounded-2xl border-primary/20 bg-white/90 shadow-sm">
                                         <CardContent className="flex gap-4 p-6">
-                                            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-green-600 text-white font-semibold">
+                                            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground font-semibold">
                                                 {index + 1}
                                             </span>
                                             <div className="space-y-1">
-                                                <p className="text-sm font-semibold text-green-700 uppercase tracking-wide">{step.title}</p>
-                                                <p className="text-sm text-gray-600 leading-relaxed">{step.detail}</p>
+                                                <p className="text-sm font-semibold text-primary uppercase tracking-wide">{step.title}</p>
+                                                <p className="text-sm text-muted-foreground leading-relaxed">{step.detail}</p>
                                             </div>
                                         </CardContent>
                                     </Card>
                                 ))}
                             </div>
                         </div>
-                        <Card className="rounded-3xl border-none bg-linear-to-br from-green-600 via-green-500 to-emerald-500 text-white shadow-xl">
+                        <Card className="rounded-3xl border-none bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-xl">
                             <CardContent className="space-y-5 p-8">
                                 <h4 className="text-2xl font-semibold">Designed for confident clinic operations</h4>
-                                <p className="text-sm text-white/80 md:text-base leading-relaxed">
+                                <p className="text-sm text-primary-foreground/90 md:text-base leading-relaxed">
                                     The portal brings scheduling, communication, and documentation together in one workflow so staff can focus on care while technology handles the details.
                                 </p>
-                                <ul className="space-y-3 text-sm text-white/80 md:text-base">
+                                <ul className="space-y-3 text-sm text-primary-foreground/90 md:text-base">
                                     <li>• Accessible on campus or remotely</li>
                                     <li>• Built with secure authentication and validation</li>
                                     <li>• Structured data for accurate reporting</li>
@@ -207,9 +207,9 @@ export default function LearnMorePage() {
                 <section className="bg-white px-6 py-16 md:px-12 md:py-10">
                     <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
-                            <Code2 className="mx-auto h-12 w-12 text-green-600" />
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Modern tools that power the experience</h3>
-                            <p className="mx-auto max-w-3xl text-gray-600">
+                            <Code2 className="mx-auto h-12 w-12 text-primary" />
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">Modern tools that power the experience</h3>
+                            <p className="mx-auto max-w-3xl text-muted-foreground">
                                 Our technology stack combines reliable frameworks and UI libraries to keep the platform scalable and intuitive.
                             </p>
                         </div>
@@ -244,15 +244,15 @@ export default function LearnMorePage() {
                 <section className="bg-white px-6 py-16 md:px-12 md:py-20">
                     <div className="mx-auto max-w-6xl space-y-12">
                         <div className="space-y-4 text-center">
-                            <Users className="mx-auto h-12 w-12 text-green-600" />
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Meet the developers</h3>
-                            <p className="mx-auto max-w-3xl text-gray-600">
+                            <Users className="mx-auto h-12 w-12 text-primary" />
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">Meet the developers</h3>
+                            <p className="mx-auto max-w-3xl text-muted-foreground">
                                 A collaborative team of HNU students engineered the platform, uniting backend reliability with intuitive user experiences.
                             </p>
                         </div>
                         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
                             {developers.map((dev) => (
-                                <Card key={dev.name} className="rounded-2xl border-green-100 bg-white/90 shadow-sm">
+                                <Card key={dev.name} className="rounded-2xl border-primary/20 bg-white/90 shadow-sm">
                                     <CardContent className="flex flex-col items-center gap-4 p-6 text-center">
                                         <Image
                                             src={dev.img}
@@ -262,8 +262,8 @@ export default function LearnMorePage() {
                                             className="h-32 w-32 rounded-full object-cover shadow"
                                         />
                                         <div className="space-y-1">
-                                            <p className="text-base font-semibold text-green-700">{dev.name}</p>
-                                            <p className="text-sm text-gray-600">{dev.role}</p>
+                                            <p className="text-base font-semibold text-primary">{dev.name}</p>
+                                            <p className="text-sm text-muted-foreground">{dev.role}</p>
                                         </div>
                                     </CardContent>
                                 </Card>
@@ -273,18 +273,18 @@ export default function LearnMorePage() {
                 </section>
 
                 <section className="px-6 py-16 md:px-12">
-                    <div className="mx-auto max-w-5xl rounded-3xl border border-green-200 bg-linear-to-br from-green-100 via-white to-green-50 p-10 text-center shadow-lg">
-                        <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Ready to streamline clinic operations?</h3>
-                        <p className="mx-auto mt-4 max-w-2xl text-gray-600">
+                    <div className="mx-auto max-w-5xl rounded-3xl border border-primary/20 bg-linear-to-br from-primary/10 via-white to-primary/5 p-10 text-center shadow-lg">
+                        <h3 className="text-2xl font-bold text-primary md:text-3xl">Ready to streamline clinic operations?</h3>
+                        <p className="mx-auto mt-4 max-w-2xl text-muted-foreground">
                             Log in to the HNU Clinic portal to manage appointments, update records, and keep your team aligned with the latest patient information.
                         </p>
                         <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
                             <Link href="/login">
-                                <Button size="lg" className="bg-green-600 text-white shadow-md hover:bg-green-700">
+                                <Button size="lg" className="rounded-xl bg-primary text-primary-foreground shadow-md hover:bg-primary/90">
                                     Access the portal
                                 </Button>
                             </Link>
-                            <Link href="/#contact" className="text-sm font-medium text-green-700 hover:text-green-800">
+                            <Link href="/#contact" className="text-sm font-medium text-primary hover:text-primary/80">
                                 Contact the clinic support team
                             </Link>
                         </div>
@@ -292,20 +292,20 @@ export default function LearnMorePage() {
                 </section>
             </main>
 
-            <footer className="bg-green-900 text-green-50">
+            <footer className="bg-primary text-primary-foreground">
                 <div className="mx-auto grid max-w-7xl gap-8 px-6 py-12 md:px-12 md:grid-cols-3">
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">HNU Clinic</p>
-                        <p className="text-sm leading-relaxed text-green-100">
+                        <p className="text-sm leading-relaxed text-primary-foreground/80">
                             Supporting Holy Name University with a modern, patient-centered clinic experience.
                         </p>
                     </div>
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">Quick Links</p>
-                        <ul className="space-y-2 text-sm text-green-100">
+                        <ul className="space-y-2 text-sm text-primary-foreground/80">
                             {navigation.map((item) => (
                                 <li key={item.label}>
-                                    <Link href={item.href} className="transition hover:text-white">
+                                    <Link href={item.href} className="transition hover:text-primary-foreground">
                                         {item.label}
                                     </Link>
                                 </li>
@@ -314,15 +314,15 @@ export default function LearnMorePage() {
                     </div>
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">Need assistance?</p>
-                        <p className="text-sm leading-relaxed text-green-100">
+                        <p className="text-sm leading-relaxed text-primary-foreground/80">
                             Visit the About page to meet the clinic team or send a message through the contact form for tailored support.
                         </p>
-                        <Link href="/about" className="inline-flex text-sm font-medium text-white underline-offset-4 hover:underline">
+                        <Link href="/about" className="inline-flex text-sm font-medium text-primary-foreground underline-offset-4 hover:underline">
                             Meet the health services department
                         </Link>
                     </div>
                 </div>
-                <div className="border-t border-green-700/60 py-4 text-center text-xs text-green-200">
+                <div className="border-t border-primary-foreground/20 py-4 text-center text-xs text-primary-foreground/80">
                     © {new Date().getFullYear()} HNU Clinic Health Record &amp; Appointment System
                 </div>
             </footer>

--- a/src/app/learn-more/page.tsx
+++ b/src/app/learn-more/page.tsx
@@ -100,7 +100,7 @@ export default function LearnMorePage() {
             <main className="flex-1">
                 <section className="relative overflow-hidden">
                     <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/15 via-white to-primary/5" />
-                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,rgba(22,163,74,0.15),transparent_65%)]" />
+                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-full md:w-1/2 bg-[radial-gradient(circle_at_top_right,rgba(22,163,74,0.15),transparent_60%)]" />
                     <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-12 px-6 py-16 md:flex-row md:px-12 md:py-24">
                         <div className="max-w-xl space-y-6 text-center md:text-left">
                             <span className="inline-flex items-center rounded-full border border-primary/20 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,7 +64,7 @@ export default function HomePage() {
             <main className="flex-1">
                 <section className="relative overflow-hidden">
                     <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/15 via-white to-primary/5" />
-                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,rgba(22,163,74,0.15),transparent_60%)]" />
+                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-full md:w-1/2 bg-[radial-gradient(circle_at_top_right,rgba(22,163,74,0.15),transparent_60%)]" />
                     <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-12 px-6 py-16 md:flex-row md:px-12 md:py-24">
                         <div className="max-w-xl space-y-6 text-center md:text-left">
                             <span className="inline-flex items-center rounded-full border border-primary/20 bg-white px-4 py-1 text-sm font-semibold text-primary shadow-sm">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,7 +77,7 @@ export default function HomePage() {
                                 Our public homepage at <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-primary underline underline-offset-2">www.hnu-clinic-app.com</Link> introduces the system students, faculty, and staff use to request appointments, manage records, and coordinate care.
                             </p>
                             <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
-                                We help patients schedule visits, notify doctors of updates, and keep sensitive information synchronized between care teams—all while upholding the privacy expectations of the HNU community.
+                                We help patients schedule visits, notify patients of updates, and keep sensitive information synchronized. All while upholding the privacy expectations of the HNU community.
                             </p>
                         </div>
                         <div className="flex flex-1 justify-center md:justify-end">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,25 +58,25 @@ const workflowSteps = [
 
 export default function HomePage() {
     return (
-        <div className="flex min-h-screen flex-col bg-linear-to-b from-green-50 via-white to-green-50">
+        <div className="flex min-h-screen flex-col bg-linear-to-b from-primary/10 via-white to-primary/5">
             <SiteHeader navigation={navigation} />
 
             <main className="flex-1">
                 <section className="relative overflow-hidden">
-                    <div className="absolute inset-0 -z-10 bg-linear-to-br from-green-100 via-white to-green-50" />
-                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,rgba(34,197,94,0.12),transparent_60%)]" />
+                    <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/15 via-white to-primary/5" />
+                    <div className="absolute inset-y-0 right-0 -z-10 h-full w-1/2 bg-[radial-gradient(circle_at_top,rgba(22,163,74,0.15),transparent_60%)]" />
                     <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-12 px-6 py-16 md:flex-row md:px-12 md:py-24">
                         <div className="max-w-xl space-y-6 text-center md:text-left">
-                            <span className="inline-flex items-center rounded-full border border-green-100 bg-white px-4 py-1 text-sm font-medium text-green-700 shadow-sm">
+                            <span className="inline-flex items-center rounded-full border border-primary/20 bg-white px-4 py-1 text-sm font-semibold text-primary shadow-sm">
                                 HNU Clinic · Capstone Project
                             </span>
-                            <h2 className="text-3xl font-bold leading-tight text-green-600 md:text-5xl">
+                            <h2 className="text-3xl font-bold leading-tight text-primary md:text-5xl">
                                 Manage health records, book visits, and stay connected.
                             </h2>
-                            <p className="text-base leading-relaxed text-gray-700 md:text-lg">
-                                Our public homepage at <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link> introduces the system students, faculty, and staff use to request appointments, manage records, and coordinate care.
+                            <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
+                                Our public homepage at <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-primary underline underline-offset-2">www.hnu-clinic-app.com</Link> introduces the system students, faculty, and staff use to request appointments, manage records, and coordinate care.
                             </p>
-                            <p className="text-base leading-relaxed text-gray-700 md:text-lg">
+                            <p className="text-base leading-relaxed text-muted-foreground md:text-lg">
                                 We help patients schedule visits, notify doctors of updates, and keep sensitive information synchronized between care teams—all while upholding the privacy expectations of the HNU community.
                             </p>
                         </div>
@@ -96,58 +96,58 @@ export default function HomePage() {
                 <section id="features" className="bg-white px-6 py-16 md:px-12 md:py-15">
                     <div className="mx-auto max-w-7xl space-y-12">
                         <div className="mx-auto max-w-3xl space-y-4 text-center">
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Built for dependable clinic operations</h3>
-                            <p className="text-gray-600">
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">Built for dependable clinic operations</h3>
+                            <p className="text-muted-foreground">
                                 HNU Clinic brings essential services together so patients and providers can focus on care—not coordination.
                             </p>
                         </div>
                         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
                             {featureCards.map(({ title, description, icon: Icon }) => (
-                                <Card key={title} className="rounded-2xl border-green-100 bg-white/90 shadow-lg transition hover:shadow-xl">
+                                <Card key={title} className="rounded-2xl border-primary/20 bg-white/90 shadow-lg transition hover:-translate-y-1 hover:shadow-xl">
                                     <CardHeader className="flex flex-col gap-4">
-                                        <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-50 text-green-600 shadow-sm">
+                                        <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
                                             <Icon className="h-6 w-6" />
                                         </span>
-                                        <CardTitle className="text-xl font-semibold text-green-700">{title}</CardTitle>
+                                        <CardTitle className="text-xl font-semibold text-primary">{title}</CardTitle>
                                     </CardHeader>
-                                    <CardContent className="pt-0 text-sm leading-relaxed text-gray-600">{description}</CardContent>
+                                    <CardContent className="pt-0 text-sm leading-relaxed text-muted-foreground">{description}</CardContent>
                                 </Card>
                             ))}
                         </div>
                     </div>
                 </section>
 
-                <section id="workflow" className="bg-linear-to-r from-green-50 to-white px-6 py-16 md:px-12 md:py-20">
+                <section id="workflow" className="bg-linear-to-r from-primary/10 via-white to-primary/5 px-6 py-16 md:px-12 md:py-20">
                     <div className="mx-auto flex max-w-6xl flex-col gap-10 lg:flex-row">
                         <div className="flex-1 space-y-5">
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">A connected workflow from booking to follow-up</h3>
-                            <p className="text-gray-600">
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">A connected workflow from booking to follow-up</h3>
+                            <p className="text-muted-foreground">
                                 Every interaction—scheduling, attendance, documentation—feeds into one secure system so nothing slips through the cracks.
                             </p>
                             <div className="space-y-4">
-                                <div className="flex items-center gap-3 rounded-xl border border-green-100 bg-white/90 p-4 shadow-sm">
-                                    <ShieldCheck className="h-10 w-10 text-green-600" />
+                                <div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-white/90 p-4 shadow-sm">
+                                    <ShieldCheck className="h-10 w-10 text-primary" />
                                     <div>
-                                        <p className="font-semibold text-green-700">Secure access</p>
-                                        <p className="text-sm text-gray-600">
+                                        <p className="font-semibold text-primary">Secure access</p>
+                                        <p className="text-sm text-muted-foreground">
                                             Role-based permissions ensure patient data is always protected.
                                         </p>
                                     </div>
                                 </div>
-                                <div className="flex items-center gap-3 rounded-xl border border-green-100 bg-white/90 p-4 shadow-sm">
-                                    <Clock className="h-10 w-10 text-green-600" />
+                                <div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-white/90 p-4 shadow-sm">
+                                    <Clock className="h-10 w-10 text-primary" />
                                     <div>
-                                        <p className="font-semibold text-green-700">Smarter scheduling</p>
-                                        <p className="text-sm text-gray-600">
+                                        <p className="font-semibold text-primary">Smarter scheduling</p>
+                                        <p className="text-sm text-muted-foreground">
                                             Duty hours, leave management, and reminders keep appointments running smoothly.
                                         </p>
                                     </div>
                                 </div>
-                                <div className="flex items-center gap-3 rounded-xl border border-green-100 bg-white/90 p-4 shadow-sm">
-                                    <MapPin className="h-10 w-10 text-green-600" />
+                                <div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-white/90 p-4 shadow-sm">
+                                    <MapPin className="h-10 w-10 text-primary" />
                                     <div>
-                                        <p className="font-semibold text-green-700">Clinic coverage</p>
-                                        <p className="text-sm text-gray-600">
+                                        <p className="font-semibold text-primary">Clinic coverage</p>
+                                        <p className="text-sm text-muted-foreground">
                                             Track which clinics are staffed each day with real-time availability.
                                         </p>
                                     </div>
@@ -157,14 +157,14 @@ export default function HomePage() {
                         <div className="flex-1 space-y-6">
                             <div className="space-y-4">
                                 {workflowSteps.map((step, index) => (
-                                    <Card key={step.title} className="rounded-2xl border-green-100 bg-white/95 shadow-lg">
+                                    <Card key={step.title} className="rounded-2xl border-primary/20 bg-white/95 shadow-lg">
                                         <CardHeader className="flex items-center gap-4">
-                                            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100 text-lg font-semibold text-green-700">
+                                            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-lg font-semibold text-primary">
                                                 {index + 1}
                                             </span>
-                                            <CardTitle className="text-lg text-green-700">{step.title}</CardTitle>
+                                            <CardTitle className="text-lg text-primary">{step.title}</CardTitle>
                                         </CardHeader>
-                                        <CardContent className="pt-0 text-sm leading-relaxed text-gray-600">{step.description}</CardContent>
+                                        <CardContent className="pt-0 text-sm leading-relaxed text-muted-foreground">{step.description}</CardContent>
                                     </Card>
                                 ))}
                             </div>
@@ -175,12 +175,12 @@ export default function HomePage() {
                 <section id="contact" className="bg-white px-6 pb-16 md:px-12 md:pb-20">
                     <div className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-2">
                         <div className="space-y-4">
-                            <h3 className="text-2xl font-bold text-green-600 md:text-3xl">Let’s connect</h3>
-                            <p className="text-gray-600">
+                            <h3 className="text-2xl font-bold text-primary md:text-3xl">Let’s connect</h3>
+                            <p className="text-muted-foreground">
                                 Reach out to learn more about the HNU Clinic platform or request a walkthrough for your team.
                             </p>
-                            <div className="space-y-4 rounded-2xl border border-green-100 bg-green-50/60 p-6 text-sm text-green-700">
-                                <p className="font-semibold text-green-700">Verified presence</p>
+                            <div className="space-y-4 rounded-2xl border border-primary/20 bg-primary/10 p-6 text-sm text-primary">
+                                <p className="font-semibold text-primary">Verified presence</p>
                                 <p>
                                     This application is presented by HNU Clinic and currently hosted on <Link href="https://www.hnu-clinic-app.com/" className="font-semibold underline underline-offset-2">www.hnu-clinic-app.com</Link>, where you can review privacy details before signing in.
                                 </p>
@@ -189,26 +189,26 @@ export default function HomePage() {
                                 </p>
                             </div>
                         </div>
-                        <div className="rounded-2xl border border-green-100 bg-white/90 p-6 shadow-lg">
+                        <div className="rounded-2xl border border-primary/20 bg-white/90 p-6 shadow-lg">
                             <ContactForm />
                         </div>
                     </div>
                 </section>
             </main>
-            <footer className="bg-green-900 text-green-50">
+            <footer className="bg-primary text-primary-foreground">
                 <div className="mx-auto grid max-w-7xl gap-8 px-6 py-12 md:px-12 md:grid-cols-3">
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">HNU Clinic</p>
-                        <p className="text-sm leading-relaxed text-green-100">
+                        <p className="text-sm leading-relaxed text-primary-foreground/80">
                             Dedicated to providing a safe and welcoming health experience for the Holy Name University community.
                         </p>
                     </div>
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">Quick Links</p>
-                        <ul className="space-y-2 text-sm text-green-100">
+                        <ul className="space-y-2 text-sm text-primary-foreground/80">
                             {navigation.map((item) => (
                                 <li key={item.label}>
-                                    <Link href={item.href} className="transition hover:text-white">
+                                    <Link href={item.href} className="transition hover:text-primary-foreground">
                                         {item.label}
                                     </Link>
                                 </li>
@@ -217,18 +217,18 @@ export default function HomePage() {
                     </div>
                     <div className="space-y-3">
                         <p className="text-lg font-semibold">Connect with Us</p>
-                        <p className="text-sm leading-relaxed text-green-100">
+                        <p className="text-sm leading-relaxed text-primary-foreground/80">
                             Reach out to the clinic staff for guidance on scheduling, records, or wellness programs tailored to campus needs.
                         </p>
                         <Link
                             href="/learn-more"
-                            className="inline-flex text-sm font-medium text-white underline-offset-4 hover:underline"
+                            className="inline-flex text-sm font-medium text-primary-foreground underline-offset-4 hover:underline"
                         >
                             Learn more about the system
                         </Link>
                     </div>
                 </div>
-                <div className="border-t border-green-700/60 py-4 text-center text-xs text-green-200">
+                <div className="border-t border-primary-foreground/20 py-4 text-center text-xs text-primary-foreground/80">
                     © {new Date().getFullYear()} HNU Clinic Health Record &amp; Appointment System
                 </div>
             </footer>


### PR DESCRIPTION
## Summary
- restyle landing, learn more, and about pages to use the primary application color palette and gradients
- adjust cards, buttons, and typography to mirror in-app panels and improve hover states
- update page footers and call-to-action sections for consistent theming across marketing pages

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692025cdf3d0832783681d116ed7c612)