### PR TITLE
Add patient profile avatar uploads and display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "nanoid": "^5.1.6",
         "next": "15.5.4",
         "next-auth": "^4.24.11",
+        "next-cloudinary": "^6.17.5",
         "next-themes": "^0.4.6",
         "node-fetch": "^3.3.2",
         "puppeteer-core": "^24.31.0",
@@ -106,6 +107,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudinary-util/types": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/types/-/types-1.5.10.tgz",
+      "integrity": "sha512-n5lrm7SdAXhgWEbkSJKHZGnaoO9G/g4WYS6HYnq/k4nLj79sYfQZOoKjyR8hF2iyLRdLkT+qlk68RNFFv5tKew==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/url-loader": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/url-loader/-/url-loader-5.10.4.tgz",
+      "integrity": "sha512-gHkdvOaV+rlcwuIT7Vqd0ts/H5bsH4+bwFten/gIZ8oRjzdTBvgIY3R6F8bbJt0pFIEfpFEQLe4rPkl0NNqEWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/util": "3.3.2",
+        "@cloudinary/url-gen": "1.15.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@cloudinary-util/url-loader/node_modules/@cloudinary-util/util": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-3.3.2.tgz",
+      "integrity": "sha512-Cc0iFxzfl7fcOXuznpeZFGYC885Of/vDgccRDnhTe/8Rf8YKv2PjLtezyo0VgmdA/CpeZy29NCXAsf6liokbwg==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/url-loader/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@cloudinary-util/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-S4xcou/3A7l5o+bcKlw2VHBNgwups7/0lbVDT/cO5YmtrcEYXgj6LGmwnjvpTm/x571VPVN8x5jWdT3rLZiKJQ==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary/transformation-builder-sdk": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary/transformation-builder-sdk/-/transformation-builder-sdk-1.21.2.tgz",
+      "integrity": "sha512-ehOgKUaP+Nvuf7B0TosmB8iilL0kdiVjzjl8tIK06cjvsNnwSJI3xP9nEJmKkvqNxwwFwvYXT+mxUTqnSv9JOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/url-gen": "^1.7.0"
+      }
+    },
+    "node_modules/@cloudinary/url-gen": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary/url-gen/-/url-gen-1.15.0.tgz",
+      "integrity": "sha512-bjU67eZxLUgoRy/Plli4TQio7q6P31OYqnEgXxeN9TKXrzr6h0DeEdIUhKI9gy3HkEBWXWWJIPh7j7gkOJPnyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/transformation-builder-sdk": "^1.10.0"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -7755,6 +7813,21 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-cloudinary": {
+      "version": "6.17.5",
+      "resolved": "https://registry.npmjs.org/next-cloudinary/-/next-cloudinary-6.17.5.tgz",
+      "integrity": "sha512-YIyIWw5Ds30f4rnED+E9ssLUd94FOPTtbkO2KUvOcw9z4irOEIpb1goxMxbn2EUBnIGQOd6uUf1gFizjME7pMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/url-loader": "5.10.4",
+        "@cloudinary-util/util": "4.0.0"
+      },
+      "peerDependencies": {
+        "next": "^12 || ^13 || ^14 || >=15.0.0-rc || ^15",
+        "react": "^17 || ^18 || >=19.0.0-beta || ^19"
       }
     },
     "node_modules/next-themes": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "nanoid": "^5.1.6",
     "next": "15.5.4",
     "next-auth": "^4.24.11",
+    "next-cloudinary": "^6.17.5",
     "next-themes": "^0.4.6",
     "node-fetch": "^3.3.2",
     "puppeteer-core": "^24.31.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Users {
   password            String
   status              AccountStatus        @default(Active)
   role                Role
+  profile_image       String?
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
   appointmentsCreated Appointment[]        @relation("CreatedAppointments")

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -12,6 +12,11 @@ import {
 } from "@prisma/client";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
