### PR TITLE
Add SMS delivery to password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ prisma/
 | `GMAIL_CLIENT_ID` | OAuth client ID for Gmail API access (`src/lib/email.ts`). |
 | `GMAIL_CLIENT_SECRET` | OAuth client secret paired with the client ID (`src/lib/email.ts`). |
 | `GMAIL_REFRESH_TOKEN` | Long-lived refresh token used to mint Gmail access tokens (`src/lib/email.ts`). |
+| `PHILSMS_APP_KEY` | API key for the PhilSMS gateway when sending password reset codes via SMS (`src/lib/sms.ts`). |
+| `PHILSMS_APP_SECRET` | API secret for PhilSMS requests (`src/lib/sms.ts`). |
+| `PHILSMS_SENDER_ID` | Optional branded sender ID/label for outbound PhilSMS messages (`src/lib/sms.ts`). |
+| `PHILSMS_API_URL` | Optional override for the PhilSMS API endpoint (defaults to `https://app.philsms.com/api/v3/sms/send`). |
 | `NEXT_PUBLIC_APP_URL` | Public base URL used by nurse-side server actions (`src/app/nurse/actions.ts`). |
 | `TZ` | Time-zone override (set to `Asia/Manila` in `next.config.ts`). |
 

--- a/src/app/api/auth/request-reset/route.ts
+++ b/src/app/api/auth/request-reset/route.ts
@@ -6,6 +6,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { sendEmail } from "@/lib/email";
 import { normalizeResetContact } from "@/lib/password-reset";
+import { sendSms } from "@/lib/sms";
 import { generateNumericCode } from "@/lib/security";
 import { ipKey, jsonFieldKey, withRateLimit } from "@/lib/rate-limit";
 
