### PR TITLE
Add privacy page header and restyle password trigger

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,16 @@
 import Link from "next/link";
 
+import { SiteHeader } from "@/components/marketing/site-header";
+
+const navigation = [
+    { href: "/#features", label: "Features" },
+    { href: "/#workflow", label: "Workflow" },
+    { href: "/about", label: "About" },
+    { href: "/learn-more", label: "Learn More" },
+    { href: "/privacy", label: "Privacy" },
+    { href: "/#contact", label: "Contact" },
+];
+
 export const metadata = {
     title: "Privacy Policy | HNU Clinic",
     description: "Learn how the HNU Clinic app collects, uses, and protects information across sign-in and care workflows.",
@@ -7,101 +18,105 @@ export const metadata = {
 
 export default function PrivacyPage() {
     return (
-        <div className="bg-white">
-            <section className="bg-linear-to-b from-green-50 via-white to-green-50 px-6 py-16 md:px-12 md:py-24">
-                <div className="mx-auto max-w-4xl space-y-12">
-                    <div className="space-y-4 text-center md:text-left">
-                        <span className="inline-flex items-center rounded-full border border-green-100 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-green-700">
-                            HNU Clinic Privacy Statement
-                        </span>
-                        <h1 className="text-3xl font-bold text-green-700 md:text-4xl">Privacy Policy</h1>
-                        <p className="text-base leading-relaxed text-gray-700 md:text-lg">
-                            This policy explains how the HNU Clinic capstone application collects, uses, and protects information when you visit <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link>, request an account, and use the scheduling, records, and notification features offered to the Holy Name University community.
+        <div className="flex min-h-screen flex-col bg-white">
+            <SiteHeader navigation={navigation} />
+
+            <main className="flex-1">
+                <section className="bg-linear-to-b from-green-50 via-white to-green-50 px-6 py-16 md:px-12 md:py-24">
+                    <div className="mx-auto max-w-4xl space-y-12">
+                        <div className="space-y-4 text-center md:text-left">
+                            <span className="inline-flex items-center rounded-full border border-green-100 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-green-700">
+                                HNU Clinic Privacy Statement
+                            </span>
+                            <h1 className="text-3xl font-bold text-green-700 md:text-4xl">Privacy Policy</h1>
+                            <p className="text-base leading-relaxed text-gray-700 md:text-lg">
+                                This policy explains how the HNU Clinic capstone application collects, uses, and protects information when you visit <Link href="https://www.hnu-clinic-app.com/" className="font-semibold text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link>, request an account, and use the scheduling, records, and notification features offered to the Holy Name University community.
+                            </p>
+                        </div>
+
+                        <div className="space-y-10 text-sm leading-relaxed text-gray-700 md:text-base">
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">Information we collect</h2>
+                                <ul className="list-disc space-y-2 pl-6">
+                                    <li>
+                                        <span className="font-medium text-green-700">Account request details:</span> when you ask for clinic portal access through the homepage contact form, you provide your Holy Name University student or employee status, school or employee ID, date of birth, gender, and a campus email address where the nurse can send the credentials.
+                                    </li>
+                                    <li>
+                                        <span className="font-medium text-green-700">Account and health records:</span> clinic staff may add or update demographic profiles, appointment bookings, consultation notes, prescriptions, medical certificates, and other campus clinic documentation tied to your profile.
+                                    </li>
+                                    <li>
+                                        <span className="font-medium text-green-700">Support and inquiry messages:</span> inquiries submitted through the contact form or support email include your name, email, and message so the clinic can reply. These details are emailed to the clinic inbox and are not stored in the app database.
+                                    </li>
+                                    <li>
+                                        <span className="font-medium text-green-700">System logs:</span> the platform records basic audit events (such as appointment updates and notification deliveries) to help administrators troubleshoot issues.
+                                    </li>
+                                </ul>
+                            </section>
+
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">How we use your information</h2>
+                                <ul className="list-disc space-y-2 pl-6">
+                                    <li>Confirm you are a Holy Name University student or employee before a nurse creates your clinic account and issues a temporary password.</li>
+                                    <li>Match you with the correct patient or employee record so staff can schedule visits, document care, manage medicine inventory, and prepare medical certificates.</li>
+                                    <li>Send transactional emails—appointment requests, approvals, reschedules, cancellations, completion summaries, and password reset codes—through the Gmail API so patients and clinicians stay informed.</li>
+                                    <li>Respond to questions you submit through the contact form or support email address and document follow-up for clinic staff.</li>
+                                </ul>
+                            </section>
+
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">Requesting portal access</h2>
+                                <p>
+                                    Clinic accounts are provisioned by the nursing team. Eligible users can request access through the homepage contact form by sharing their full name, campus role, Holy Name University school or employee ID, gender, and date of birth. The nurse reviews each request and, once approved, sends the username (matching the provided ID) and a temporary password to the institutional email address on file. You must change that password after your first sign-in.
+                                </p>
+                                <p>
+                                    If you later add a personal email to your profile, the system will send a verification link to confirm ownership before notifications are delivered to that address.
+                                </p>
+                            </section>
+
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">Sharing and third parties</h2>
+                                <p>
+                                    We do not sell your information or share it with advertisers. Email notifications are sent through the clinic’s managed Gmail account and are limited to transactional messages about appointments, records, and password resets.
+                                </p>
+                                <p>
+                                    The application is hosted on Vercel, and supporting services such as database hosting are administered by the HNU Clinic capstone team. No marketing or analytics platforms ingest your health information.
+                                </p>
+                            </section>
+
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">Data retention and control</h2>
+                                <p>
+                                    Health records managed inside the application follow Holy Name University clinic retention guidelines. You may request corrections or deactivation of your portal access by contacting the clinic support desk at <Link href="mailto:hnucliniccapstone@gmail.com" className="font-medium text-green-700 underline underline-offset-2">hnucliniccapstone@gmail.com</Link>.
+                                </p>
+                                <p>
+                                    To request removal of your account or associated information, contact the clinic support desk so the nursing staff can review and process the request.
+                                </p>
+                            </section>
+
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">Security practices</h2>
+                                <p>
+                                    The application encrypts information in transit and at rest. Role-based permissions ensure only authorized clinic personnel can view or update sensitive records, and key actions are logged for auditing.
+                                </p>
+                                <p>
+                                    Hosting is currently provided through Vercel at <Link href="https://www.hnu-clinic-app.com/" className="font-medium text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link>. Access is limited to the HNU Clinic team responsible for this capstone project.
+                                </p>
+                            </section>
+
+                            <section className="space-y-3">
+                                <h2 className="text-xl font-semibold text-green-700">Contact us</h2>
+                                <p>
+                                    Questions about this policy or your data can be directed to <Link href="mailto:hnucliniccapstone@gmail.com" className="font-medium text-green-700 underline underline-offset-2">hnucliniccapstone@gmail.com</Link>. You may also reach the clinic office at Holy Name University Main Campus during regular operating hours.
+                                </p>
+                            </section>
+                        </div>
+
+                        <p className="text-xs text-gray-500">
+                            Effective date: {new Date().getFullYear()}.
                         </p>
                     </div>
-
-                    <div className="space-y-10 text-sm leading-relaxed text-gray-700 md:text-base">
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">Information we collect</h2>
-                            <ul className="list-disc space-y-2 pl-6">
-                                <li>
-                                    <span className="font-medium text-green-700">Account request details:</span> when you ask for clinic portal access through the homepage contact form, you provide your Holy Name University student or employee status, school or employee ID, date of birth, gender, and a campus email address where the nurse can send the credentials.
-                                </li>
-                                <li>
-                                    <span className="font-medium text-green-700">Account and health records:</span> clinic staff may add or update demographic profiles, appointment bookings, consultation notes, prescriptions, medical certificates, and other campus clinic documentation tied to your profile.
-                                </li>
-                                <li>
-                                    <span className="font-medium text-green-700">Support and inquiry messages:</span> inquiries submitted through the contact form or support email include your name, email, and message so the clinic can reply. These details are emailed to the clinic inbox and are not stored in the app database.
-                                </li>
-                                <li>
-                                    <span className="font-medium text-green-700">System logs:</span> the platform records basic audit events (such as appointment updates and notification deliveries) to help administrators troubleshoot issues.
-                                </li>
-                            </ul>
-                        </section>
-
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">How we use your information</h2>
-                            <ul className="list-disc space-y-2 pl-6">
-                                <li>Confirm you are a Holy Name University student or employee before a nurse creates your clinic account and issues a temporary password.</li>
-                                <li>Match you with the correct patient or employee record so staff can schedule visits, document care, manage medicine inventory, and prepare medical certificates.</li>
-                                <li>Send transactional emails—appointment requests, approvals, reschedules, cancellations, completion summaries, and password reset codes—through the Gmail API so patients and clinicians stay informed.</li>
-                                <li>Respond to questions you submit through the contact form or support email address and document follow-up for clinic staff.</li>
-                            </ul>
-                        </section>
-
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">Requesting portal access</h2>
-                            <p>
-                                Clinic accounts are provisioned by the nursing team. Eligible users can request access through the homepage contact form by sharing their full name, campus role, Holy Name University school or employee ID, gender, and date of birth. The nurse reviews each request and, once approved, sends the username (matching the provided ID) and a temporary password to the institutional email address on file. You must change that password after your first sign-in.
-                            </p>
-                            <p>
-                                If you later add a personal email to your profile, the system will send a verification link to confirm ownership before notifications are delivered to that address.
-                            </p>
-                        </section>
-
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">Sharing and third parties</h2>
-                            <p>
-                                We do not sell your information or share it with advertisers. Email notifications are sent through the clinic’s managed Gmail account and are limited to transactional messages about appointments, records, and password resets.
-                            </p>
-                            <p>
-                                The application is hosted on Vercel, and supporting services such as database hosting are administered by the HNU Clinic capstone team. No marketing or analytics platforms ingest your health information.
-                            </p>
-                        </section>
-
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">Data retention and control</h2>
-                            <p>
-                                Health records managed inside the application follow Holy Name University clinic retention guidelines. You may request corrections or deactivation of your portal access by contacting the clinic support desk at <Link href="mailto:hnucliniccapstone@gmail.com" className="font-medium text-green-700 underline underline-offset-2">hnucliniccapstone@gmail.com</Link>.
-                            </p>
-                            <p>
-                                To request removal of your account or associated information, contact the clinic support desk so the nursing staff can review and process the request.
-                            </p>
-                        </section>
-
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">Security practices</h2>
-                            <p>
-                                The application encrypts information in transit and at rest. Role-based permissions ensure only authorized clinic personnel can view or update sensitive records, and key actions are logged for auditing.
-                            </p>
-                            <p>
-                                Hosting is currently provided through Vercel at <Link href="https://www.hnu-clinic-app.com/" className="font-medium text-green-700 underline underline-offset-2">www.hnu-clinic-app.com</Link>. Access is limited to the HNU Clinic team responsible for this capstone project.
-                            </p>
-                        </section>
-
-                        <section className="space-y-3">
-                            <h2 className="text-xl font-semibold text-green-700">Contact us</h2>
-                            <p>
-                                Questions about this policy or your data can be directed to <Link href="mailto:hnucliniccapstone@gmail.com" className="font-medium text-green-700 underline underline-offset-2">hnucliniccapstone@gmail.com</Link>. You may also reach the clinic office at Holy Name University Main Campus during regular operating hours.
-                            </p>
-                        </section>
-                    </div>
-
-                    <p className="text-xs text-gray-500">
-                        Effective date: {new Date().getFullYear()}.
-                    </p>
-                </div>
-            </section>
+                </section>
+            </main>
         </div>
     );
 }

--- a/src/components/account/account-card.tsx
+++ b/src/components/account/account-card.tsx
@@ -75,7 +75,7 @@ export function AccountCard({
                     onSubmit={onPasswordSubmit}
                     onSuccess={onPasswordSuccess}
                     triggerAriaLabel={triggerAriaLabel}
-                    triggerClassName="rounded-2xl border-white/40 bg-white/20 text-white shadow-sm transition hover:bg-white/30 hover:text-white"
+                    triggerClassName="justify-between border-white/50 bg-white/15 text-white backdrop-blur md:w-auto md:justify-start"
                     dialogTitle="Update account password"
                 />
             </CardHeader>

--- a/src/components/account/account-card.tsx
+++ b/src/components/account/account-card.tsx
@@ -48,7 +48,7 @@ export function AccountCard({
     return (
         <Card
             className={cn(
-                "relative overflow-hidden rounded-[32px] border border-green-100/70 bg-white/95 shadow-xl backdrop-blur",
+                "relative overflow-hidden rounded-4xl border border-green-100/70 bg-white/95 shadow-xl backdrop-blur",
                 className
             )}
         >
@@ -59,7 +59,7 @@ export function AccountCard({
             </div>
             <CardHeader
                 className={cn(
-                    "relative flex flex-col gap-4 border-b border-white/10 bg-gradient-to-r from-emerald-600 via-green-600 to-emerald-500 px-6 py-6 text-white md:flex-row md:items-center md:justify-between",
+                    "relative flex flex-col gap-4 border-b border-white/10 bg-linear-to-r from-emerald-600 via-green-600 to-emerald-500 px-6 py-6 text-white md:flex-row md:items-center md:justify-between",
                     headerClassName
                 )}
             >

--- a/src/components/account/account-password-dialog.tsx
+++ b/src/components/account/account-password-dialog.tsx
@@ -181,16 +181,16 @@ export function AccountPasswordDialog({
                     variant="outline"
                     aria-label={triggerAriaLabel}
                     className={cn(
-                        "group inline-flex items-center gap-3 rounded-2xl border-green-100 bg-white/80 px-3 py-2 text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:border-green-200 hover:bg-white",
+                        "group inline-flex w-full max-w-sm items-center gap-2 rounded-full border-green-200/80 bg-white/90 px-2 py-2 text-green-800 shadow-sm transition duration-150 hover:-translate-y-[1px] hover:border-green-300 hover:bg-white md:w-auto",
                         triggerClassName
                     )}
                 >
-                    <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-green-50 text-green-700 shadow-sm transition group-hover:bg-green-100">
-                        <Cog className="h-5 w-5" />
+                    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-green-700 ring-1 ring-inset ring-green-200">
+                        Security
                     </span>
-                    <span className="text-left">
-                        <span className="block text-xs font-semibold uppercase tracking-wide text-green-800">Security</span>
-                        <span className="text-sm font-semibold">Update password</span>
+                    <span className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-500 to-green-500 px-3 py-1 text-sm font-semibold text-white shadow-inner shadow-emerald-400/30 transition group-hover:from-emerald-600 group-hover:to-green-600">
+                        <Cog className="h-4 w-4" />
+                        <span className="whitespace-nowrap">Update password</span>
                     </span>
                 </Button>
             </DialogTrigger>

--- a/src/components/account/account-password-dialog.tsx
+++ b/src/components/account/account-password-dialog.tsx
@@ -181,15 +181,12 @@ export function AccountPasswordDialog({
                     variant="outline"
                     aria-label={triggerAriaLabel}
                     className={cn(
-                        "group inline-flex w-full max-w-sm items-center gap-2 rounded-full border-green-200/80 bg-white/90 px-2 py-2 text-green-800 shadow-sm transition duration-150 hover:-translate-y-[1px] hover:border-green-300 hover:bg-white md:w-auto",
+                        "group inline-flex w-auto items-center rounded-full border-green-200/80 bg-white/90 px-1 py-4.5 text-green-800 shadow-sm transition duration-150 hover:-translate-y-px hover:border-green-300 hover:bg-white",
                         triggerClassName
                     )}
                 >
-                    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-green-700 ring-1 ring-inset ring-green-200">
-                        Security
-                    </span>
-                    <span className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-500 to-green-500 px-3 py-1 text-sm font-semibold text-white shadow-inner shadow-emerald-400/30 transition group-hover:from-emerald-600 group-hover:to-green-600">
-                        <Cog className="h-4 w-4" />
+                    <span className="inline-flex items-center gap-2 rounded-full bg-linear-to-r from-emerald-500 to-green-500 px-3 py-1 text-base font-semibold text-white shadow-inner shadow-emerald-400/30 transition group-hover:from-emerald-600 group-hover:to-green-600">
+                        <Cog className="h-7 w-7" />
                         <span className="whitespace-nowrap">Update password</span>
                     </span>
                 </Button>

--- a/src/components/account/account-password-dialog.tsx
+++ b/src/components/account/account-password-dialog.tsx
@@ -179,14 +179,19 @@ export function AccountPasswordDialog({
             <DialogTrigger asChild>
                 <Button
                     variant="outline"
-                    size="icon"
                     aria-label={triggerAriaLabel}
                     className={cn(
-                        "rounded-xl border-green-200 text-green-700 hover:bg-green-100/60",
+                        "group inline-flex items-center gap-3 rounded-2xl border-green-100 bg-white/80 px-3 py-2 text-green-700 shadow-sm transition hover:-translate-y-[1px] hover:border-green-200 hover:bg-white",
                         triggerClassName
                     )}
                 >
-                    <Cog className="h-5 w-5 text-white" />
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-green-50 text-green-700 shadow-sm transition group-hover:bg-green-100">
+                        <Cog className="h-5 w-5" />
+                    </span>
+                    <span className="text-left">
+                        <span className="block text-xs font-semibold uppercase tracking-wide text-green-800">Security</span>
+                        <span className="text-sm font-semibold">Update password</span>
+                    </span>
                 </Button>
             </DialogTrigger>
 


### PR DESCRIPTION
## Summary
- add the marketing site header to the privacy policy page for consistent navigation
- restyle the password update trigger with a labeled gear icon for clearer affordance

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d4c7dae0832794132f4eed1005e8)