+import {
+    deleteCloudinaryImage,
+    extractPublicIdFromUrl,
+    uploadDataUrlToCloudinary,
+} from "@/lib/cloudinary";
 
 // ---------------- ENUM HELPERS ----------------
 function mapDepartment(val?: string | null): Department | undefined {
@@ -298,9 +303,43 @@ export async function PUT(req: Request) {
             (typeof normalizedProfileImage === "string" && normalizedProfileImage.startsWith("data:image"));
         const userUpdateInput: Prisma.UsersUpdateInput = {};
         let nextProfileImage = user.profile_image ?? null;
+        const existingPublicId = extractPublicIdFromUrl(user.profile_image);
 
         if (shouldUpdateProfileImage) {
-            userUpdateInput.profile_image = normalizedProfileImage ?? null;
+            if (normalizedProfileImage === null) {
+                if (existingPublicId) {
+                    try {
+                        await deleteCloudinaryImage(existingPublicId);
+                    } catch (error) {
+                        console.error("[Cloudinary] Failed to delete previous avatar", error);
+                    }
+                }
+                userUpdateInput.profile_image = null;
+                nextProfileImage = null;
+            } else if (typeof normalizedProfileImage === "string") {
+                try {
+                    const upload = await uploadDataUrlToCloudinary(
+                        normalizedProfileImage,
+                        session.user.id
+                    );
+                    userUpdateInput.profile_image = upload.secure_url ?? null;
+                    nextProfileImage = upload.secure_url ?? null;
+
+                    if (existingPublicId && upload.public_id && existingPublicId !== upload.public_id) {
+                        try {
+                            await deleteCloudinaryImage(existingPublicId);
+                        } catch (error) {
+                            console.error("[Cloudinary] Failed to clean up old avatar", error);
+                        }
+                    }
+                } catch (error) {
+                    console.error("[Cloudinary] Upload failed", error);
+                    return NextResponse.json(
+                        { error: "Failed to upload profile image" },
+                        { status: 500 }
+                    );
+                }
+            }
         }
 
         const incomingDOB = toDate(profile.date_of_birth);

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -245,6 +245,9 @@ export async function GET() {
             status: user.status,
             type: user.student ? "student" : user.employee ? "employee" : null,
             profile: user.student ?? user.employee ?? null,
+            profileImage: user.profile_image
+                ? `/api/profile/avatar/${user.user_id}`
+                : null,
         });
     } catch (err) {
         console.error("[GET /api/patient/account/me]", err);
@@ -264,6 +267,17 @@ export async function PUT(req: Request) {
 
         const payload = await req.json();
         const profile = (payload?.profile ?? {}) as Record<string, unknown>;
+        const hasProfileImageField = Object.prototype.hasOwnProperty.call(
+            payload,
+            "profileImage"
+        );
+        const rawProfileImage = hasProfileImageField ? payload.profileImage : undefined;
+        const normalizedProfileImage =
+            typeof rawProfileImage === "string" && rawProfileImage.trim().length
+                ? rawProfileImage.trim()
+                : rawProfileImage === null
+                    ? null
+                    : undefined;
 
         const user = await prisma.users.findUnique({
             where: { user_id: session.user.id },
@@ -279,6 +293,15 @@ export async function PUT(req: Request) {
         const isStudent = Boolean(user.student);
         const isEmployee = Boolean(user.employee);
         const existingProfile = user.student ?? user.employee;
+        const shouldUpdateProfileImage =
+            normalizedProfileImage === null ||
+            (typeof normalizedProfileImage === "string" && normalizedProfileImage.startsWith("data:image"));
+        const userUpdateInput: Prisma.UsersUpdateInput = {};
+        let nextProfileImage = user.profile_image ?? null;
+
+        if (shouldUpdateProfileImage) {
+            userUpdateInput.profile_image = normalizedProfileImage ?? null;
+        }
 
         const incomingDOB = toDate(profile.date_of_birth);
         const existingDOB = existingProfile?.date_of_birth ?? null;
@@ -380,6 +403,15 @@ export async function PUT(req: Request) {
                 data,
             });
 
+            if (Object.keys(userUpdateInput).length > 0) {
+                const updatedUser = await prisma.users.update({
+                    where: { user_id: session.user.id },
+                    data: userUpdateInput,
+                    select: { profile_image: true },
+                });
+                nextProfileImage = updatedUser.profile_image ?? null;
+            }
+
             if (shouldClearVerification) {
                 await clearEmailVerifications(session.user.id);
             }
@@ -412,6 +444,9 @@ export async function PUT(req: Request) {
                 profile: updated,
                 type: "student",
                 verificationEmailSent: Boolean(verificationEmail),
+                profileImage: nextProfileImage
+                    ? `/api/profile/avatar/${session.user.id}`
+                    : null,
             });
         }
 
@@ -513,6 +548,15 @@ export async function PUT(req: Request) {
                 data,
             });
 
+            if (Object.keys(userUpdateInput).length > 0) {
+                const updatedUser = await prisma.users.update({
+                    where: { user_id: session.user.id },
+                    data: userUpdateInput,
+                    select: { profile_image: true },
+                });
+                nextProfileImage = updatedUser.profile_image ?? null;
+            }
+
             if (shouldClearVerification) {
                 await clearEmailVerifications(session.user.id);
             }
@@ -545,6 +589,9 @@ export async function PUT(req: Request) {
                 profile: updated,
                 type: "employee",
                 verificationEmailSent: Boolean(verificationEmail),
+                profileImage: nextProfileImage
+                    ? `/api/profile/avatar/${session.user.id}`
+                    : null,
             });
         }
 

