### PR TITLE
Optimize nurse accounts initial load

### DIFF
--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -333,8 +333,10 @@ export function NurseAccountsPageClient({
 
     // Always refresh once on mount to ensure working scholar flags reflect latest server state
     useEffect(() => {
-        void loadUsers({ silent: true });
-    }, [loadUsers]);
+        if (initialUsersLoaded) {
+            void loadUsers({ silent: true });
+        }
+    }, [initialUsersLoaded, loadUsers]);
 
     useEffect(() => {
         if (role !== "PATIENT") {

--- a/src/app/nurse/accounts/page.tsx
+++ b/src/app/nurse/accounts/page.tsx
@@ -3,22 +3,14 @@ import { unstable_noStore as noStore } from "next/cache";
 
 import NurseAccountsLoading from "./loading";
 import { NurseAccountsPageClient } from "./page.client";
-import {
-    normalizeNurseAccountProfile,
-    normalizeNurseAccountUsers,
-    type NurseAccountProfileApi,
-    type NurseAccountsUserApi,
-} from "./types";
+import { normalizeNurseAccountProfile, normalizeNurseAccountUsers, type NurseAccountProfileApi } from "./types";
 import { serverFetch } from "@/lib/server-api";
 
 export default async function NurseAccountsPage() {
     noStore();
-    const [initialUsers, initialProfile] = await Promise.all([
-        serverFetch<NurseAccountsUserApi[]>("/api/nurse/accounts"),
-        serverFetch<NurseAccountProfileApi>("/api/nurse/accounts/me"),
-    ]);
+    const initialProfile = await serverFetch<NurseAccountProfileApi>("/api/nurse/accounts/me");
 
-    const normalizedUsers = normalizeNurseAccountUsers(initialUsers);
+    const normalizedUsers = normalizeNurseAccountUsers([]);
     const normalizedProfile = normalizeNurseAccountProfile(initialProfile);
 
     return (
@@ -26,7 +18,7 @@ export default async function NurseAccountsPage() {
             <NurseAccountsPageClient
                 initialUsers={normalizedUsers}
                 initialProfile={normalizedProfile}
-                initialUsersLoaded={Array.isArray(initialUsers)}
+                initialUsersLoaded={false}
                 initialProfileLoaded={Boolean(normalizedProfile)}
             />
         </Suspense>


### PR DESCRIPTION
## Summary
- avoid server-side fetching of all nurse accounts to reduce initial payload size
- keep initial nurse profile fetch while leaving account list to client-side loading
- skip redundant background refresh when no initial user data is present

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924598716fc8327a5f0e5cce40e8892)