@@ -28,7 +29,7 @@ async function handler(req: Request) {
 
         if (typeof contact !== "string") {
             return NextResponse.json(
-                { error: "Contact email is required." },
+                { error: "Email address or mobile number is required." },
                 { status: 400 }
             );
         }
@@ -37,37 +38,57 @@ async function handler(req: Request) {
 
         if (!normalized) {
             return NextResponse.json(
-                { error: "Enter a valid email address." },
+                { error: "Enter a valid email address or mobile number." },
                 { status: 400 }
             );
         }
 
-        // Find user by email
+        // Find user by email or mobile number
         const user = await prisma.users.findFirst({
-            where: {
-                OR: [
-                    {
-                        student: {
-                            is: {
-                                email: {
-                                    equals: normalized.normalized,
-                                    mode: "insensitive",
-                                },
-                            },
-                        },
-                    },
-                    {
-                        employee: {
-                            is: {
-                                email: {
-                                    equals: normalized.normalized,
-                                    mode: "insensitive",
-                                },
-                            },
-                        },
-                    },
-                ],
-            },
+            where:
+                normalized.type === "EMAIL"
+                    ? {
+                          OR: [
+                              {
+                                  student: {
+                                      is: {
+                                          email: {
+                                              equals: normalized.normalized,
+                                              mode: "insensitive",
+                                          },
+                                      },
+                                  },
+                              },
+                              {
+                                  employee: {
+                                      is: {
+                                          email: {
+                                              equals: normalized.normalized,
+                                              mode: "insensitive",
+                                          },
+                                      },
+                                  },
+                              },
+                          ],
+                      }
+                    : {
+                          OR: [
+                              {
+                                  student: {
+                                      is: {
+                                          contactno: { in: normalized.variants },
+                                      },
+                                  },
+                              },
+                              {
+                                  employee: {
+                                      is: {
+                                          contactno: { in: normalized.variants },
+                                      },
+                                  },
+                              },
+                          ],
+                      },
             include: {
                 student: { select: { fname: true, lname: true } },
                 employee: { select: { fname: true, lname: true } },
@@ -77,7 +98,7 @@ async function handler(req: Request) {
         if (!user) {
             return NextResponse.json({
                 success: true,
-                message: "If an account exists for that email, a reset code has been sent.",
+                message: "If an account exists for that contact, a reset code has been sent.",
             });
         }
 
@@ -171,27 +192,46 @@ If you didn't request this, please ignore this email.
 This message was automatically sent from the HNU Clinic Capstone Project website.`;
 
         try {
-            await sendEmail({
-                to: normalized.normalized,
-                subject: "Password Reset Code",
-                html: htmlContent,
-                fromName: "HNU Clinic",
-                text: textContent,
-            });
-        } catch (emailError) {
-            console.error("Failed to send reset email:", emailError);
+            if (normalized.type === "EMAIL") {
+                await sendEmail({
+                    to: normalized.normalized,
+                    subject: "Password Reset Code",
+                    html: htmlContent,
+                    fromName: "HNU Clinic",
+                    text: textContent,
+                });
+            } else {
+                const smsMessage = [
+                    "HNU Clinic password reset code:",
+                    code,
+                    "This code will expire in 10 minutes.",
+                    "Ignore this message if you did not request it.",
+                ].join("\n");
+
+                await sendSms({
+                    to: normalized.normalized,
+                    message: smsMessage,
+                });
+            }
+        } catch (sendError) {
+            console.error("Failed to send reset notification:", sendError);
             try {
                 await prisma.passwordResetToken.delete({ where: { id: createdToken.id } });
             } catch (cleanupError) {
                 console.error(
-                    "Failed to clean up reset token after email error:",
+                    "Failed to clean up reset token after notification error:",
                     cleanupError,
                 );
             }
 
             const missingSender =
-                emailError instanceof Error &&
-                emailError.message.includes("Missing GMAIL_USER in environment");
+                sendError instanceof Error &&
+                sendError.message.includes("Missing GMAIL_USER in environment");
+
+            const missingSmsCredentials =
+                sendError instanceof Error &&
+                (sendError.message.includes("PHILSMS_APP_KEY") ||
+                    sendError.message.includes("PHILSMS_APP_SECRET"));
 
             if (missingSender) {
                 return NextResponse.json(
@@ -200,15 +240,22 @@ This message was automatically sent from the HNU Clinic Capstone Project website
                 );
             }
 
+            if (missingSmsCredentials) {
+                return NextResponse.json(
+                    { error: "SMS service is not configured." },
+                    { status: 500 },
+                );
+            }
+
             return NextResponse.json(
-                { error: "Failed to send reset email. Please try again later." },
+                { error: "Failed to send reset code. Please try again later." },
                 { status: 500 },
             );
         }
 
         return NextResponse.json({
             success: true,
-            message: "If an account exists for that email, a reset code has been sent.",
+            message: "If an account exists for that contact, a reset code has been sent.",
         });
     } catch (error: unknown) {
         console.error("REQUEST-RESET ERROR DETAILS:", error);
@@ -243,7 +290,7 @@ export const POST = withRateLimit(
             limit: 4,
             windowMs: 60 * 60_000,
             message:
-                "Too many reset requests for this email. Please wait before requesting another code.",
+                "Too many reset requests for this contact. Please wait before requesting another code.",
         },
     ],
     handler

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -23,7 +23,7 @@ async function handler(req: Request) {
 
         if (!normalized) {
             return NextResponse.json(
-                { error: "Enter a valid email address." },
+                { error: "Enter a valid email address or mobile number." },
                 { status: 400 }
             );
         }

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -150,7 +150,7 @@ export default function LoginPageClient() {
         const trimmed = currentContact.trim();
         const normalized = normalizeResetContact(trimmed);
         if (!normalized) {
-            setContactError("Enter a valid email address.");
+            setContactError("Enter a valid email address or mobile number.");
             return false;
         }
 
@@ -165,7 +165,8 @@ export default function LoginPageClient() {
             });
             const data = await res.json();
             if (res.ok) {
-                toast.success("Verification code sent via email!");
+                const channel = normalized.type === "SMS" ? "SMS" : "email";
+                toast.success(`Verification code sent via ${channel}!`);
                 setTokenSent(true);
                 setResendCooldown(60);
                 return true;
@@ -429,8 +430,8 @@ export default function LoginPageClient() {
                         <DialogTitle className="text-primary">Reset Password</DialogTitle>
                         <DialogDescription className="text-gray-600">
                             {tokenSent
-                                ? "Enter the 6 digit code sent to your email and set your new password."
-                                : "Enter your registered email address to receive a reset code."}
+                                ? "Enter the 6 digit code we sent and set your new password."
+                                : "Enter your registered email or mobile number to receive a reset code."}
                         </DialogDescription>
                     </DialogHeader>
 
@@ -443,7 +444,7 @@ export default function LoginPageClient() {
                                         setContact(e.target.value);
                                         if (contactError) setContactError(null);
                                     }}
-                                    placeholder="Enter email address"
+                                    placeholder="Enter email or mobile number"
                                     disabled={verifying}
                                     required
                                 />
@@ -451,7 +452,7 @@ export default function LoginPageClient() {
                                     <p className="text-sm text-red-600">{contactError}</p>
                                 )}
                                 <p className="text-xs text-slate-500">
-                                    We&apos;ll send a 6-digit code to your email address.
+                                    We&apos;ll send a 6-digit code to your email inbox or via SMS.
                                 </p>
                             </div>
                             <DialogFooter className="flex-col gap-2 sm:flex-row">

--- a/src/lib/password-reset.ts
+++ b/src/lib/password-reset.ts
@@ -1,4 +1,4 @@
-export type ResetContactType = "EMAIL";
+export type ResetContactType = "EMAIL" | "SMS";
 
 export interface NormalizedContact {
     normalized: string;
@@ -7,6 +7,47 @@ export interface NormalizedContact {
 }
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PH_MOBILE_DIGITS = /\d/g;
+
+function normalizePhilippineMobile(input: string): NormalizedContact | null {
+    const digitsOnly = input.match(PH_MOBILE_DIGITS)?.join("") ?? "";
+
+    if (!digitsOnly) {
+        return null;
+    }
+
+    // Common patterns: 09XXXXXXXXX (11 digits) or +639XXXXXXXXX (12 digits without plus)
+    if (digitsOnly.length === 11 && digitsOnly.startsWith("09")) {
+        const e164 = `+63${digitsOnly.slice(1)}`;
+        return {
+            normalized: e164,
+            type: "SMS",
+            variants: [e164, digitsOnly, `63${digitsOnly.slice(1)}`],
+        };
+    }
+
+    if (digitsOnly.length === 12 && digitsOnly.startsWith("639")) {
+        const e164 = `+${digitsOnly}`;
+        const local = `0${digitsOnly.slice(2)}`;
+        return {
+            normalized: e164,
+            type: "SMS",
+            variants: [e164, digitsOnly, local],
+        };
+    }
+
+    if (digitsOnly.length === 10 && digitsOnly.startsWith("9")) {
+        const e164 = `+63${digitsOnly}`;
+        const local = `0${digitsOnly}`;
+        return {
+            normalized: e164,
+            type: "SMS",
+            variants: [e164, digitsOnly, local],
+        };
+    }
+
+    return null;
+}
 
 /**
  * Ensures the reset contact is a valid email and returns normalized variants.
@@ -16,6 +57,11 @@ export function normalizeResetContact(input: string): NormalizedContact | null {
 
     if (!raw) {
         return null;
+    }
+
+    const phone = normalizePhilippineMobile(raw);
+    if (phone) {
+        return phone;
     }
 
     if (!EMAIL_REGEX.test(raw)) {

--- a/src/lib/sms.ts
+++ b/src/lib/sms.ts
@@ -1,0 +1,55 @@
+import fetch from "node-fetch";
+
+function getRequiredEnv(name: string): string {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error(`Missing ${name} in environment`);
+    }
+    return value;
+}
+
+export interface SmsPayload {
+    to: string;
+    message: string;
+}
+
+export async function sendSms({ to, message }: SmsPayload): Promise<void> {
+    const appKey = getRequiredEnv("PHILSMS_APP_KEY");
+    const appSecret = getRequiredEnv("PHILSMS_APP_SECRET");
+    const senderId = process.env.PHILSMS_SENDER_ID?.trim();
+
+    const payload: Record<string, unknown> = {
+        app_key: appKey,
+        app_secret: appSecret,
+        recipients: [to],
+        message,
+    };
+
+    if (senderId) {
+        payload.sender_id = senderId;
+    }
+
+    const response = await fetch(
+        process.env.PHILSMS_API_URL?.trim() || "https://app.philsms.com/api/v3/sms/send",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        },
+    );
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`PhilSMS request failed (${response.status}): ${errorText}`);
+    }
+
+    const result = (await response.json()) as {
+        success?: boolean;
+        code?: number;
+        message?: string;
+    };
+
+    if (result.success === false || (typeof result.code === "number" && result.code >= 400)) {
+        throw new Error(result.message || "PhilSMS rejected the SMS payload.");
+    }
+}


### PR DESCRIPTION
## Summary
- add SMS-capable contact normalization for password reset requests
- send reset codes through PhilSMS when a mobile number is provided and document required environment variables
- update login reset UI messaging for email or SMS delivery

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692174cddf088327aa71d17e09b2d1b6)