### PR TITLE
Refactor dashboards with unified green design

### DIFF
--- a/src/app/doctor/page.tsx
+++ b/src/app/doctor/page.tsx
@@ -2,68 +2,62 @@
 
 import Link from "next/link";
 import {
+    Activity,
+    Bell,
     CalendarDays,
     ClipboardList,
+    HeartPulse,
     Pill,
     Stethoscope,
-    UserCog,
-    Clock4,
 } from "lucide-react";
 
-import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
-import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
+import { StatCard } from "@/components/dashboard/stat-card";
 import DoctorLayout from "@/components/doctor/doctor-layout";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
-const managementAreas = [
+const schedule = [
     {
-        title: "Account management",
-        description:
-            "Update your profile, change credentials, and review administrative access details to stay compliant.",
-        href: "/doctor/account",
-        icon: UserCog,
-        cta: "Review account",
+        label: "Dental consultation",
+        patient: "Lauren Laboy",
+        time: "09:00 AM",
+        status: "Confirmed",
     },
     {
-        title: "Consultation hours",
-        description:
-            "Configure clinics, adjust availability, and publish upcoming consultation windows for students and staff.",
-        href: "/doctor/consultation",
-        icon: Clock4,
-        cta: "Manage schedule",
+        label: "General check-up",
+        patient: "Albert Green",
+        time: "10:30 AM",
+        status: "On site",
     },
     {
-        title: "Appointment oversight",
-        description:
-            "Approve requests, document visit outcomes, and coordinate reschedules with the clinic care team.",
-        href: "/doctor/appointments",
-        icon: CalendarDays,
-        cta: "View appointments",
-    },
-    {
-        title: "Medicine dispensing",
-        description:
-            "Record dispensed medicines, verify inventory balances, and ensure prescriptions are properly documented.",
-        href: "/doctor/dispense",
-        icon: Pill,
-        cta: "Log dispense",
-    },
-    {
-        title: "Patient insights",
-        description:
-            "Review patient records, access latest consultations, and prepare for follow-up care.",
-        href: "/doctor/patients",
-        icon: ClipboardList,
-        cta: "Open registry",
+        label: "Follow-up",
+        patient: "Quentin Cruz",
+        time: "01:00 PM",
+        status: "Pending",
     },
 ];
 
-const operationalHighlights = [
-    "Coordinate with the nursing team before updating consultation slots to prevent scheduling conflicts.",
-    "All appointment adjustments notify the patient automatically—include clear notes for reschedules or cancellations.",
-    "Document dispensed medicines within the same day to keep the inventory ledger accurate.",
+const quickLinks = [
+    { label: "Account settings", href: "/doctor/account" },
+    { label: "Consultation hours", href: "/doctor/consultation" },
+    { label: "Appointment queue", href: "/doctor/appointments" },
+    { label: "Dispensing log", href: "/doctor/dispense" },
+    { label: "Patient registry", href: "/doctor/patients" },
+];
+
+const patientOverview = [
+    { label: "New patients", value: 34, accent: "bg-emerald-500" },
+    { label: "Returning", value: 112, accent: "bg-primary" },
+    { label: "Follow-ups", value: 48, accent: "bg-emerald-300" },
+    { label: "Meds dispensed", value: 76, accent: "bg-primary/70" },
 ];
 
 export default function DoctorDashboardPage() {
@@ -72,62 +66,154 @@ export default function DoctorDashboardPage() {
     return (
         <DoctorLayout
             title="Clinical operations overview"
-            description="Monitor your upcoming schedule, manage patient interactions, and streamline coordination with the HNU Clinic team."
+            description="Monitor upcoming visits, streamline coordination, and keep your clinic view organized."
             actions={
                 <Button asChild className="hidden rounded-xl bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 md:flex">
                     <Link href="/doctor/consultation">Update availability</Link>
                 </Button>
             }
         >
-            <DashboardWelcome
-                heading={`Good day, Dr. ${firstName}`}
-                description="Review key updates for the day, respond to appointment movements, and keep your consultation schedule aligned with campus demand."
-                className="bg-linear-to-r"
-            />
+            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-emerald-50 p-8 shadow-sm">
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                    <div className="space-y-3">
+                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Good morning</p>
+                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">Dr. {firstName}, here&apos;s today&apos;s plan</h3>
+                        <p className="max-w-2xl text-sm text-muted-foreground">
+                            Check your schedule, review follow-up tasks, and keep dispensing logs up to date. Everything you need for today&apos;s campus visits is summarized below.
+                        </p>
+                        <div className="flex flex-wrap gap-3">
+                            <Badge className="rounded-full bg-primary/15 px-3 py-1 text-primary">Clinic synced</Badge>
+                            <Badge variant="secondary" className="rounded-full bg-white text-primary shadow-sm">
+                                <Stethoscope className="mr-1.5 h-4 w-4" />
+                                3 active clinics
+                            </Badge>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-4 rounded-2xl border border-primary/20 bg-white/80 px-5 py-4 shadow-sm">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+                            <HeartPulse className="h-5 w-5" />
+                        </div>
+                        <div>
+                            <p className="text-sm text-muted-foreground">Next consultation</p>
+                            <p className="text-lg font-semibold text-primary">09:00 AM · Dental</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
 
-            <QuickActionsGrid
-                actions={managementAreas}
-                highlight={{
-                    title: "Clinic insights",
-                    icon: Stethoscope,
-                    description: [
-                        "Align your consultation blocks with high-demand clinics to reduce wait times and improve patient satisfaction.",
-                        "Use the dispensing log to monitor supply usage so the pharmacy team can replenish critical medicines on schedule.",
-                    ],
-                    className: "bg-linear-to-br",
-                }}
-            />
+            <section className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <StatCard
+                    title="Today&apos;s visits"
+                    value="23"
+                    helper="Arrivals across all clinics"
+                    icon={CalendarDays}
+                    trendLabel="+4"
+                    trendValue="vs yesterday"
+                />
+                <StatCard
+                    title="Medications dispensed"
+                    value="148"
+                    helper="Across 18 prescriptions"
+                    icon={Pill}
+                    trendLabel="+12"
+                    trendValue="new"
+                />
+                <StatCard
+                    title="Follow-ups"
+                    value="12"
+                    helper="Requires confirmation"
+                    icon={ClipboardList}
+                    trendLabel="3 urgent"
+                    trendValue="today"
+                />
+                <StatCard
+                    title="Messages"
+                    value="7"
+                    helper="Unseen updates"
+                    icon={Bell}
+                    trendLabel="1 high"
+                    trendValue="priority"
+                />
+            </section>
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
-                    <CardHeader>
-                        <CardTitle className="text-lg text-primary">Operational checklist</CardTitle>
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-row items-center justify-between gap-3">
+                        <div>
+                            <CardTitle className="text-lg text-primary">Today&apos;s consultations</CardTitle>
+                            <p className="text-sm text-muted-foreground">Keep patients moving by marking arrivals and outcomes.</p>
+                        </div>
+                        <Button asChild variant="ghost" className="rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
+                            <Link href="/doctor/appointments">View full queue</Link>
+                        </Button>
                     </CardHeader>
-                    <CardContent className="space-y-3 text-sm text-muted-foreground">
-                        <ul className="space-y-2">
-                            {operationalHighlights.map((item) => (
-                                <li key={item} className="flex items-start gap-2 rounded-2xl bg-primary/10 p-3">
-                                    <span className="mt-1 flex h-2.5 w-2.5 shrink-0 rounded-full bg-primary" />
-                                    <span>{item}</span>
-                                </li>
-                            ))}
-                        </ul>
+                    <CardContent className="space-y-3">
+                        {schedule.map((item) => (
+                            <div key={item.label} className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div className="space-y-1">
+                                    <p className="text-sm font-semibold text-primary">{item.label}</p>
+                                    <p className="text-sm text-muted-foreground">{item.patient}</p>
+                                </div>
+                                <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                                    <Badge variant="outline" className="rounded-full border-primary/30 text-primary">
+                                        {item.status}
+                                    </Badge>
+                                    <span className="font-semibold text-primary">{item.time}</span>
+                                </div>
+                            </div>
+                        ))}
                     </CardContent>
                 </Card>
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
+
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg text-primary">Resources</CardTitle>
+                        <CardTitle className="text-lg text-primary">Quick navigation</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3 text-sm text-muted-foreground">
-                        <p>
-                            Access updated clinic forms, incident templates, and medication guides to keep documentation consistent across the team.
-                        </p>
-                        <Button asChild variant="outline" className="w-full rounded-xl border-primary/30 text-primary hover:bg-primary/10">
-                            <Link href="/doctor/dispense">Go to dispensing log</Link>
-                        </Button>
-                        <Button asChild variant="ghost" className="w-full rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
-                            <Link href="/doctor/patients">Browse patient registry</Link>
-                        </Button>
+                        <p>Select a workspace to jump into the latest activity.</p>
+                        <div className="space-y-2">
+                            {quickLinks.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 px-3 py-2 font-semibold text-primary transition hover:-translate-y-0.5 hover:bg-primary/10"
+                                >
+                                    {link.label}
+                                    <Activity className="h-4 w-4" />
+                                </Link>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+
+            <section className="grid gap-5 lg:grid-cols-[1fr_1.1fr]">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-primary">Patient overview</CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid gap-4 md:grid-cols-2">
+                        {patientOverview.map((item) => (
+                            <div key={item.label} className="space-y-2 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div className="flex items-center justify-between text-sm text-muted-foreground">
+                                    <p>{item.label}</p>
+                                    <span className={`h-2.5 w-2.5 rounded-full ${item.accent}`} />
+                                </div>
+                                <p className="text-2xl font-semibold text-primary">{item.value}</p>
+                                <Progress value={Math.min(item.value, 120)} className="h-2" />
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
+                    <CardHeader>
+                        <CardTitle className="text-lg">Clinical reminders</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
+                        <p>Ensure dispensing notes are recorded within the shift so inventory updates stay accurate.</p>
+                        <p>Notify the nursing desk when rescheduling to keep patient communications consistent.</p>
+                        <p>Use the patient registry to review previous consults before today&apos;s appointments.</p>
                     </CardContent>
                 </Card>
             </section>

--- a/src/app/nurse/page.tsx
+++ b/src/app/nurse/page.tsx
@@ -2,46 +2,41 @@
 
 import Link from "next/link";
 import {
+    Activity,
     BarChart3,
+    CalendarClock,
     ClipboardCheck,
     Package,
+    ShieldCheck,
     Users,
 } from "lucide-react";
 
-import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
-import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
+import { StatCard } from "@/components/dashboard/stat-card";
 import { NurseLayout } from "@/components/nurse/nurse-layout";
 import { Button } from "@/components/ui/button";
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
-const quickActions = [
-    {
-        title: "Supervise inventory",
-        description: "Monitor critical stock levels, log replenishments, and flag expiring supplies.",
-        href: "/nurse/inventory",
-        icon: Package,
-        cta: "Review inventory",
-    },
-    {
-        title: "Support patient records",
-        description: "Update consultation notes, upload vitals, and prepare charts for the medical team.",
-        href: "/nurse/records",
-        icon: ClipboardCheck,
-        cta: "View records",
-    },
-    {
-        title: "Administer accounts",
-        description: "Create new profiles, reset credentials, and keep access permissions current.",
-        href: "/nurse/accounts",
-        icon: Users,
-        cta: "Manage accounts",
-    },
+const stockAlerts = [
+    { item: "Surgical masks", level: 28, status: "Restock soon" },
+    { item: "Alcohol pads", level: 12, status: "Critical" },
+    { item: "Paracetamol", level: 44, status: "Healthy" },
+];
+
+const quickLinks = [
+    { label: "Inventory", href: "/nurse/inventory" },
+    { label: "Patient records", href: "/nurse/records" },
+    { label: "Clinic schedule", href: "/nurse/clinic" },
+    { label: "Dispensing log", href: "/nurse/dispense" },
+    { label: "Accounts", href: "/nurse/accounts" },
+];
+
+const roster = [
+    { label: "Morning clinics", value: "08:00 - 12:00", tag: "Campus A" },
+    { label: "Afternoon clinics", value: "01:00 - 04:00", tag: "Dental" },
+    { label: "Evening support", value: "Telehealth", tag: "On call" },
 ];
 
 export default function NurseDashboardPage() {
@@ -49,49 +44,154 @@ export default function NurseDashboardPage() {
 
     return (
         <NurseLayout
-            title="Dashboard Overview"
-            description="Manage accounts, clinic schedules, inventory, and records with a clear operational snapshot."
+            title="Dashboard overview"
+            description="Coordinate appointments, supplies, and records with a refreshed, data-forward view."
             actions={
                 <Button asChild className="hidden rounded-xl bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 md:flex">
-                    <Link href="/nurse/records">View Records</Link>
+                    <Link href="/nurse/records">View records</Link>
                 </Button>
             }
         >
-            <DashboardWelcome
-                heading={`Good day, Nurse ${firstName}`}
-                description="Keep the clinic running smoothly with instant visibility into schedules, stock levels, and patient coordination. Use the quick tools below to support the care team."
-            />
+            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-emerald-50 p-8 shadow-sm">
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                    <div className="space-y-3">
+                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Welcome back</p>
+                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">Nurse {firstName}, here&apos;s your snapshot</h3>
+                        <p className="max-w-2xl text-sm text-muted-foreground">
+                            Track stock, patient records, and clinic coverage from one screen. Use the navigation cards to jump into the workspace you need.
+                        </p>
+                        <div className="flex flex-wrap gap-3">
+                            <Badge className="rounded-full bg-primary/15 px-3 py-1 text-primary">Shift ready</Badge>
+                            <Badge variant="secondary" className="rounded-full bg-white text-primary shadow-sm">
+                                <ShieldCheck className="mr-1.5 h-4 w-4" />
+                                Compliance updated
+                            </Badge>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-4 rounded-2xl border border-primary/20 bg-white/80 px-5 py-4 shadow-sm">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+                            <BarChart3 className="h-5 w-5" />
+                        </div>
+                        <div>
+                            <p className="text-sm text-muted-foreground">Today&apos;s coverage</p>
+                            <p className="text-lg font-semibold text-primary">3 clinics · 2 nurses</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
 
-            <QuickActionsGrid
-                actions={quickActions}
-                highlight={{
-                    title: "Operations insights",
-                    icon: BarChart3,
-                    description: [
-                        "Align on clinic traffic peaks early to balance resources and shorten wait times for students and staff.",
-                        "Keep communication logs updated so physicians can review triage actions and respond to follow-up needs quickly.",
-                    ],
-                }}
-            />
+            <section className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <StatCard
+                    title="Appointments"
+                    value="18"
+                    helper="Arrivals + walk-ins"
+                    icon={CalendarClock}
+                    trendLabel="+2"
+                    trendValue="vs yesterday"
+                />
+                <StatCard
+                    title="Dispensing"
+                    value="94"
+                    helper="Logged today"
+                    icon={ClipboardCheck}
+                    trendLabel="+8"
+                    trendValue="items"
+                />
+                <StatCard
+                    title="Inventory alerts"
+                    value="3"
+                    helper="Needs attention"
+                    icon={Package}
+                    trendLabel="1 critical"
+                    trendValue="item"
+                />
+                <StatCard
+                    title="Account actions"
+                    value="5"
+                    helper="Pending approvals"
+                    icon={Users}
+                    trendLabel="New"
+                    trendValue="requests"
+                />
+            </section>
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-row items-center justify-between gap-3">
+                        <div>
+                            <CardTitle className="text-lg text-primary">Stock health</CardTitle>
+                            <p className="text-sm text-muted-foreground">Keep the shelves balanced by watching low-supply items.</p>
+                        </div>
+                        <Button asChild variant="ghost" className="rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
+                            <Link href="/nurse/inventory">Open inventory</Link>
+                        </Button>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {stockAlerts.map((item) => (
+                            <div key={item.item} className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div className="space-y-1">
+                                    <p className="text-sm font-semibold text-primary">{item.item}</p>
+                                    <p className="text-sm text-muted-foreground">{item.status}</p>
+                                </div>
+                                <div className="flex w-1/3 flex-col gap-2 text-sm text-muted-foreground">
+                                    <Progress value={item.level} className="h-2" />
+                                    <span className="self-end font-semibold text-primary">{item.level}%</span>
+                                </div>
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg text-primary">How to keep clinic flow steady</CardTitle>
+                        <CardTitle className="text-lg text-primary">Quick navigation</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3 text-sm text-muted-foreground">
-                        <p>
-                            Review pending appointments each morning and pre-stage the necessary charts and equipment so care teams can begin on time.
-                        </p>
-                        <p>
-                            Document every dispensing and inventory update as it happens. Accurate logs keep compliance effortless during audits.
-                        </p>
-                        <Button asChild variant="outline" className="w-full rounded-xl border-primary/30 text-primary hover:bg-primary/10">
-                            <Link href="/nurse/dispense">Open dispensing log</Link>
-                        </Button>
-                        <Button asChild variant="ghost" className="w-full rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
-                            <Link href="/nurse/clinic">View clinic schedule</Link>
-                        </Button>
+                        <p>Jump directly into the workspace you need during today&apos;s shift.</p>
+                        <div className="space-y-2">
+                            {quickLinks.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 px-3 py-2 font-semibold text-primary transition hover:-translate-y-0.5 hover:bg-primary/10"
+                                >
+                                    {link.label}
+                                    <Activity className="h-4 w-4" />
+                                </Link>
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+
+            <section className="grid gap-5 lg:grid-cols-[1fr_1.1fr]">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-primary">Clinic coverage</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {roster.map((slot) => (
+                            <div key={slot.label} className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div>
+                                    <p className="text-sm font-semibold text-primary">{slot.label}</p>
+                                    <p className="text-sm text-muted-foreground">{slot.value}</p>
+                                </div>
+                                <Badge variant="outline" className="rounded-full border-primary/30 text-primary">
+                                    {slot.tag}
+                                </Badge>
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
+                    <CardHeader>
+                        <CardTitle className="text-lg">Coordination reminders</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
+                        <p>Log dispensing as you go to keep the doctor and inventory teams aligned.</p>
+                        <p>Confirm vitals in patient records before handoff to reduce repeat intake questions.</p>
+                        <p>Keep queue updates visible so students receive timely arrival instructions.</p>
                     </CardContent>
                 </Card>
             </section>

--- a/src/app/patient/page.tsx
+++ b/src/app/patient/page.tsx
@@ -1,43 +1,39 @@
 "use client";
 
 import Link from "next/link";
-import { Bell, CalendarDays, Stethoscope, User } from "lucide-react";
+import { Bell, CalendarDays, Heart, MapPin, NotebookPen, Stethoscope, User } from "lucide-react";
 
-import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
-import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
+import { StatCard } from "@/components/dashboard/stat-card";
 import PatientLayout from "@/components/patient/patient-layout";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
-const quickActions = [
+const reminders = [
     {
-        title: "Manage your profile",
-        description: "Review and update your contact details, academic information, and emergency contacts in one place.",
-        href: "/patient/account",
-        icon: User,
-        cta: "Review account",
+        label: "Dental follow-up",
+        details: "Friday · 10:00 AM",
+        status: "Confirmed",
     },
     {
-        title: "Book a consultation",
-        description: "Check available clinics, select a physician or dentist, and send your appointment request instantly.",
-        href: "/patient/appointments",
-        icon: CalendarDays,
-        cta: "Plan visit",
-    },
-    {
-        title: "Follow clinic updates",
-        description: "Track appointment changes, reminders, and announcements so you are always ready for your next visit.",
-        href: "/patient/notification",
-        icon: Bell,
-        cta: "View notifications",
+        label: "General check-up",
+        details: "Pending schedule",
+        status: "Action needed",
     },
 ];
 
-const wellnessHighlights = [
-    "Arrive 10 minutes early to allow time for screening and paperwork.",
-    "Keep your emergency contact details up to date for faster coordination.",
-    "Bring your student/employee ID whenever you have a scheduled visit.",
+const wellness = [
+    { label: "Sleep", value: 72 },
+    { label: "Hydration", value: 64 },
+    { label: "Movement", value: 58 },
+];
+
+const quickLinks = [
+    { label: "Manage profile", href: "/patient/account" },
+    { label: "Book appointment", href: "/patient/appointments" },
+    { label: "Clinic notifications", href: "/patient/notification" },
 ];
 
 export default function PatientDashboardPage() {
@@ -46,59 +42,150 @@ export default function PatientDashboardPage() {
     return (
         <PatientLayout
             title="Dashboard overview"
-            description="A personalized snapshot of your activity with HNU Clinic. Access appointments, account information, and announcements at a glance."
+            description="Plan visits, review notifications, and track your health tasks with a refreshed green theme."
             actions={
                 <Button asChild className="hidden rounded-xl bg-primary px-5 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 md:flex">
                     <Link href="/patient/appointments">Schedule visit</Link>
                 </Button>
             }
         >
-            <DashboardWelcome
-                heading={`Hello, ${firstName}`}
-                description="Stay on top of your health journey. From this dashboard you can update your profile, manage bookings, and monitor clinic communications tailored for you."
-                className="bg-linear-to-r"
-            />
+            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-emerald-50 p-8 shadow-sm">
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                    <div className="space-y-3">
+                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Hello there</p>
+                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">{firstName}, keep your care on track</h3>
+                        <p className="max-w-2xl text-sm text-muted-foreground">
+                            Review upcoming visits, confirm reminders, and keep your contact details updated so the clinic can reach you with ease.
+                        </p>
+                        <div className="flex flex-wrap gap-3">
+                            <Badge className="rounded-full bg-primary/15 px-3 py-1 text-primary">Notifications on</Badge>
+                            <Badge variant="secondary" className="rounded-full bg-white text-primary shadow-sm">
+                                <MapPin className="mr-1.5 h-4 w-4" />
+                                Campus clinic · Open
+                            </Badge>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-4 rounded-2xl border border-primary/20 bg-white/80 px-5 py-4 shadow-sm">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+                            <Stethoscope className="h-5 w-5" />
+                        </div>
+                        <div>
+                            <p className="text-sm text-muted-foreground">Next step</p>
+                            <p className="text-lg font-semibold text-primary">Confirm Friday follow-up</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
 
-            <QuickActionsGrid
-                actions={quickActions}
-                highlight={{
-                    title: "Clinic insights",
-                    icon: Stethoscope,
-                    description: [
-                        "Walk-ins are accommodated based on availability. Booking ahead ensures your preferred doctor and service are ready when you arrive.",
-                        "Keep notifications enabled to receive movement updates, instructions, and reminders directly from the clinic team.",
-                    ],
-                    className: "bg-linear-to-br",
-                }}
-            />
+            <section className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <StatCard
+                    title="Booked visits"
+                    value="2"
+                    helper="Upcoming this week"
+                    icon={CalendarDays}
+                    trendLabel="+1"
+                    trendValue="new"
+                />
+                <StatCard
+                    title="Notifications"
+                    value="5"
+                    helper="Unread updates"
+                    icon={Bell}
+                    trendLabel="1 urgent"
+                    trendValue="action"
+                />
+                <StatCard
+                    title="Profile completeness"
+                    value="92%"
+                    helper="Emergency contacts saved"
+                    icon={User}
+                    trendLabel="Updated"
+                    trendValue="recently"
+                />
+                <StatCard
+                    title="Wellness streak"
+                    value="8 days"
+                    helper="Habits logged"
+                    icon={Heart}
+                    trendLabel="Keep it up"
+                    trendValue=""
+                />
+            </section>
 
             <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
-                    <CardHeader>
-                        <CardTitle className="text-lg text-primary">How to prepare for your next appointment</CardTitle>
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-row items-center justify-between gap-3">
+                        <div>
+                            <CardTitle className="text-lg text-primary">Your appointments</CardTitle>
+                            <p className="text-sm text-muted-foreground">Confirm schedules or request adjustments ahead of time.</p>
+                        </div>
+                        <Button asChild variant="ghost" className="rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
+                            <Link href="/patient/appointments">Manage visits</Link>
+                        </Button>
                     </CardHeader>
-                    <CardContent className="space-y-3 text-sm text-muted-foreground">
-                        <p>
-                            Updating your personal details before the visit helps our staff deliver faster care.
-                        </p>
-                        <p>
-                            If you need to adjust the schedule, request a reschedule from the Appointments page. The clinic will confirm availability and notify you through email and the portal.
-                        </p>
+                    <CardContent className="space-y-3">
+                        {reminders.map((item) => (
+                            <div key={item.label} className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div>
+                                    <p className="text-sm font-semibold text-primary">{item.label}</p>
+                                    <p className="text-sm text-muted-foreground">{item.details}</p>
+                                </div>
+                                <Badge variant="outline" className="rounded-full border-primary/30 text-primary">
+                                    {item.status}
+                                </Badge>
+                            </div>
+                        ))}
                     </CardContent>
                 </Card>
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
+
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg text-primary">Wellness reminders</CardTitle>
+                        <CardTitle className="text-lg text-primary">Quick actions</CardTitle>
                     </CardHeader>
-                    <CardContent className="space-y-2 text-sm text-muted-foreground">
-                        <ul className="space-y-2">
-                            {wellnessHighlights.map((tip) => (
-                                <li key={tip} className="flex items-start gap-2 rounded-2xl bg-primary/10 p-3">
-                                    <span className="mt-1 flex h-2.5 w-2.5 shrink-0 rounded-full bg-primary" />
-                                    <span>{tip}</span>
-                                </li>
+                    <CardContent className="space-y-3 text-sm text-muted-foreground">
+                        <p>Keep your profile and reminders current.</p>
+                        <div className="space-y-2">
+                            {quickLinks.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 px-3 py-2 font-semibold text-primary transition hover:-translate-y-0.5 hover:bg-primary/10"
+                                >
+                                    {link.label}
+                                    <NotebookPen className="h-4 w-4" />
+                                </Link>
                             ))}
-                        </ul>
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+
+            <section className="grid gap-5 lg:grid-cols-[1fr_1.1fr]">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-primary">Wellness overview</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {wellness.map((item) => (
+                            <div key={item.label} className="space-y-2 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div className="flex items-center justify-between text-sm text-muted-foreground">
+                                    <p>{item.label}</p>
+                                    <span className="font-semibold text-primary">{item.value}%</span>
+                                </div>
+                                <Progress value={item.value} className="h-2" />
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
+                    <CardHeader>
+                        <CardTitle className="text-lg">Visit reminders</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
+                        <p>Arrive 10 minutes early for screening and paperwork.</p>
+                        <p>Keep your contact details up to date so the clinic can confirm changes quickly.</p>
+                        <p>Enable notifications to receive reminders and preparation tips right away.</p>
                     </CardContent>
                 </Card>
             </section>

--- a/src/app/scholar/page.tsx
+++ b/src/app/scholar/page.tsx
@@ -4,67 +4,38 @@ import { useMemo } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
+    Activity,
     CalendarDays,
-    ClipboardList,
     FileSpreadsheet,
     NotebookPen,
     Users2,
+    Workflow,
 } from "lucide-react";
 
+import { StatCard } from "@/components/dashboard/stat-card";
 import ScholarLayout from "@/components/scholar/scholar-layout";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 
-const workflowHighlights = [
-    {
-        title: "Coordinate appointments",
-        description:
-            "Review upcoming visits, arrange queues, and update the board when there are walk-ins or cancellations.",
-        href: "/scholar/appointments",
-        icon: CalendarDays,
-        cta: "Open appointment hub",
-    },
-    {
-        title: "Assist patient intake",
-        description:
-            "Search student profiles, confirm eligibility, and share the latest notes with the nursing team.",
-        href: "/scholar/patients",
-        icon: Users2,
-        cta: "View patient list",
-    },
-    {
-        title: "Maintain scholar records",
-        description:
-            "Keep your contact and emergency details updated so the clinic can reach you during campus operations.",
-        href: "/scholar/account",
-        icon: ClipboardList,
-        cta: "Manage account",
-    },
-] as const;
-
-const supportChecklist = [
-    "Confirm the day’s appointment roster at least one hour before clinic opening.",
-    "Log every walk-in case in the shared tracker so nurses can assign the next available slot.",
-    "Escalate urgent symptoms directly to the nurse channel to alert the medical team immediately.",
+const tasks = [
+    { label: "Confirm morning queue", detail: "Coordinate with nurses", status: "Due 8:30 AM" },
+    { label: "Update walk-ins", detail: "Log new arrivals", status: "Ongoing" },
+    { label: "Share patient notes", detail: "Send to doctor channel", status: "Before 3 PM" },
 ];
 
-const documentationTips = [
-    {
-        label: "Schedule walk-ins",
-        description: "Document walk-in for visibility across the clinic.",
-        href: "/scholar/appointments",
-    },
-    {
-        label: "Sync patient information",
-        description: "Verify program, year level, and contact details during intake.",
-        href: "/scholar/patients",
-    },
-    {
-        label: "Refresh personal records",
-        description: "Review your profile and confirm that emergency contacts are current.",
-        href: "/scholar/account",
-    },
-] as const;
+const quickLinks = [
+    { label: "Appointment board", href: "/scholar/appointments" },
+    { label: "Patient list", href: "/scholar/patients" },
+    { label: "Manage account", href: "/scholar/account" },
+];
+
+const metrics = [
+    { label: "Appointments", value: 26 },
+    { label: "Walk-ins", value: 9 },
+    { label: "Pending updates", value: 4 },
+];
 
 export default function ScholarDashboardPage() {
     const { data: session } = useSession();
@@ -74,7 +45,7 @@ export default function ScholarDashboardPage() {
     return (
         <ScholarLayout
             title="Clinic coordination hub"
-            description="Monitor appointments, support patient intake, and keep campus care moving smoothly."
+            description="Monitor appointments, keep the board aligned, and support patient intake with a fresh dashboard layout."
             actions={
                 <Button
                     asChild
@@ -84,97 +55,141 @@ export default function ScholarDashboardPage() {
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-primary/5 p-6 shadow-sm">
+            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-emerald-50 p-8 shadow-sm">
                 <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
                     <div className="space-y-3">
                         <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Welcome back</p>
                         <h3 className="text-3xl font-semibold text-primary md:text-4xl">Good day, Scholar {firstName}</h3>
                         <p className="max-w-2xl text-sm text-muted-foreground">
-                            Keep the clinic desk synchronized—double-check booking requests, guide students through intake, and
-                            flag any priority concerns early so the team can respond quickly.
+                            Keep the queue visible, log walk-ins quickly, and share updates with the clinic team so today&apos;s flow stays smooth.
                         </p>
+                        <div className="flex flex-wrap gap-3">
+                            <Badge className="rounded-full bg-primary/15 px-3 py-1 text-primary">Desk open</Badge>
+                            <Badge variant="secondary" className="rounded-full bg-white text-primary shadow-sm">
+                                <Workflow className="mr-1.5 h-4 w-4" />
+                                Sync in progress
+                            </Badge>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-4 rounded-2xl border border-primary/20 bg-white/80 px-5 py-4 shadow-sm">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+                            <FileSpreadsheet className="h-5 w-5" />
+                        </div>
+                        <div>
+                            <p className="text-sm text-muted-foreground">Priority</p>
+                            <p className="text-lg font-semibold text-primary">Finalize morning roster</p>
+                        </div>
                     </div>
                 </div>
             </section>
 
-            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-                {workflowHighlights.map(({ title, description, href, icon: Icon, cta }) => (
-                    <Card
-                        key={title}
-                        className="h-full rounded-3xl border-primary/20 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
-                    >
-                        <CardHeader className="flex flex-row items-start justify-between gap-3">
-                            <div className="space-y-1">
-                                <CardTitle className="flex items-center gap-3 text-lg text-primary">
-                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                        <Icon className="h-5 w-5" />
-                                    </span>
-                                    {title}
-                                </CardTitle>
-                                <p className="text-sm font-normal text-muted-foreground">{description}</p>
-                            </div>
-                        </CardHeader>
-                        <CardContent>
-                            <Button
-                                asChild
-                                variant="ghost"
-                                className="rounded-xl bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20"
-                            >
-                                <Link href={href}>{cta}</Link>
-                            </Button>
-                        </CardContent>
-                    </Card>
-                ))}
-                <Card className="h-full rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-3 text-lg">
-                            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
-                                <NotebookPen className="h-5 w-5" />
-                            </span>
-                            Coordination insights
-                        </CardTitle>
+            <section className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <StatCard
+                    title="Appointments today"
+                    value="26"
+                    helper="Including walk-ins"
+                    icon={CalendarDays}
+                    trendLabel="+5"
+                    trendValue="vs yesterday"
+                />
+                <StatCard
+                    title="Patients assisted"
+                    value="41"
+                    helper="Checked-in students"
+                    icon={Users2}
+                    trendLabel="+7"
+                    trendValue="handled"
+                />
+                <StatCard
+                    title="Board updates"
+                    value="12"
+                    helper="Status changes"
+                    icon={Activity}
+                    trendLabel="Live"
+                    trendValue="now"
+                />
+                <StatCard
+                    title="Notes shared"
+                    value="18"
+                    helper="Sent to clinic"
+                    icon={NotebookPen}
+                    trendLabel="Clear"
+                    trendValue="handoffs"
+                />
+            </section>
+
+            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-row items-center justify-between gap-3">
+                        <div>
+                            <CardTitle className="text-lg text-primary">Shift checklist</CardTitle>
+                            <p className="text-sm text-muted-foreground">Keep the clinic team informed as you move through tasks.</p>
+                        </div>
+                        <Button asChild variant="ghost" className="rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
+                            <Link href="/scholar/appointments">Open board</Link>
+                        </Button>
                     </CardHeader>
-                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
-                        <p>
-                            Share status updates in the clinic chat when appointment queues change so the medical team can adapt their rounds.
-                        </p>
-                        <p>
-                            Keep intake forms organized before handoff—complete profiles help nurses and doctors focus on care instead of paperwork.
-                        </p>
+                    <CardContent className="space-y-3">
+                        {tasks.map((item) => (
+                            <div key={item.label} className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div>
+                                    <p className="text-sm font-semibold text-primary">{item.label}</p>
+                                    <p className="text-sm text-muted-foreground">{item.detail}</p>
+                                </div>
+                                <Badge variant="outline" className="rounded-full border-primary/30 text-primary">
+                                    {item.status}
+                                </Badge>
+                            </div>
+                        ))}
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-primary">Quick navigation</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm text-muted-foreground">
+                        <p>Jump into the tools you use most often.</p>
+                        <div className="space-y-2">
+                            {quickLinks.map((link) => (
+                                <Link
+                                    key={link.href}
+                                    href={link.href}
+                                    className="flex items-center justify-between rounded-2xl border border-primary/15 bg-primary/5 px-3 py-2 font-semibold text-primary transition hover:-translate-y-0.5 hover:bg-primary/10"
+                                >
+                                    {link.label}
+                                    <NotebookPen className="h-4 w-4" />
+                                </Link>
+                            ))}
+                        </div>
                     </CardContent>
                 </Card>
             </section>
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
+            <section className="grid gap-5 lg:grid-cols-[1fr_1.1fr]">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
                     <CardHeader>
-                        <CardTitle className="text-lg text-primary">Checklist for smooth clinic flow</CardTitle>
+                        <CardTitle className="text-lg text-primary">Coordination stats</CardTitle>
                     </CardHeader>
-                    <CardContent className="space-y-3 text-sm text-muted-foreground">
-                        {supportChecklist.map((item) => (
-                            <div key={item} className="flex gap-3">
-                                <FileSpreadsheet className="mt-1 h-4 w-4 text-primary" />
-                                <p>{item}</p>
+                    <CardContent className="grid gap-4 md:grid-cols-3">
+                        {metrics.map((item) => (
+                            <div key={item.label} className="space-y-2 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <p className="text-sm text-muted-foreground">{item.label}</p>
+                                <p className="text-2xl font-semibold text-primary">{item.value}</p>
+                                <Progress value={Math.min(item.value, 100)} className="h-2" />
                             </div>
                         ))}
                     </CardContent>
                 </Card>
-                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
+
+                <Card className="rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
                     <CardHeader>
-                        <CardTitle className="text-lg text-primary">Documentation shortcuts</CardTitle>
+                        <CardTitle className="text-lg">Handoff reminders</CardTitle>
                     </CardHeader>
-                    <CardContent className="space-y-4 text-sm text-muted-foreground">
-                        {documentationTips.map(({ label, description, href }) => (
-                            <div key={label} className="space-y-2 rounded-2xl border border-primary/20 bg-primary/5 p-4">
-                                <div className="flex items-center justify-between">
-                                    <p className="font-semibold text-primary">{label}</p>
-                                    <Button asChild variant="link" className="h-auto p-0 text-sm font-semibold text-primary">
-                                        <Link href={href}>Open</Link>
-                                    </Button>
-                                </div>
-                                <p>{description}</p>
-                            </div>
-                        ))}
+                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
+                        <p>Log every walk-in on the appointment board so nurses and doctors see changes immediately.</p>
+                        <p>Share quick notes with the care team when symptoms warrant faster triage.</p>
+                        <p>Confirm student details during intake to avoid delays during the consultation.</p>
                     </CardContent>
                 </Card>
             </section>

--- a/src/components/dashboard/stat-card.tsx
+++ b/src/components/dashboard/stat-card.tsx
@@ -1,0 +1,41 @@
+import { LucideIcon } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface StatCardProps {
+    title: string;
+    value: string;
+    icon: LucideIcon;
+    helper?: string;
+    trendLabel?: string;
+    trendValue?: string;
+}
+
+export function StatCard({ title, value, helper, icon: Icon, trendLabel, trendValue }: StatCardProps) {
+    return (
+        <Card className="group relative overflow-hidden rounded-3xl border-primary/15 bg-white/90 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
+            <div className="absolute inset-x-0 top-0 h-1.5 bg-linear-to-r from-primary/80 via-emerald-500 to-primary/70" />
+            <CardHeader className="flex flex-row items-center justify-between gap-4 pb-2">
+                <div className="space-y-1">
+                    <p className="text-sm text-muted-foreground">{title}</p>
+                    <CardTitle className="text-3xl font-semibold text-primary">{value}</CardTitle>
+                </div>
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                    <Icon className="h-5 w-5" />
+                </span>
+            </CardHeader>
+            {(helper || trendLabel || trendValue) && (
+                <CardContent className="flex items-center justify-between text-sm text-muted-foreground">
+                    <p>{helper}</p>
+                    {(trendLabel || trendValue) && (
+                        <Badge variant="secondary" className="rounded-full bg-primary/10 text-primary">
+                            {trendLabel && <span className="mr-1 font-medium">{trendLabel}</span>}
+                            {trendValue}
+                        </Badge>
+                    )}
+                </CardContent>
+            )}
+        </Card>
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared StatCard component to provide consistent metric styling across dashboards
- redesign doctor, nurse, patient, and scholar landing pages with green-focused panels, quick links, and updated data cards
- refresh supporting sections to highlight schedules, tasks, and reminders aligned with the new layout

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692452b7d5508327990408d360a7e9dd)