--- a/src/app/api/profile/avatar/[userId]/route.ts
+++ b/src/app/api/profile/avatar/[userId]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+function buildImageResponse(imageData: string | null | undefined) {
+    if (!imageData) return null;
+    const dataUrlMatch = imageData.match(/^data:(.+);base64,(.*)$/);
+    if (!dataUrlMatch) return null;
+
+    const [, mime, base64] = dataUrlMatch;
+    try {
+        const buffer = Buffer.from(base64, "base64");
+        return new NextResponse(buffer, {
+            status: 200,
+            headers: {
+                "Content-Type": mime || "image/png",
+                "Cache-Control": "no-store",
+                "Content-Length": buffer.byteLength.toString(),
+            },
+        });
+    } catch (error) {
+        console.error("[GET /api/profile/avatar] Failed to parse image", error);
+        return null;
+    }
+}
+
+export async function GET(
+    _req: Request,
+    { params }: { params: { userId: string } }
+) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const userId = params.userId;
+    if (!userId) {
+        return NextResponse.json({ error: "Missing user id" }, { status: 400 });
+    }
+
+    try {
+        const user = await prisma.users.findUnique({
+            where: { user_id: userId },
+            select: { profile_image: true },
+        });
+
+        const response = buildImageResponse(user?.profile_image);
+        if (!response) {
+            return new NextResponse(null, { status: 204 });
+        }
+
+        return response;
+    } catch (error) {
+        console.error("[GET /api/profile/avatar/:userId]", error);
+        return NextResponse.json({ error: "Failed to fetch avatar" }, { status: 500 });
+    }
+}

--- a/src/app/api/profile/avatar/[userId]/route.ts
+++ b/src/app/api/profile/avatar/[userId]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
@@ -29,16 +29,17 @@ function buildImageResponse(imageData: string | null | undefined) {
     }
 }
 
