### PR TITLE
Refactor role dashboards with shared components

### DIFF
--- a/src/app/doctor/page.tsx
+++ b/src/app/doctor/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
 import Link from "next/link";
-import { useSession } from "next-auth/react";
 import {
     CalendarDays,
     ClipboardList,
@@ -12,9 +10,12 @@ import {
     Clock4,
 } from "lucide-react";
 
+import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
+import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
 import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
 const managementAreas = [
     {
@@ -66,9 +67,7 @@ const operationalHighlights = [
 ];
 
 export default function DoctorDashboardPage() {
-    const { data: session } = useSession();
-    const fullName = session?.user?.name ?? "Doctor";
-    const firstName = useMemo(() => fullName.split(" ")[0] || fullName, [fullName]);
+    const { firstName } = useDashboardUser("Doctor");
 
     return (
         <DoctorLayout
@@ -80,65 +79,24 @@ export default function DoctorDashboardPage() {
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-primary/5 p-6 shadow-sm">
-                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="space-y-3">
-                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">
-                            Welcome back
-                        </p>
-                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">
-                            Good day, Dr. {firstName}
-                        </h3>
-                        <p className="max-w-2xl text-sm text-muted-foreground">
-                            Review key updates for the day, respond to appointment movements, and keep your consultation schedule aligned with campus demand.
-                        </p>
-                    </div>
-                </div>
-            </section>
+            <DashboardWelcome
+                heading={`Good day, Dr. ${firstName}`}
+                description="Review key updates for the day, respond to appointment movements, and keep your consultation schedule aligned with campus demand."
+                className="bg-linear-to-r"
+            />
 
-            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-                {managementAreas.map(({ title, description, href, icon: Icon, cta }) => (
-                    <Card
-                        key={title}
-                        className="h-full rounded-3xl border-primary/20 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
-                    >
-                        <CardHeader className="flex flex-row items-start justify-between gap-3">
-                            <div className="space-y-1">
-                                <CardTitle className="flex items-center gap-3 text-lg text-primary">
-                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                        <Icon className="h-5 w-5" />
-                                    </span>
-                                    {title}
-                                </CardTitle>
-                                <p className="text-sm font-normal text-muted-foreground">{description}</p>
-                            </div>
-                        </CardHeader>
-                        <CardContent>
-                            <Button asChild variant="ghost" className="rounded-xl bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20">
-                                <Link href={href}>{cta}</Link>
-                            </Button>
-                        </CardContent>
-                    </Card>
-                ))}
-                <Card className="h-full rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-3 text-lg">
-                            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
-                                <Stethoscope className="h-5 w-5" />
-                            </span>
-                            Clinic insights
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
-                        <p>
-                            Align your consultation blocks with high-demand clinics to reduce wait times and improve patient satisfaction.
-                        </p>
-                        <p>
-                            Use the dispensing log to monitor supply usage so the pharmacy team can replenish critical medicines on schedule.
-                        </p>
-                    </CardContent>
-                </Card>
-            </section>
+            <QuickActionsGrid
+                actions={managementAreas}
+                highlight={{
+                    title: "Clinic insights",
+                    icon: Stethoscope,
+                    description: [
+                        "Align your consultation blocks with high-demand clinics to reduce wait times and improve patient satisfaction.",
+                        "Use the dispensing log to monitor supply usage so the pharmacy team can replenish critical medicines on schedule.",
+                    ],
+                    className: "bg-linear-to-br",
+                }}
+            />
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">

--- a/src/app/nurse/page.tsx
+++ b/src/app/nurse/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
 import Link from "next/link";
-import { useSession } from "next-auth/react";
 import {
     BarChart3,
     ClipboardCheck,
@@ -10,6 +8,8 @@ import {
     Users,
 } from "lucide-react";
 
+import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
+import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
 import { NurseLayout } from "@/components/nurse/nurse-layout";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +18,7 @@ import {
     CardHeader,
     CardTitle,
 } from "@/components/ui/card";
+import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
 const quickActions = [
     {
@@ -44,9 +45,7 @@ const quickActions = [
 ];
 
 export default function NurseDashboardPage() {
-    const { data: session } = useSession();
-    const fullName = session?.user?.name ?? "Nurse";
-    const firstName = useMemo(() => fullName.split(" ")[0] || fullName, [fullName]);
+    const { firstName } = useDashboardUser("Nurse");
 
     return (
         <NurseLayout
@@ -58,61 +57,22 @@ export default function NurseDashboardPage() {
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-primary/20 bg-gradient-to-r from-primary/10 via-white to-primary/5 p-6 shadow-sm">
-                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="space-y-2">
-                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Welcome back</p>
-                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">Good day, Nurse {firstName}</h3>
-                        <p className="max-w-2xl text-sm text-muted-foreground">
-                            Keep the clinic running smoothly with instant visibility into schedules, stock levels, and patient coordination. Use the quick tools below to support the care team.
-                        </p>
-                    </div>
-                </div>
-            </section>
+            <DashboardWelcome
+                heading={`Good day, Nurse ${firstName}`}
+                description="Keep the clinic running smoothly with instant visibility into schedules, stock levels, and patient coordination. Use the quick tools below to support the care team."
+            />
 
-            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-                {quickActions.map(({ title, description, href, icon: Icon, cta }) => (
-                    <Card
-                        key={title}
-                        className="h-full rounded-3xl border-primary/20 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
-                    >
-                        <CardHeader className="flex flex-row items-start justify-between gap-3">
-                            <div className="space-y-1">
-                                <CardTitle className="flex items-center gap-3 text-lg text-primary">
-                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                        <Icon className="h-5 w-5" />
-                                    </span>
-                                    {title}
-                                </CardTitle>
-                                <p className="text-sm font-normal text-muted-foreground">{description}</p>
-                            </div>
-                        </CardHeader>
-                        <CardContent>
-                            <Button asChild variant="ghost" className="rounded-xl bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20">
-                                <Link href={href}>{cta}</Link>
-                            </Button>
-                        </CardContent>
-                    </Card>
-                ))}
-                <Card className="h-full rounded-3xl border-primary/20 bg-gradient-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-3 text-lg">
-                            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
-                                <BarChart3 className="h-5 w-5" />
-                            </span>
-                            Operations insights
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
-                        <p>
-                            Align on clinic traffic peaks early to balance resources and shorten wait times for students and staff.
-                        </p>
-                        <p>
-                            Keep communication logs updated so physicians can review triage actions and respond to follow-up needs quickly.
-                        </p>
-                    </CardContent>
-                </Card>
-            </section>
+            <QuickActionsGrid
+                actions={quickActions}
+                highlight={{
+                    title: "Operations insights",
+                    icon: BarChart3,
+                    description: [
+                        "Align on clinic traffic peaks early to balance resources and shorten wait times for students and staff.",
+                        "Keep communication logs updated so physicians can review triage actions and respond to follow-up needs quickly.",
+                    ],
+                }}
+            />
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">

--- a/src/app/patient/page.tsx
+++ b/src/app/patient/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
 import Link from "next/link";
-import { useSession } from "next-auth/react";
 import { Bell, CalendarDays, Stethoscope, User } from "lucide-react";
 
+import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
+import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
 import PatientLayout from "@/components/patient/patient-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
 const quickActions = [
     {
@@ -40,9 +41,7 @@ const wellnessHighlights = [
 ];
 
 export default function PatientDashboardPage() {
-    const { data: session } = useSession();
-    const fullName = session?.user?.name ?? "Patient";
-    const firstName = useMemo(() => fullName.split(" ")[0] || fullName, [fullName]);
+    const { firstName } = useDashboardUser("Patient");
 
     return (
         <PatientLayout
@@ -54,58 +53,24 @@ export default function PatientDashboardPage() {
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-primary/5 p-6 shadow-sm">
-                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="space-y-2">
-                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Welcome back</p>
-                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">Hello, {firstName}</h3>
-                        <p className="max-w-2xl text-sm text-muted-foreground">
-                            Stay on top of your health journey. From this dashboard you can update your profile, manage bookings, and monitor clinic communications tailored for you.
-                        </p>
-                    </div>
-                </div>
-            </section>
+            <DashboardWelcome
+                heading={`Hello, ${firstName}`}
+                description="Stay on top of your health journey. From this dashboard you can update your profile, manage bookings, and monitor clinic communications tailored for you."
+                className="bg-linear-to-r"
+            />
 
-            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-                {quickActions.map(({ title, description, href, icon: Icon, cta }) => (
-                    <Card key={title} className="h-full rounded-3xl border-primary/20 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
-                        <CardHeader className="flex flex-row items-start justify-between gap-3">
-                            <div className="space-y-1">
-                                <CardTitle className="flex items-center gap-3 text-lg text-primary">
-                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                        <Icon className="h-5 w-5" />
-                                    </span>
-                                    {title}
-                                </CardTitle>
-                                <p className="text-sm font-normal text-muted-foreground">{description}</p>
-                            </div>
-                        </CardHeader>
-                        <CardContent>
-                            <Button asChild variant="ghost" className="rounded-xl bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20">
-                                <Link href={href}>{cta}</Link>
-                            </Button>
-                        </CardContent>
-                    </Card>
-                ))}
-                <Card className="h-full rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-3 text-lg">
-                            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
-                                <Stethoscope className="h-5 w-5" />
-                            </span>
-                            Clinic insights
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3 text-sm leading-relaxed">
-                        <p className="text-white/90">
-                            Walk-ins are accommodated based on availability. Booking ahead ensures your preferred doctor and service are ready when you arrive.
-                        </p>
-                        <p className="text-white/90">
-                            Keep notifications enabled to receive movement updates, instructions, and reminders directly from the clinic team.
-                        </p>
-                    </CardContent>
-                </Card>
-            </section>
+            <QuickActionsGrid
+                actions={quickActions}
+                highlight={{
+                    title: "Clinic insights",
+                    icon: Stethoscope,
+                    description: [
+                        "Walk-ins are accommodated based on availability. Booking ahead ensures your preferred doctor and service are ready when you arrive.",
+                        "Keep notifications enabled to receive movement updates, instructions, and reminders directly from the clinic team.",
+                    ],
+                    className: "bg-linear-to-br",
+                }}
+            />
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">

--- a/src/components/dashboard/dashboard-welcome.tsx
+++ b/src/components/dashboard/dashboard-welcome.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface DashboardWelcomeProps {
+    eyebrow?: string;
+    heading: string;
+    description: string;
+    className?: string;
+    children?: ReactNode;
+}
+
+export function DashboardWelcome({
+    eyebrow = "Welcome back",
+    heading,
+    description,
+    className,
+    children,
+}: DashboardWelcomeProps) {
+    return (
+        <section
+            className={cn(
+                "rounded-3xl border border-primary/20 bg-gradient-to-r from-primary/10 via-white to-primary/5 p-6 shadow-sm",
+                className,
+            )}
+        >
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-2">
+                    <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">{eyebrow}</p>
+                    <h3 className="text-3xl font-semibold text-primary md:text-4xl">{heading}</h3>
+                    <p className="max-w-2xl text-sm text-muted-foreground">{description}</p>
+                </div>
+                {children}
+            </div>
+        </section>
+    );
+}

--- a/src/components/dashboard/quick-actions-grid.tsx
+++ b/src/components/dashboard/quick-actions-grid.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import { LucideIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface QuickAction {
+    title: string;
+    description: string;
+    href: string;
+    icon: LucideIcon;
+    cta: string;
+}
+
+interface HighlightCardProps {
+    title: string;
+    icon: LucideIcon;
+    description: string[];
+    className?: string;
+}
+
+interface QuickActionsGridProps {
+    actions: QuickAction[];
+    highlight: HighlightCardProps;
+    className?: string;
+}
+
+export function QuickActionsGrid({ actions, highlight, className }: QuickActionsGridProps) {
+    const { title, icon: HighlightIcon, description: highlightDescription, className: highlightClassName } = highlight;
+
+    return (
+        <section className={cn("grid gap-5 md:grid-cols-2 xl:grid-cols-3", className)}>
+            {actions.map(({ title: actionTitle, description, href, icon: Icon, cta }) => (
+                <Card
+                    key={actionTitle}
+                    className="h-full rounded-3xl border-primary/20 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+                >
+                    <CardHeader className="flex flex-row items-start justify-between gap-3">
+                        <div className="space-y-1">
+                            <CardTitle className="flex items-center gap-3 text-lg text-primary">
+                                <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                                    <Icon className="h-5 w-5" />
+                                </span>
+                                {actionTitle}
+                            </CardTitle>
+                            <p className="text-sm font-normal text-muted-foreground">{description}</p>
+                        </div>
+                    </CardHeader>
+                    <CardContent>
+                        <Button asChild variant="ghost" className="rounded-xl bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20">
+                            <Link href={href}>{cta}</Link>
+                        </Button>
+                    </CardContent>
+                </Card>
+            ))}
+            <Card
+                className={cn(
+                    "h-full rounded-3xl border-primary/20 bg-gradient-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md",
+                    highlightClassName,
+                )}
+            >
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-3 text-lg">
+                        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
+                            <HighlightIcon className="h-5 w-5" />
+                        </span>
+                        {title}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
+                    {highlightDescription.map((paragraph) => (
+                        <p key={paragraph}>{paragraph}</p>
+                    ))}
+                </CardContent>
+            </Card>
+        </section>
+    );
+}

--- a/src/components/dashboard/quick-actions-grid.tsx
+++ b/src/components/dashboard/quick-actions-grid.tsx
@@ -56,7 +56,7 @@ export function QuickActionsGrid({ actions, highlight, className }: QuickActions
             ))}
             <Card
                 className={cn(
-                    "h-full rounded-3xl border-primary/20 bg-gradient-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md",
+                    "h-full rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md",
                     highlightClassName,
                 )}
             >

--- a/src/hooks/use-dashboard-user.ts
+++ b/src/hooks/use-dashboard-user.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSession } from "next-auth/react";
+
+export function useDashboardUser(fallbackName: string) {
+    const { data: session } = useSession();
+    const fullName = session?.user?.name ?? fallbackName;
+    const firstName = useMemo(() => fullName.split(" ")[0] || fullName, [fullName]);
+
+    return { firstName, fullName };
+}


### PR DESCRIPTION
## Summary
- add shared dashboard welcome and quick action components for consistent layouts
- centralize dashboard user name handling through a reusable hook
- update doctor, nurse, and patient dashboards to leverage shared UI blocks while keeping role-specific content

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228e66dfa08327a88bfd27a90b5094)