### PR TITLE
Add pagination to patient records tables

### DIFF
--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -47,6 +47,8 @@ export default function DoctorPatientsPage() {
     const [activeTab, setActiveTab] = useState<RecordDetailsDialogTab>("details");
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [isRefreshing, startTransition] = useTransition();
 
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
@@ -105,6 +107,22 @@ export default function DoctorPatientsPage() {
             return matchesSearch && matchesStatus && matchesType && matchesAppointment;
         });
     }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [appointmentFilter, deferredSearch, statusFilter, typeFilter]);
+
+    useEffect(() => {
+        const maxPage = Math.max(1, Math.ceil(filteredRecords.length / pageSize));
+        if (currentPage > maxPage) {
+            setCurrentPage(maxPage);
+        }
+    }, [currentPage, filteredRecords.length, pageSize]);
+
+    const paginatedRecords = useMemo(() => {
+        const start = (currentPage - 1) * pageSize;
+        return filteredRecords.slice(start, start + pageSize);
+    }, [currentPage, filteredRecords, pageSize]);
 
     const totalPatients = records.length;
     const withAppointments = useMemo(
@@ -324,9 +342,13 @@ export default function DoctorPatientsPage() {
                         </CardHeader>
                         <CardContent className="pt-4">
                             <PatientDirectoryTable
-                                records={filteredRecords}
+                                records={paginatedRecords}
                                 loading={loadingRecords}
                                 onOpenDetails={openDetails}
+                                totalRecords={filteredRecords.length}
+                                pageSize={pageSize}
+                                currentPage={currentPage}
+                                onPageChange={setCurrentPage}
                             />
                         </CardContent>
                     </Card>

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -53,6 +53,8 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
     const [activeTab, setActiveTab] = useState<RecordDetailsDialogTab>("details");
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [isRefreshing, startTransition] = useTransition();
 
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
@@ -113,6 +115,22 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
             return matchesSearch && matchesStatus && matchesType && matchesAppointment;
         });
     }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [appointmentFilter, deferredSearch, statusFilter, typeFilter]);
+
+    useEffect(() => {
+        const maxPage = Math.max(1, Math.ceil(filteredRecords.length / pageSize));
+        if (currentPage > maxPage) {
+            setCurrentPage(maxPage);
+        }
+    }, [currentPage, filteredRecords.length, pageSize]);
+
+    const paginatedRecords = useMemo(() => {
+        const start = (currentPage - 1) * pageSize;
+        return filteredRecords.slice(start, start + pageSize);
+    }, [currentPage, filteredRecords, pageSize]);
 
     const totalPatients = records.length;
     const withAppointments = useMemo(
@@ -345,9 +363,13 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
                         </CardHeader>
                         <CardContent className="pt-4">
                             <PatientDirectoryTable
-                                records={filteredRecords}
+                                records={paginatedRecords}
                                 loading={loadingRecords}
                                 onOpenDetails={openDetails}
+                                totalRecords={filteredRecords.length}
+                                pageSize={pageSize}
+                                currentPage={currentPage}
+                                onPageChange={setCurrentPage}
                             />
                         </CardContent>
                     </Card>

--- a/src/app/nurse/records/patient-directory-table.tsx
+++ b/src/app/nurse/records/patient-directory-table.tsx
@@ -3,6 +3,7 @@
 import { memo, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import {
     Table,
     TableBody,
@@ -28,9 +29,21 @@ interface PatientDirectoryTableProps {
     records: PatientRecord[];
     loading: boolean;
     onOpenDetails: (record: PatientRecord) => void;
+    totalRecords: number;
+    pageSize: number;
+    currentPage: number;
+    onPageChange: (page: number) => void;
 }
 
-function PatientDirectoryTableComponent({ records, loading, onOpenDetails }: PatientDirectoryTableProps) {
+function PatientDirectoryTableComponent({
+    records,
+    loading,
+    onOpenDetails,
+    totalRecords,
+    pageSize,
+    currentPage,
+    onPageChange,
+}: PatientDirectoryTableProps) {
     const rows = useMemo(() => {
         return records.map((record) => {
             const statusKey = record.status.toLowerCase();
@@ -116,6 +129,10 @@ function PatientDirectoryTableComponent({ records, loading, onOpenDetails }: Pat
         });
     }, [records, onOpenDetails]);
 
+    const totalPages = Math.max(1, Math.ceil(totalRecords / pageSize));
+    const startIndex = totalRecords === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+    const endIndex = totalRecords === 0 ? 0 : Math.min(startIndex + records.length - 1, totalRecords);
+
     return (
         <div className="overflow-x-auto">
             <Table className="min-w-full text-sm">
@@ -149,6 +166,35 @@ function PatientDirectoryTableComponent({ records, loading, onOpenDetails }: Pat
                     )}
                 </TableBody>
             </Table>
+
+            <div className="mt-4 flex flex-col gap-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                <span>
+                    Showing {startIndex}-{endIndex} of {totalRecords}
+                </span>
+                <div className="flex items-center gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={loading || currentPage <= 1}
+                        onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+                    >
+                        Previous
+                    </Button>
+                    <span className="text-xs">
+                        Page {currentPage} of {totalPages}
+                    </span>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={loading || currentPage >= totalPages}
+                        onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+                    >
+                        Next
+                    </Button>
+                </div>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add shared pagination controls to the patient directory table with navigation buttons and counts
- paginate nurse and doctor patient registry views to display 10 records per page while preserving filters

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928597dbef0832797d84c98fdc20892)