-export async function GET(
-    _req: Request,
-    { params }: { params: { userId: string } }
-) {
+type RouteContext = {
+    params: Promise<{ userId: string }>;
+};
+
+export async function GET(_req: NextRequest, context: RouteContext) {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const userId = params.userId;
+    const { userId } = await context.params;
     if (!userId) {
         return NextResponse.json({ error: "Missing user id" }, { status: 400 });
     }

--- a/src/app/api/profile/avatar/[userId]/route.ts
+++ b/src/app/api/profile/avatar/[userId]/route.ts
@@ -6,6 +6,9 @@ import { prisma } from "@/lib/prisma";
 
 function buildImageResponse(imageData: string | null | undefined) {
     if (!imageData) return null;
+    if (imageData.startsWith("http://") || imageData.startsWith("https://")) {
+        return NextResponse.redirect(imageData, { status: 302 });
+    }
     const dataUrlMatch = imageData.match(/^data:(.+);base64,(.*)$/);
     if (!dataUrlMatch) return null;
 

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -7,6 +7,7 @@ import { AlertCircle, BadgeCheck, Loader2, RefreshCcw, Search, Stethoscope, User
 import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -44,6 +45,7 @@ type PatientRecord = {
     date_of_birth: string | null;
     status: string;
     appointment_id: string | null;
+    profileImage?: string | null;
     department?: string | null;
     program?: string | null;
     year_level?: string | null;
@@ -188,6 +190,12 @@ function formatYearTypes(value: string | null | undefined) {
         return humanizeEnumValue(value);
     }
     return value;
+}
+
+function buildInitials(name: string) {
+    const [first = "", second = ""] = name.trim().split(" ");
+    const initials = `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
+    return initials || "PT";
 }
 
 function formatBloodType(value: string | null | undefined) {
@@ -519,6 +527,7 @@ export default function DoctorPatientsPage() {
                                         <TableBody>
                                             {filteredRecords.map((record) => {
                                                 const statusKey = record.status.toLowerCase();
+                                                const initials = buildInitials(record.fullName);
                                                 return (
                                                     <TableRow
                                                         key={record.id}
@@ -534,11 +543,22 @@ export default function DoctorPatientsPage() {
                                                         role="button"
                                                     >
                                                         <TableCell className="font-medium text-primary">
-                                                            <div className="flex flex-col">
-                                                                <span>{record.fullName}</span>
-                                                                <span className="text-xs text-muted-foreground">
-                                                                    {record.contactno ? record.contactno : "No contact number"}
-                                                                </span>
+                                                            <div className="flex items-center gap-3">
+                                                                <Avatar className="h-10 w-10 border border-primary/15">
+                                                                    <AvatarImage
+                                                                        src={record.profileImage || undefined}
+                                                                        alt={record.fullName}
+                                                                    />
+                                                                    <AvatarFallback className="bg-primary/10 text-primary">
+                                                                        {initials}
+                                                                    </AvatarFallback>
+                                                                </Avatar>
+                                                                <div className="flex flex-col">
+                                                                    <span>{record.fullName}</span>
+                                                                    <span className="text-xs text-muted-foreground">
+                                                                        {record.contactno ? record.contactno : "No contact number"}
+                                                                    </span>
+                                                                </div>
                                                             </div>
                                                         </TableCell>
                                                         <TableCell>{record.patientId}</TableCell>
@@ -613,8 +633,22 @@ export default function DoctorPatientsPage() {
                                 </DialogHeader>
 
                                 <div className="rounded-2xl bg-primary/10/70 p-4 text-primary">
-                                    <p className="text-lg font-semibold">{selectedRecord.fullName}</p>
-                                    <div className="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+                                    <div className="flex items-center gap-3">
+                                        <Avatar className="h-12 w-12 border border-primary/15">
+                                            <AvatarImage
+                                                src={selectedRecord.profileImage || undefined}
+                                                alt={selectedRecord.fullName}
+                                            />
+                                            <AvatarFallback className="bg-white/80 text-primary">
+                                                {buildInitials(selectedRecord.fullName)}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div>
+                                            <p className="text-lg font-semibold">{selectedRecord.fullName}</p>
+                                            <p className="text-xs uppercase tracking-wide text-primary/80">Patient record</p>
+                                        </div>
+                                    </div>
+                                    <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
                                         <div>
                                             <p className="text-xs uppercase tracking-wide text-primary">Patient ID</p>
                                             <p className="font-medium text-primary">{selectedRecord.patientId}</p>

--- a/src/app/nurse/records/patient-directory-table.tsx
+++ b/src/app/nurse/records/patient-directory-table.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
     Table,
     TableBody,
@@ -29,11 +30,18 @@ interface PatientDirectoryTableProps {
     onOpenDetails: (record: PatientRecord) => void;
 }
 
+function buildInitials(name: string) {
+    const [first = "", second = ""] = name.trim().split(" ");
+    const initials = `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
+    return initials || "PT";
+}
+
 function PatientDirectoryTableComponent({ records, loading, onOpenDetails }: PatientDirectoryTableProps) {
     const rows = useMemo(() => {
         return records.map((record) => {
             const statusKey = record.status.toLowerCase();
             const statusClasses = PATIENT_STATUS_CLASSES[statusKey] ?? PATIENT_STATUS_CLASSES.inactive;
+            const initials = buildInitials(record.fullName);
 
             return (
                 <TableRow
@@ -50,11 +58,17 @@ function PatientDirectoryTableComponent({ records, loading, onOpenDetails }: Pat
                     }}
                 >
                     <TableCell className="font-medium text-primary">
-                        <div className="flex flex-col">
-                            <span>{record.fullName}</span>
-                            <span className="text-xs text-muted-foreground">
-                                {record.contactno ? record.contactno : "No contact number"}
-                            </span>
+                        <div className="flex items-center gap-3">
+                            <Avatar className="h-10 w-10 border border-primary/15">
+                                <AvatarImage src={record.profileImage || undefined} alt={record.fullName} />
+                                <AvatarFallback className="bg-primary/10 text-primary">{initials}</AvatarFallback>
+                            </Avatar>
+                            <div className="flex flex-col">
+                                <span>{record.fullName}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    {record.contactno ? record.contactno : "No contact number"}
+                                </span>
+                            </div>
                         </div>
                     </TableCell>
                     <TableCell className="font-mono text-sm text-muted-foreground">{record.patientId}</TableCell>

--- a/src/app/nurse/records/patient-record-dialog.tsx
+++ b/src/app/nurse/records/patient-record-dialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/patient-format";
 import { formatMedicalHistory, parseMedicalHistory } from "@/lib/medical-history";
 import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -35,6 +36,12 @@ interface RecordDetailsDialogProps {
     onSaveNotes: (event: React.FormEvent<HTMLFormElement>) => void;
     updatingPatientId: string | null;
     savingNotesPatientId: string | null;
+}
+
+function buildInitials(name: string) {
+    const [first = "", second = ""] = name.trim().split(" ");
+    const initials = `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
+    return initials || "PT";
 }
 
 function RecordDetailsDialogComponent({
@@ -74,8 +81,19 @@ function RecordDetailsDialogComponent({
                     </DialogHeader>
 
                     <div className="rounded-2xl bg-primary/10/70 p-4 text-primary">
-                        <p className="text-lg font-semibold">{record.fullName}</p>
-                        <div className="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+                        <div className="flex items-center gap-3">
+                            <Avatar className="h-12 w-12 border border-primary/15">
+                                <AvatarImage src={record.profileImage || undefined} alt={record.fullName} />
+                                <AvatarFallback className="bg-white/80 text-primary">
+                                    {buildInitials(record.fullName)}
+                                </AvatarFallback>
+                            </Avatar>
+                            <div>
+                                <p className="text-lg font-semibold">{record.fullName}</p>
+                                <p className="text-xs uppercase tracking-wide text-primary/80">Patient record</p>
+                            </div>
+                        </div>
+                        <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
                             <div>
                                 <p className="text-xs uppercase tracking-wide text-primary">Patient ID</p>
                                 <p className="font-medium text-primary">{record.patientId}</p>

--- a/src/app/nurse/records/types.ts
+++ b/src/app/nurse/records/types.ts
@@ -32,6 +32,7 @@ export type PatientRecord = {
     date_of_birth: string | null;
     status: string;
     appointment_id: string | null;
+    profileImage?: string | null;
     department?: string | null;
     program?: string | null;
     year_level?: string | null;

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { toast } from "sonner";
 import {
     Loader2,
@@ -14,6 +14,7 @@ import {
     UserRound,
     KeyRound,
     HeartPulse,
+    Image as ImageIcon,
 } from "lucide-react";
 
 import PatientLayout from "@/components/patient/patient-layout";
@@ -39,6 +40,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { AccountCard } from "@/components/account/account-card";
 import { AccountRefreshButton } from "@/components/account/account-refresh-button";
 import { AccountSection } from "@/components/account/account-section";
@@ -160,6 +162,7 @@ const isBasicEducationDepartment = (dept?: string | null) => dept === BASIC_EDUC
 
 const departmentOptions = Object.values(patientDepartmentEnumMap);
 const bloodTypeOptions = Object.values(patientBloodTypeEnumMap);
+const MAX_AVATAR_SIZE_BYTES = 500 * 1024; // 500KB
 
 export type PatientAccountPageClientProps = {
     initialProfile: PatientAccountProfile | null;
@@ -190,6 +193,7 @@ export function PatientAccountPageClient({
     const [tempGender, setTempGender] = useState<"Male" | "Female" | "">("");
     const [showGenderConfirm, setShowGenderConfirm] = useState(false);
     const [refreshingProfile, setRefreshingProfile] = useState(false);
+    const avatarInputRef = useRef<HTMLInputElement | null>(null);
 
     const buildYearLevelPayload = (target: PatientAccountProfile) => {
         if (profileType !== "student") {
@@ -362,6 +366,44 @@ export function PatientAccountPageClient({
         profile?.year_level
     );
 
+    const profileInitials = (() => {
+        const first = profile?.fname?.charAt(0) ?? profile?.username?.charAt(0) ?? "";
+        const last = profile?.lname?.charAt(0) ?? profile?.username?.charAt(1) ?? "";
+        const initials = `${first}${last}`.toUpperCase();
+        return initials || "PT";
+    })();
+
+    const handleAvatarChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+
+        if (!file.type.startsWith("image/")) {
+            toast.error("Please upload an image file.");
+            return;
+        }
+
+        if (file.size > MAX_AVATAR_SIZE_BYTES) {
+            toast.error("Profile photo must be 500KB or smaller.");
+            return;
+        }
+
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            const result = reader.result;
+            if (typeof result === "string") {
+                setProfile((prev) => (prev ? { ...prev, profileImage: result } : prev));
+            }
+        };
+        reader.readAsDataURL(file);
+    };
+
+    const handleAvatarRemove = () => {
+        setProfile((prev) => (prev ? { ...prev, profileImage: null } : prev));
+        if (avatarInputRef.current) {
+            avatarInputRef.current.value = "";
+        }
+    };
+
     const handleProfileUpdate = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!profile) return;
@@ -442,6 +484,10 @@ export function PatientAccountPageClient({
                     const nextYearLevel = data.profile.year_level
                         ? patientYearLevelEnumMap[data.profile.year_level]
                         : prev?.year_level;
+                    const nextProfileImage =
+                        typeof data.profileImage === "string"
+                            ? data.profileImage
+                            : prev?.profileImage ?? null;
 
                     return {
                         ...prev!,
@@ -451,6 +497,7 @@ export function PatientAccountPageClient({
                         bloodtype: data.profile.bloodtype
                             ? patientBloodTypeEnumMap[data.profile.bloodtype]
                             : prev?.bloodtype,
+                        profileImage: nextProfileImage,
                     };
                 });
             }
@@ -538,6 +585,49 @@ export function PatientAccountPageClient({
                             onPasswordSubmit={handlePasswordSubmit}
                         >
                             <form onSubmit={handleProfileUpdate} className="space-y-10">
+                                <AccountSection
+                                    icon={ImageIcon}
+                                    title="Profile photo"
+                                    description="Personalize your account with a clear picture."
+                                >
+                                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                                        <Avatar className="h-20 w-20 border-2 border-emerald-100">
+                                            <AvatarImage
+                                                src={profile.profileImage || undefined}
+                                                alt={`${profile.fname} ${profile.lname}`.trim() || "User avatar"}
+                                            />
+                                            <AvatarFallback className="bg-emerald-50 text-emerald-700">
+                                                {profileInitials}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div className="space-y-2">
+                                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                                                <Input
+                                                    ref={avatarInputRef}
+                                                    type="file"
+                                                    accept="image/*"
+                                                    className="max-w-xs cursor-pointer"
+                                                    onChange={handleAvatarChange}
+                                                />
+                                                {profile.profileImage ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        className="rounded-xl"
+                                                        onClick={handleAvatarRemove}
+                                                    >
+                                                        Remove photo
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                            <p className="text-xs text-muted-foreground">
+                                                Upload a recent square photo under 500KB. If no image is saved, your initials
+                                                will be shown.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </AccountSection>
+
                                 <AccountSection
                                     icon={KeyRound}
                                     title="Account credentials"

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -448,7 +448,13 @@ export function PatientAccountPageClient({
             const res = await fetch("/api/patient/account/me", {
                 method: "PUT",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ profile: payload }),
+                body: JSON.stringify({
+                    profile: payload,
+                    profileImage:
+                        typeof updatedProfile.profileImage === "string"
+                            ? updatedProfile.profileImage
+                            : updatedProfile.profileImage ?? null,
+                }),
             });
 
             const data = await res.json();

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -31,6 +31,7 @@ export type PatientAccountProfileApi = {
     } | null;
     patientType?: string | null;
     type?: string | null;
+    profileImage?: string | null;
 };
 
 export const patientDepartmentEnumMap: Record<string, string> = {
@@ -114,6 +115,7 @@ export type PatientAccountProfile = {
     emergencyco_name?: string | null;
     emergencyco_num?: string | null;
     emergencyco_relation?: string | null;
+    profileImage?: string | null;
 };
 
 export type PatientAccountNormalization = {
@@ -136,6 +138,7 @@ export function normalizePatientAccountProfile(
         username: response.username || "",
         role: response.role || "",
         status: response.status || "Inactive",
+        profileImage: response.profileImage || null,
         fname: raw.fname || "",
         mname: raw.mname || "",
         lname: raw.lname || "",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -29,6 +29,7 @@ interface AppUser {
     name?: string | null;
     role: Role;
     status: AccountStatus;
+    image?: string | null;
 }
 
 interface AppJWT extends JWT {
@@ -36,6 +37,7 @@ interface AppJWT extends JWT {
     role?: Role;
     status?: AccountStatus;
     lastChecked?: number;
+    image?: string | null;
 }
 
 interface AppSession extends Session {
@@ -52,6 +54,7 @@ type FoundUser = {
     password: string;
     role: Role;
     status: AccountStatus;
+    profile_image?: string | null;
     student: { fname: string; lname: string } | null;
     employee: { fname: string; lname: string } | null;
 };
@@ -96,6 +99,7 @@ export const authOptions: NextAuthOptions = {
                             password: true,
                             role: true,
                             status: true,
+                            profile_image: true,
                             student: { select: { fname: true, lname: true } },
                             employee: { select: { fname: true, lname: true } },
                         },
@@ -157,6 +161,9 @@ export const authOptions: NextAuthOptions = {
                             : "User",
                     role: user.role,
                     status: user.status,
+                    image: user.profile_image
+                        ? `/api/profile/avatar/${user.user_id}`
+                        : null,
                 };
             },
         }),
@@ -172,6 +179,7 @@ export const authOptions: NextAuthOptions = {
                 token.name = u.name ?? token.name;
                 token.status = u.status;
                 token.lastChecked = Date.now();
+                token.image = u.image ?? token.image;
             } else if (token.id) {
                 // Refresh account status every five minutes to keep status in sync
                 const now = Date.now();
@@ -181,11 +189,14 @@ export const authOptions: NextAuthOptions = {
                     const dbUser = await withDb(() =>
                         prisma.users.findUnique({
                             where: { user_id: token.id as string },
-                            select: { status: true },
+                            select: { status: true, profile_image: true },
                         })
                     );
                     token.status = dbUser?.status ?? AccountStatus.Inactive;
                     (token as AppJWT).lastChecked = now;
+                    token.image = dbUser?.profile_image
+                        ? `/api/profile/avatar/${token.id}`
+                        : null;
                 }
             }
             return token as AppJWT;
@@ -199,6 +210,7 @@ export const authOptions: NextAuthOptions = {
                 session.user.role = t.role ?? Role.PATIENT;
                 session.user.name = t.name ?? session.user.name;
                 session.user.status = t.status ?? AccountStatus.Inactive;
+                session.user.image = t.image ?? session.user.image ?? null;
             }
             return session as AppSession;
         },

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,108 @@
+import crypto from "crypto";
+
+const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+const apiKey = process.env.CLOUDINARY_API_KEY;
+const apiSecret = process.env.CLOUDINARY_API_SECRET;
+
+export type CloudinaryUploadResult = {
+    secure_url?: string;
+    public_id?: string;
+};
+
+function assertCloudinaryConfig() {
+    if (!cloudName || !apiKey || !apiSecret) {
+        throw new Error("Cloudinary environment variables are missing");
+    }
+}
+
+function buildSignature(params: Record<string, string>) {
+    const sortedKeys = Object.keys(params).sort();
+    const toSign = sortedKeys
+        .map((key) => `${key}=${params[key]}`)
+        .join("&");
+    return crypto.createHash("sha1").update(`${toSign}${apiSecret}`).digest("hex");
+}
+
+export function extractPublicIdFromUrl(url: string | null | undefined): string | null {
+    if (!url) return null;
+    try {
+        const parsed = new URL(url);
+        const parts = parsed.pathname.split("/").filter(Boolean);
+        const uploadIndex = parts.findIndex((part) => part === "upload");
+        if (uploadIndex === -1) return null;
+        const publicIdParts = parts.slice(uploadIndex + 1);
+        const withoutVersion = publicIdParts[0]?.startsWith("v")
+            ? publicIdParts.slice(1)
+            : publicIdParts;
+        if (!withoutVersion.length) return null;
+        const filename = withoutVersion.join("/");
+        return decodeURIComponent(filename.replace(/\.[^./]+$/, ""));
+    } catch (error) {
+        console.error("[Cloudinary] Failed to parse public id", error);
+        return null;
+    }
+}
+
+export async function uploadDataUrlToCloudinary(
+    dataUrl: string,
+    userId: string
+): Promise<CloudinaryUploadResult> {
+    assertCloudinaryConfig();
+    const timestamp = Math.round(Date.now() / 1000);
+    const folder = "hnu-clinic-app/avatars";
+    const publicId = `user_${userId}`;
+    const signature = buildSignature({
+        folder,
+        public_id: publicId,
+        timestamp: String(timestamp),
+    });
+
+    const form = new FormData();
+    form.append("file", dataUrl);
+    form.append("api_key", apiKey!);
+    form.append("timestamp", String(timestamp));
+    form.append("signature", signature);
+    form.append("folder", folder);
+    form.append("public_id", publicId);
+    form.append("overwrite", "true");
+    form.append("invalidate", "true");
+
+    const res = await fetch(
+        `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
+        { method: "POST", body: form }
+    );
+
+    if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(`Cloudinary upload failed: ${errorText}`);
+    }
+
+    return (await res.json()) as CloudinaryUploadResult;
+}
+
+export async function deleteCloudinaryImage(publicId: string) {
+    assertCloudinaryConfig();
+    const timestamp = Math.round(Date.now() / 1000);
+    const signature = buildSignature({
+        public_id: publicId,
+        timestamp: String(timestamp),
+    });
+
+    const form = new FormData();
+    form.append("public_id", publicId);
+    form.append("api_key", apiKey!);
+    form.append("timestamp", String(timestamp));
+    form.append("signature", signature);
+
+    const res = await fetch(
+        `https://api.cloudinary.com/v1_1/${cloudName}/image/destroy`,
+        { method: "POST", body: form }
+    );
+
+    if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(`Cloudinary delete failed: ${errorText}`);
+    }
+
+    return res.json();
+}

--- a/src/lib/patient-records.ts
+++ b/src/lib/patient-records.ts
@@ -26,6 +26,7 @@ export type PatientRecordEntry = {
     gender: string | null;
     date_of_birth: string | null;
     status: string;
+    profileImage?: string | null;
     department?: string | null;
     program?: string | null;
     year_level?: string | null;
@@ -140,6 +141,7 @@ export async function fetchPatientRecords(): Promise<PatientRecordEntry[]> {
                         role: true,
                         status: true,
                         user_id: true,
+                        profile_image: true,
                         appointmentsPatient: appointmentSelection,
                     },
                 },
@@ -153,6 +155,7 @@ export async function fetchPatientRecords(): Promise<PatientRecordEntry[]> {
                         role: true,
                         status: true,
                         user_id: true,
+                        profile_image: true,
                         appointmentsPatient: appointmentSelection,
                     },
                 },
@@ -172,6 +175,9 @@ export async function fetchPatientRecords(): Promise<PatientRecordEntry[]> {
             gender: student.gender ?? null,
             date_of_birth: student.date_of_birth?.toISOString() ?? null,
             status: student.user.status,
+            profileImage: student.user.profile_image
+                ? `/api/profile/avatar/${student.user.user_id}`
+                : null,
             department: student.department,
             program: student.program,
             year_level: student.year_level,
@@ -219,6 +225,9 @@ export async function fetchPatientRecords(): Promise<PatientRecordEntry[]> {
             gender: employee.gender ?? null,
             date_of_birth: employee.date_of_birth?.toISOString() ?? null,
             status: employee.user.status,
+            profileImage: employee.user.profile_image
+                ? `/api/profile/avatar/${employee.user.user_id}`
+                : null,
             contactno: employee.contactno,
             address: employee.address,
             bloodtype: employee.bloodtype,


### PR DESCRIPTION
## Summary
- add user profile image storage and authenticated avatar delivery endpoint
- enable patients to upload or remove their profile photo within the account page
- surface stored profile avatars in patient records for staff dashboards

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692128402c688327971428e28b5cbd75)