### PR TITLE
Enhance patient and scholar appointment calendars

### DIFF
--- a/src/app/api/meta/doctor-availability/calendar/route.ts
+++ b/src/app/api/meta/doctor-availability/calendar/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { endOfManilaDay, PH_TIME_ZONE, startOfManilaDay } from "@/lib/time";
+import { withDb } from "@/lib/withDb";
+
+function parseMonth(value: string | null): { start: Date; end: Date } | null {
+    if (!value) return null;
+    const parts = value.split("-");
+    if (parts.length !== 2) return null;
+
+    const [yearStr, monthStr] = parts;
+    const year = Number(yearStr);
+    const month = Number(monthStr);
+
+    if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) {
+        return null;
+    }
+
+    const monthStart = new Date(`${yearStr}-${monthStr.padStart(2, "0")}-01T00:00:00+08:00`);
+    if (Number.isNaN(monthStart.getTime())) return null;
+
+    const nextMonthYear = month === 12 ? year + 1 : year;
+    const nextMonth = month === 12 ? 1 : month + 1;
+    const nextMonthStart = new Date(`${nextMonthYear}-${String(nextMonth).padStart(2, "0")}-01T00:00:00+08:00`);
+
+    return { start: monthStart, end: new Date(nextMonthStart.getTime() - 1000) };
+}
+
+function formatManilaDateOnly(date: Date): string {
+    return new Intl.DateTimeFormat("en-CA", {
+        timeZone: PH_TIME_ZONE,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+    }).format(date);
+}
+
+async function handler(req: Request) {
+    const { searchParams } = new URL(req.url);
+    const clinic_id = searchParams.get("clinic_id");
+    const doctor_user_id = searchParams.get("doctor_user_id");
+    const month = searchParams.get("month");
+
+    if (!clinic_id || !doctor_user_id || !month) {
+        return NextResponse.json({ message: "Missing required parameters" }, { status: 400 });
+    }
+
+    const monthBounds = parseMonth(month);
+    if (!monthBounds) {
+        return NextResponse.json({ message: "Invalid month" }, { status: 400 });
+    }
+
+    try {
+        const { start, end } = monthBounds;
+        const availabilities = await withDb(() =>
+            prisma.doctorAvailability.findMany({
+                where: {
+                    clinic_id,
+                    doctor_user_id,
+                    archivedAt: null,
+                    available_date: {
+                        gte: startOfManilaDay(formatManilaDateOnly(start)),
+                        lte: endOfManilaDay(formatManilaDateOnly(end)),
+                    },
+                },
+                orderBy: { available_date: "asc" },
+            })
+        );
+
+        const availableDates = new Set<string>();
+        const leaveDates = new Set<string>();
+
+        for (const availability of availabilities) {
+            const dateKey = formatManilaDateOnly(availability.available_date);
+            if (availability.is_on_leave) {
+                leaveDates.add(dateKey);
+                continue;
+            }
+            availableDates.add(dateKey);
+            if (leaveDates.has(dateKey)) {
+                leaveDates.delete(dateKey);
+            }
+        }
+
+        return NextResponse.json({
+            availableDates: Array.from(availableDates),
+            leaveDates: Array.from(leaveDates),
+        });
+    } catch (err) {
+        console.error("[GET /api/meta/doctor-availability/calendar]", err);
+        return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
+    }
+}
+
+export const GET = handler;

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -16,6 +16,7 @@ import {
 import PatientLayout from "@/components/patient/patient-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Calendar } from "@/components/ui/calendar";
 import { AppointmentPanel } from "@/components/appointments/appointment-panel";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -47,7 +48,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { toast } from "sonner";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
-import { formatManilaDateTime, formatTimeRange, manilaNow } from "@/lib/time";
+import { formatManilaDateTime, formatManilaISODate, formatTimeRange, manilaNow } from "@/lib/time";
 import { getServiceOptionsForSpecialization, resolveServiceType } from "@/lib/service-options";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
@@ -208,6 +209,11 @@ export default function PatientAppointmentsPage() {
     const [serviceType, setServiceType] = useState<string>("");
     const [date, setDate] = useState<string>("");
     const [timeStart, setTimeStart] = useState<string>("");
+    const [calendarMonth, setCalendarMonth] = useState<Date>(() => manilaNow());
+    const [availableDates, setAvailableDates] = useState<string[]>([]);
+    const [leaveDates, setLeaveDates] = useState<string[]>([]);
+    const [calendarLoading, setCalendarLoading] = useState(false);
+    const [calendarError, setCalendarError] = useState<string | null>(null);
 
     // My appointments
     const [appointments, setAppointments] = useState<Appointment[]>([]);
@@ -237,12 +243,16 @@ export default function PatientAppointmentsPage() {
         setDoctorId("");
         setServiceType("");
         setTimeStart("");
+        setDate("");
+        setCalendarMonth(manilaNow());
     };
 
     const handleDoctorChange = (nextDoctorId: string) => {
         setDoctorId(nextDoctorId);
         setServiceType("");
         setTimeStart("");
+        setDate("");
+        setCalendarMonth(manilaNow());
     };
 
     const handleSlotSelection = (doctor: Doctor, slot: Slot) => {
@@ -406,6 +416,59 @@ export default function PatientAppointmentsPage() {
         })();
     }, [clinicId]);
 
+    // Load available/leave dates for selected doctor
+    useEffect(() => {
+        if (!clinicId || !doctorId) {
+            setAvailableDates([]);
+            setLeaveDates([]);
+            setCalendarError(null);
+            return;
+        }
+
+        const monthKey = formatManilaISODate(calendarMonth).slice(0, 7);
+        let cancelled = false;
+
+        (async () => {
+            try {
+                setCalendarLoading(true);
+                setCalendarError(null);
+                const params = new URLSearchParams({
+                    clinic_id: clinicId,
+                    doctor_user_id: doctorId,
+                    month: monthKey,
+                });
+                const res = await fetch(`/api/meta/doctor-availability/calendar?${params.toString()}`);
+                const data = await res.json();
+
+                if (cancelled) return;
+
+                if (!res.ok) {
+                    setAvailableDates([]);
+                    setLeaveDates([]);
+                    setCalendarError(data?.message ?? "Failed to load schedule overview");
+                    return;
+                }
+
+                setAvailableDates(Array.isArray(data?.availableDates) ? data.availableDates : []);
+                setLeaveDates(Array.isArray(data?.leaveDates) ? data.leaveDates : []);
+            } catch (err) {
+                if (cancelled) return;
+                console.error(err);
+                setAvailableDates([]);
+                setLeaveDates([]);
+                setCalendarError("Unable to load schedule overview");
+            } finally {
+                if (!cancelled) {
+                    setCalendarLoading(false);
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [calendarMonth, clinicId, doctorId]);
+
     // Load availability for doctors when clinic/date change
     useEffect(() => {
         if (!clinicId || doctors.length === 0) {
@@ -518,6 +581,15 @@ export default function PatientAppointmentsPage() {
     const onLeaveDay = selectedDoctorAvailability?.onLeave ?? false;
     const selectedSlot = useMemo(() => slots.find((s) => s.start === timeStart), [slots, timeStart]);
     const selectedDoctor = useMemo(() => doctors.find((d) => d.user_id === doctorId) || null, [doctorId, doctors]);
+    const selectedDate = useMemo(() => (date ? new Date(`${date}T00:00:00+08:00`) : undefined), [date]);
+    const availableDateObjects = useMemo(
+        () => availableDates.map((value) => new Date(`${value}T00:00:00+08:00`)),
+        [availableDates]
+    );
+    const leaveDateObjects = useMemo(
+        () => leaveDates.map((value) => new Date(`${value}T00:00:00+08:00`)),
+        [leaveDates]
+    );
     const selectedClinic = useMemo(
         () => clinics.find((clinic) => clinic.clinic_id === clinicId) ?? null,
         [clinics, clinicId]
@@ -866,66 +938,8 @@ export default function PatientAppointmentsPage() {
                                 </Select>
                             </div>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="appointment-date" className="text-sm font-medium text-primary">
-                                    Date
-                                </Label>
-                                <Input
-                                    id="appointment-date"
-                                    name="appointmentDate"
-                                    type="date"
-                                    value={date}
-                                    onChange={(event) => setDate(event.target.value)}
-                                    min={minBookingDate}
-                                    className="rounded-xl border-primary/30"
-                                />
-                            </div>
-
-                            <div className="grid gap-2">
-                                <Label htmlFor="appointment-time" className="text-sm font-medium text-primary">
-                                    Preferred time
-                                </Label>
-                                <Select
-                                    value={timeStart}
-                                    onValueChange={setTimeStart}
-                                    disabled={
-                                        loadingSlots ||
-                                        !doctorId ||
-                                        !date ||
-                                        !!selectedDoctorAvailabilityError ||
-                                        onLeaveDay
-                                    }
-                                >
-                                    <SelectTrigger id="appointment-time" className="rounded-xl border-primary/30">
-                                        <SelectValue
-                                            placeholder={
-                                                !doctorId || !date
-                                                    ? "Select doctor and date"
-                                                    : loadingSlots
-                                                        ? "Loading slots..."
-                                                        : selectedDoctorAvailabilityError
-                                                            ? "Unable to load slots"
-                                                            : onLeaveDay
-                                                                ? "Doctor is on leave"
-                                                                : slots.length
-                                                                    ? "Select a time"
-                                                                    : "No slots available"
-                                            }
-                                        />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {slots.map((slot) => (
-                                            <SelectItem key={`${slot.start}-${slot.end}`} value={slot.start}>
-                                                {formatTimeRange(slot.start, slot.end)}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                                {onLeaveDay && (
-                                    <p className="text-sm text-amber-600">
-                                        This doctor is marked as on leave for the selected date.
-                                    </p>
-                                )}
+                            <div className="rounded-2xl border border-dashed border-primary/30 bg-primary/5 p-3 text-sm text-primary">
+                                Pick a date and time using the schedule card on the right.
                             </div>
 
                             <Button
@@ -959,132 +973,133 @@ export default function PatientAppointmentsPage() {
                 <div className="space-y-6">
                     <Card className="rounded-3xl border-primary/25 bg-white/95 shadow-sm">
                         <CardHeader className="space-y-1">
-                            <CardTitle className="text-lg font-semibold text-primary">Doctor availability</CardTitle>
+                            <CardTitle className="text-lg font-semibold text-primary">Schedule availability</CardTitle>
                             <p className="text-sm text-muted-foreground">
-                                Preview open slots before sending your request.
+                                Browse dates with open slots, see leave days, and pick your preferred time.
                             </p>
                         </CardHeader>
-                        <CardContent className="space-y-4">
-                            {!clinicId ? (
+                        <CardContent className="space-y-5">
+                            {!clinicId || !doctorId ? (
                                 <div className="rounded-2xl border border-dashed border-primary/30 bg-white/70 p-4 text-sm text-muted-foreground">
-                                    Select a clinic to browse available doctors.
-                                </div>
-                            ) : loadingDoctors ? (
-                                <div className="flex items-center justify-center gap-2 rounded-2xl border border-primary/25 bg-white/70 p-4 text-sm text-muted-foreground">
-                                    <Loader2 className="h-4 w-4 animate-spin" /> Loading doctors...
-                                </div>
-                            ) : doctors.length === 0 ? (
-                                <div className="rounded-2xl border border-primary/25 bg-primary/10 p-4 text-sm text-muted-foreground">
-                                    No doctors are assigned to this clinic yet. Try another clinic.
+                                    Select a clinic and doctor to preview the calendar.
                                 </div>
                             ) : (
-                                <div className="space-y-4">
-                                    {selectedClinic ? (
-                                        <div className="rounded-2xl border border-primary/25 bg-white/70 p-3">
-                                            <p className="text-xs uppercase tracking-wide text-primary">{selectedClinic.clinic_name}</p>
-                                            <p className="mt-1 text-sm font-medium text-primary">
-                                                {date ? `Showing availability for ${formatDateOnly(date)}` : "Choose a date to explore available slots."}
+                                <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_1fr]">
+                                    <div className="rounded-2xl border border-primary/20 bg-white/70 shadow-inner">
+                                        <div className="px-4 py-3">
+                                            <p className="text-xs font-semibold uppercase tracking-wide text-primary">Month overview</p>
+                                            <p className="text-sm text-muted-foreground">
+                                                {selectedDoctor?.name ? `Availability for ${selectedDoctor.name}` : "Pick a doctor to load availability"}
                                             </p>
                                         </div>
-                                    ) : null}
-
-                                    {!date ? (
-                                        <div className="rounded-2xl border border-dashed border-primary/30 bg-white/70 p-4 text-sm text-muted-foreground">
-                                            Pick a preferred date to display the available times for every doctor.
-                                        </div>
-                                    ) : null}
-
-                                    <div className="space-y-3">
-                                        {doctors.map((doctor) => {
-                                            const availability = doctorAvailability[doctor.user_id];
-                                            const doctorSlots = availability?.slots ?? [];
-                                            const doctorLoading = date ? availability?.loading ?? false : false;
-                                            const doctorError = date ? availability?.error ?? null : null;
-                                            const doctorOnLeave = date ? availability?.onLeave ?? false : false;
-                                            const isActiveDoctor = doctor.user_id === doctorId;
-
-                                            return (
-                                                <div
-                                                    key={doctor.user_id}
-                                                    className={cn(
-                                                        "rounded-2xl border p-4 transition",
-                                                        "border-primary/25 bg-white/80",
-                                                        isActiveDoctor && "border-primary bg-primary/10 shadow-sm"
-                                                    )}
-                                                >
-                                                    <div className="flex flex-wrap items-start justify-between gap-3">
-                                                        <div>
-                                                            <p className="text-sm font-semibold text-primary">{doctor.name}</p>
-                                                            <p className="text-xs text-muted-foreground">
-                                                                {doctor.specialization ?? "Doctor"}
-                                                                {selectedClinic ? ` · ${selectedClinic.clinic_name}` : ""}
-                                                            </p>
-                                                        </div>
-                                                        {isActiveDoctor && timeStart ? (
-                                                            <Badge
-                                                                variant="outline"
-                                                                className="border-primary bg-primary/10 text-[11px] font-semibold uppercase tracking-wide text-primary"
-                                                            >
-                                                                Selected
-                                                            </Badge>
-                                                        ) : null}
-                                                    </div>
-
-                                                    <div className="mt-3">
-                                                        {!date ? (
-                                                            <p className="text-xs text-muted-foreground">Select a date above to view availability.</p>
-                                                        ) : doctorLoading ? (
-                                                            <div className="flex items-center gap-2 rounded-2xl border border-primary/25 bg-white p-3 text-sm text-muted-foreground">
-                                                                <Loader2 className="h-4 w-4 animate-spin" /> Checking availability...
-                                                            </div>
-                                                        ) : doctorError ? (
-                                                            <div className="rounded-2xl border border-rose-100 bg-rose-50/60 p-3 text-sm text-rose-700">
-                                                                Unable to load the schedule for this doctor. Try again later.
-                                                            </div>
-                                                        ) : doctorOnLeave ? (
-                                                            <div className="rounded-2xl border border-amber-200 bg-amber-50/70 p-3 text-sm text-amber-800">
-                                                                This doctor is marked as on leave for {formatDateOnly(date)}.
-                                                            </div>
-                                                        ) : doctorSlots.length > 0 ? (
-                                                            <div className="grid gap-2 sm:grid-cols-2">
-                                                                {doctorSlots.map((slot) => {
-                                                                    const isSelected = isActiveDoctor && timeStart === slot.start;
-                                                                    return (
-                                                                        <button
-                                                                            key={`${doctor.user_id}-${slot.start}-${slot.end}`}
-                                                                            type="button"
-                                                                            onClick={() => handleSlotSelection(doctor, slot)}
-                                                                            className={cn(
-                                                                                "flex w-full flex-col items-start gap-1 rounded-2xl border px-3 py-2 text-left text-sm font-medium transition",
-                                                                                "border-primary/25 bg-white text-primary hover:bg-primary/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
-                                                                                isSelected && "border-primary bg-primary text-white hover:bg-primary/90 focus-visible:outline-primary"
-                                                                            )}
-                                                                            aria-pressed={isSelected}
-                                                                        >
-                                                                            <span className="leading-tight">
-                                                                                {formatTimeRange(slot.start, slot.end)}
-                                                                            </span>
-                                                                            <span
-                                                                                className={cn(
-                                                                                    "text-xs font-medium leading-tight",
-                                                                                    isSelected ? "text-white/80" : "text-muted-foreground"
-                                                                                )}
-                                                                            >
-                                                                                {isSelected ? "Selected" : "Available"}
-                                                                            </span>
-                                                                        </button>
-                                                                    );
-                                                                })}
-                                                            </div>
-                                                        ) : (
-                                                            <div className="rounded-2xl border border-rose-100 bg-rose-50/60 p-3 text-sm text-rose-700">
-                                                                No available slots for this date. Try another day.
-                                                            </div>
-                                                        )}
-                                                    </div>
+                                        <div className="relative px-3 pb-4 pt-2 sm:px-4">
+                                            {calendarLoading ? (
+                                                <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/70 backdrop-blur-sm">
+                                                    <Loader2 className="h-5 w-5 animate-spin text-primary" />
                                                 </div>
-                                            );
-                                        })}
+                                            ) : null}
+                                            <Calendar
+                                                mode="single"
+                                                month={calendarMonth}
+                                                onMonthChange={setCalendarMonth}
+                                                selected={selectedDate}
+                                                onSelect={(value) => {
+                                                    if (value) {
+                                                        setDate(formatManilaISODate(value));
+                                                        setTimeStart("");
+                                                        setCalendarMonth(value);
+                                                    }
+                                                }}
+                                                disabled={(day) => day < new Date(`${minBookingDate}T00:00:00+08:00`)}
+                                                modifiers={{ available: availableDateObjects, leave: leaveDateObjects }}
+                                                modifiersClassNames={{
+                                                    available:
+                                                        "[&>button]:border [&>button]:border-emerald-200 [&>button]:bg-emerald-50 [&>button]:text-emerald-700 [&>button[data-selected-single=true]]:!border-transparent [&>button[data-selected-single=true]]:!bg-emerald-500 [&>button[data-selected-single=true]]:!text-white [&>button[data-selected-single=true]]:!shadow-[0_10px_30px_-12px_rgba(16,185,129,0.55)] [&>button[data-selected-single=true]]:!ring-2 [&>button[data-selected-single=true]]:!ring-emerald-200/70 [&>button[data-selected-single=true]]:!ring-offset-0",
+                                                    leave:
+                                                        "[&>button]:border [&>button]:border-amber-200 [&>button]:bg-amber-50 [&>button]:text-amber-700 [&>button[data-selected-single=true]]:!border-transparent [&>button[data-selected-single=true]]:!bg-amber-500 [&>button[data-selected-single=true]]:!text-white",
+                                                }}
+                                                className="mx-auto w-full max-w-sm [--cell-size:2.4rem] sm:[--cell-size:2.7rem] [&_button[data-selected-single=true]]:border-transparent! [&_button[data-selected-single=true]]:bg-emerald-500! [&_button[data-selected-single=true]]:text-white! [&_button[data-selected-single=true]]:shadow-[0_10px_30px_-12px_rgba(16,185,129,0.55)]! [&_button[data-selected-single=true]]:ring-2! [&_button[data-selected-single=true]]:ring-emerald-200/70! [&_button[data-selected-single=true]]:ring-offset-0! [&_button[data-selected-single=true]]:outline-none! [&_button[data-selected-single=true]]:transition [&_button[data-selected-single=true]]:duration-150 [&_button[data-selected-single=true]]:ease-out [&_button[data-selected-single=true]]:scale-[1.02]"
+                                            />
+                                            <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                                                <div className="flex items-center gap-2">
+                                                    <span className="h-2 w-2 rounded-full bg-emerald-500" /> Available date
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    <span className="h-2 w-2 rounded-full bg-amber-500" /> Leave day
+                                                </div>
+                                            </div>
+                                            {calendarError ? (
+                                                <p className="mt-3 text-xs text-rose-600">{calendarError}</p>
+                                            ) : null}
+                                        </div>
+                                    </div>
+                                    <div className="space-y-3">
+                                        <div className="space-y-1">
+                                            <p className="text-xs font-semibold uppercase tracking-wide text-primary">Selected day</p>
+                                            <h3 className="text-lg font-semibold text-slate-900">
+                                                {selectedDate ? formatDateOnly(date) : "Choose a date"}
+                                            </h3>
+                                            <p className="text-sm text-muted-foreground">
+                                                {!selectedDate
+                                                    ? "Pick a date to view open slots."
+                                                    : onLeaveDay || leaveDates.includes(date)
+                                                        ? `${selectedDoctor?.name ?? "Doctor"} is on leave for this day.`
+                                                        : slots.length > 0
+                                                            ? "Select a time to include in your request."
+                                                            : "No open times for this day."}
+                                            </p>
+                                        </div>
+
+                                        {!selectedDate ? (
+                                            <div className="rounded-2xl border border-dashed border-primary/30 bg-primary/10/50 p-6 text-sm text-muted-foreground">
+                                                Choose a date on the calendar to view available times.
+                                            </div>
+                                        ) : loadingSlots ? (
+                                            <div className="flex items-center gap-2 rounded-2xl border border-primary/25 bg-white p-3 text-sm text-muted-foreground">
+                                                <Loader2 className="h-4 w-4 animate-spin" /> Checking availability...
+                                            </div>
+                                        ) : selectedDoctorAvailabilityError ? (
+                                            <div className="rounded-2xl border border-rose-100 bg-rose-50/60 p-3 text-sm text-rose-700">
+                                                Unable to load the schedule for this doctor. Try again later.
+                                            </div>
+                                        ) : onLeaveDay || leaveDates.includes(date) ? (
+                                            <div className="rounded-2xl border border-amber-200 bg-amber-50/70 p-3 text-sm text-amber-800">
+                                                This doctor is marked as on leave for {formatDateOnly(date)}.
+                                            </div>
+                                        ) : slots.length > 0 ? (
+                                            <div className="grid gap-2 sm:grid-cols-2">
+                                                {slots.map((slot) => {
+                                                    const isSelected = timeStart === slot.start;
+                                                    return (
+                                                        <button
+                                                            key={`${doctorId}-${slot.start}-${slot.end}`}
+                                                            type="button"
+                                                            onClick={() => selectedDoctor && handleSlotSelection(selectedDoctor, slot)}
+                                                            className={cn(
+                                                                "flex w-full flex-col items-start gap-1 rounded-2xl border px-3 py-2 text-left text-sm font-medium transition",
+                                                                "border-primary/25 bg-white text-primary hover:bg-primary/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                                                                isSelected && "border-primary bg-primary text-white hover:bg-primary/90 focus-visible:outline-primary"
+                                                            )}
+                                                            aria-pressed={isSelected}
+                                                        >
+                                                            <span className="leading-tight">{formatTimeRange(slot.start, slot.end)}</span>
+                                                            <span
+                                                                className={cn(
+                                                                    "text-xs font-medium leading-tight",
+                                                                    isSelected ? "text-white/80" : "text-muted-foreground"
+                                                                )}
+                                                            >
+                                                                {isSelected ? "Selected" : "Available"}
+                                                            </span>
+                                                        </button>
+                                                    );
+                                                })}
+                                            </div>
+                                        ) : (
+                                            <div className="rounded-2xl border border-rose-100 bg-rose-50/60 p-3 text-sm text-rose-700">
+                                                No available slots for this date. Try another day.
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
                             )}

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -869,123 +869,100 @@ export default function PatientAppointmentsPage() {
                 </div>
             }
         >
-            <section className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] 2xl:gap-8">
-                <div className="space-y-6">
-                    <AppointmentPanel
-                        icon={CalendarDays}
-                        title="Request an appointment"
-                        description={`Choose the clinic, provider, and time that works for you. ${earliestScheduledMessage}`}
-                        contentClassName="pt-6"
-                    >
-                        <form className="space-y-5" onSubmit={handleSubmit}>
-                            <div className="grid gap-2">
-                                <Label htmlFor="appointment-clinic" className="text-sm font-medium text-primary">
-                                    Clinic
-                                </Label>
-                                <Select value={clinicId} onValueChange={handleClinicChange} disabled={loadingClinics}>
-                                    <SelectTrigger id="appointment-clinic" className="rounded-xl border-primary/30">
-                                        <SelectValue placeholder={loadingClinics ? "Loading clinics..." : "Select clinic"} />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {clinics.map((clinic) => (
-                                            <SelectItem key={clinic.clinic_id} value={clinic.clinic_id}>
-                                                {clinic.clinic_name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
+            <section className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] 2xl:gap-8">
+                <Card className="rounded-3xl border-primary/25 bg-white/95 shadow-sm">
+                    <CardHeader className="space-y-1 border-b border-primary/15 pb-5">
+                        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                            <div className="space-y-1">
+                                <CardTitle className="flex items-center gap-3 text-lg font-semibold text-primary">
+                                    <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                                        <CalendarDays className="h-5 w-5" />
+                                    </span>
+                                    Schedule availability & booking
+                                </CardTitle>
+                                <p className="text-sm text-muted-foreground">
+                                    Browse open dates, pick a slot, and submit your request in one place.
+                                </p>
                             </div>
-
-                            <div className="grid gap-2">
-                                <Label htmlFor="appointment-doctor" className="text-sm font-medium text-primary">
-                                    Doctor
-                                </Label>
-                                <Select
-                                    value={doctorId}
-                                    onValueChange={handleDoctorChange}
-                                    disabled={!clinicId || loadingDoctors}
-                                >
-                                    <SelectTrigger id="appointment-doctor" className="rounded-xl border-primary/30">
-                                        <SelectValue
-                                            placeholder={!clinicId ? "Select clinic first" : loadingDoctors ? "Loading doctors..." : "Select doctor"}
-                                        />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {doctors.map((doctor) => (
-                                            <SelectItem key={doctor.user_id} value={doctor.user_id}>
-                                                {doctor.name} ({doctor.specialization ?? "N/A"})
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
+                            <div className="rounded-2xl border border-primary/20 bg-primary/5 px-4 py-2 text-xs font-medium text-primary shadow-sm">
+                                Earliest booking: {formatDateOnly(minBookingDate) || minBookingDate}
                             </div>
+                        </div>
+                    </CardHeader>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="appointment-service" className="text-sm font-medium text-primary">
-                                    Service type
-                                </Label>
-                                <Select value={serviceType} onValueChange={setServiceType} disabled={!selectedDoctor}>
-                                    <SelectTrigger id="appointment-service" className="rounded-xl border-primary/30">
-                                        <SelectValue placeholder={!selectedDoctor ? "Select doctor first" : "Select service"} />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {availableServices.map((service) => (
-                                            <SelectItem key={service.value} value={service.value}>
-                                                {service.label}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
-
-                            <div className="rounded-2xl border border-dashed border-primary/30 bg-primary/5 p-3 text-sm text-primary">
-                                Pick a date and time using the schedule card on the right.
-                            </div>
-
-                            <Button
-                                type="submit"
-                                className="w-full rounded-xl bg-primary py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90"
-                                disabled={submitting}
-                            >
-                                {submitting ? (
-                                    <>
-                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Submitting...
-                                    </>
-                                ) : (
-                                    "Request appointment"
-                                )}
-                            </Button>
-                        </form>
-                    </AppointmentPanel>
-
-                    <Card className="rounded-3xl border-primary/25 bg-linear-to-br from-primary via-primary/90 to-primary/80 text-white shadow-md">
-                        <CardHeader>
-                            <CardTitle className="text-lg">Important reminders</CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-3 text-sm text-white/90">
-                            <p>Bring your Student/Employee ID and arrive 10 minutes early for screening and verification.</p>
-                            <p>If you can no longer attend, submit a reschedule or cancellation so another patient can use the slot.</p>
-                            <p>Watch your notifications for approvals, movement updates, and doctor instructions.</p>
-                        </CardContent>
-                    </Card>
-                </div>
-
-                <div className="space-y-6">
-                    <Card className="rounded-3xl border-primary/25 bg-white/95 shadow-sm">
-                        <CardHeader className="space-y-1">
-                            <CardTitle className="text-lg font-semibold text-primary">Schedule availability</CardTitle>
-                            <p className="text-sm text-muted-foreground">
-                                Browse dates with open slots, see leave days, and pick your preferred time.
-                            </p>
-                        </CardHeader>
-                        <CardContent className="space-y-5">
-                            {!clinicId || !doctorId ? (
-                                <div className="rounded-2xl border border-dashed border-primary/30 bg-white/70 p-4 text-sm text-muted-foreground">
-                                    Select a clinic and doctor to preview the calendar.
+                    <CardContent className="space-y-6 pt-6">
+                        <form className="space-y-6" onSubmit={handleSubmit}>
+                            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                <div className="grid gap-2">
+                                    <Label htmlFor="appointment-clinic" className="text-sm font-medium text-primary">
+                                        Clinic
+                                    </Label>
+                                    <Select value={clinicId} onValueChange={handleClinicChange} disabled={loadingClinics}>
+                                        <SelectTrigger id="appointment-clinic" className="rounded-xl border-primary/30 bg-white">
+                                            <SelectValue placeholder={loadingClinics ? "Loading clinics..." : "Select clinic"} />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {clinics.map((clinic) => (
+                                                <SelectItem key={clinic.clinic_id} value={clinic.clinic_id}>
+                                                    {clinic.clinic_name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
                                 </div>
-                            ) : (
-                                <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_1fr]">
-                                    <div className="rounded-2xl border border-primary/20 bg-white/70 shadow-inner">
+
+                                <div className="grid gap-2">
+                                    <Label htmlFor="appointment-doctor" className="text-sm font-medium text-primary">
+                                        Doctor
+                                    </Label>
+                                    <Select
+                                        value={doctorId}
+                                        onValueChange={handleDoctorChange}
+                                        disabled={!clinicId || loadingDoctors}
+                                    >
+                                        <SelectTrigger id="appointment-doctor" className="rounded-xl border-primary/30 bg-white">
+                                            <SelectValue
+                                                placeholder={!clinicId ? "Select clinic first" : loadingDoctors ? "Loading doctors..." : "Select doctor"}
+                                            />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {doctors.map((doctor) => (
+                                                <SelectItem key={doctor.user_id} value={doctor.user_id}>
+                                                    {doctor.name} ({doctor.specialization ?? "N/A"})
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+
+                                <div className="grid gap-2 md:col-span-2 xl:col-span-1">
+                                    <Label htmlFor="appointment-service" className="text-sm font-medium text-primary">
+                                        Service type
+                                    </Label>
+                                    <Select value={serviceType} onValueChange={setServiceType} disabled={!selectedDoctor}>
+                                        <SelectTrigger id="appointment-service" className="rounded-xl border-primary/30 bg-white">
+                                            <SelectValue placeholder={!selectedDoctor ? "Select doctor first" : "Select service"} />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {availableServices.map((service) => (
+                                                <SelectItem key={service.value} value={service.value}>
+                                                    {service.label}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+
+                            <div className="space-y-4">
+                                {!clinicId || !doctorId ? (
+                                    <div className="rounded-2xl border border-dashed border-primary/30 bg-primary/5 p-4 text-sm text-muted-foreground">
+                                        Select a clinic and doctor first to preview their availability.
+                                    </div>
+                                ) : null}
+
+                                <div className="grid gap-6 xl:grid-cols-[minmax(0,380px)_1fr]">
+                                    <div className="rounded-2xl border border-primary/20 bg-white/80 shadow-inner">
                                         <div className="px-4 py-3">
                                             <p className="text-xs font-semibold uppercase tracking-wide text-primary">Month overview</p>
                                             <p className="text-sm text-muted-foreground">
@@ -1033,6 +1010,7 @@ export default function PatientAppointmentsPage() {
                                             ) : null}
                                         </div>
                                     </div>
+
                                     <div className="space-y-3">
                                         <div className="space-y-1">
                                             <p className="text-xs font-semibold uppercase tracking-wide text-primary">Selected day</p>
@@ -1102,7 +1080,39 @@ export default function PatientAppointmentsPage() {
                                         )}
                                     </div>
                                 </div>
-                            )}
+                            </div>
+
+                            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                                <div className="rounded-2xl border border-dashed border-primary/30 bg-primary/5 p-3 text-sm text-primary">
+                                    {earliestScheduledMessage}
+                                </div>
+                                <Button
+                                    type="submit"
+                                    className="w-full rounded-xl bg-primary py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 lg:w-auto"
+                                    disabled={submitting}
+                                >
+                                    {submitting ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Submitting...
+                                        </>
+                                    ) : (
+                                        "Request appointment"
+                                    )}
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                <div className="space-y-6">
+                    <Card className="rounded-3xl border-primary/25 bg-linear-to-br from-primary via-primary/90 to-primary/80 text-white shadow-md">
+                        <CardHeader>
+                            <CardTitle className="text-lg">Important reminders</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3 text-sm text-white/90">
+                            <p>Bring your Student/Employee ID and arrive 10 minutes early for screening and verification.</p>
+                            <p>If you can no longer attend, submit a reschedule or cancellation so another patient can use the slot.</p>
+                            <p>Watch your notifications for approvals, movement updates, and doctor instructions.</p>
                         </CardContent>
                     </Card>
 

--- a/src/app/patient/appointments/page.tsx
+++ b/src/app/patient/appointments/page.tsx
@@ -869,7 +869,7 @@ export default function PatientAppointmentsPage() {
                 </div>
             }
         >
-            <section className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] 2xl:gap-8">
+            <section className="space-y-6 2xl:space-y-8">
                 <Card className="rounded-3xl border-primary/25 bg-white/95 shadow-sm">
                     <CardHeader className="space-y-1 border-b border-primary/15 pb-5">
                         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -1104,7 +1104,7 @@ export default function PatientAppointmentsPage() {
                     </CardContent>
                 </Card>
 
-                <div className="space-y-6">
+                <div className="grid gap-6 lg:grid-cols-2 2xl:gap-8">
                     <Card className="rounded-3xl border-primary/25 bg-linear-to-br from-primary via-primary/90 to-primary/80 text-white shadow-md">
                         <CardHeader>
                             <CardTitle className="text-lg">Important reminders</CardTitle>

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -44,6 +44,9 @@ import ScholarAppointmentsLoading from "./loading";
 
 const STATUS_ORDER = ["Pending", "Approved", "Moved", "Completed", "Cancelled"] as const;
 
+const MIN_BOOKING_LEAD_DAYS = 3;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
 type AppointmentStatus = (typeof STATUS_ORDER)[number];
 
 type ScholarAppointment = {
@@ -147,6 +150,12 @@ function formatTimeWindow(start: string, end: string) {
     return endText ? `${startText} – ${endText}` : startText;
 }
 
+function computeMinBookingDate(): string {
+    const base = manilaNow();
+    const future = new Date(base.getTime() + MIN_BOOKING_LEAD_DAYS * DAY_IN_MS);
+    return formatManilaISODate(future);
+}
+
 export default function ScholarAppointmentsPage() {
     const [appointments, setAppointments] = useState<ScholarAppointment[]>([]);
     const [loading, setLoading] = useState(true);
@@ -155,6 +164,7 @@ export default function ScholarAppointmentsPage() {
     const [statusFilter, setStatusFilter] = useState<string>("active");
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [createSubmitting, setCreateSubmitting] = useState(false);
+    const [minBookingDate, setMinBookingDate] = useState(() => computeMinBookingDate());
 
     const [patientOptions, setPatientOptions] = useState<PatientOption[]>([]);
     const [patientsLoaded, setPatientsLoaded] = useState(false);
@@ -181,11 +191,36 @@ export default function ScholarAppointmentsPage() {
     const [onLeaveDay, setOnLeaveDay] = useState(false);
 
     const [createService, setCreateService] = useState("");
-    const [createDate, setCreateDate] = useState(() => formatManilaISODate(manilaNow()));
+    const [createDate, setCreateDate] = useState(() => computeMinBookingDate());
     const [createRemarks, setCreateRemarks] = useState("");
 
+    useEffect(() => {
+        const updateMinDate = () =>
+            setMinBookingDate((current) => {
+                const next = computeMinBookingDate();
+                return current === next ? current : next;
+            });
+
+        updateMinDate();
+        const interval = setInterval(updateMinDate, 60 * 60 * 1000);
+        return () => clearInterval(interval);
+    }, []);
+
+    useEffect(() => {
+        const minDate = new Date(`${minBookingDate}T00:00:00+08:00`);
+        setAvailabilityMonth(minDate);
+        setCreateDate((current) => {
+            if (!current) return minBookingDate;
+            const currentDate = new Date(`${current}T00:00:00+08:00`);
+            if (currentDate < minDate) {
+                return minBookingDate;
+            }
+            return current;
+        });
+    }, [minBookingDate]);
+
     const resetCreateForm = useCallback(() => {
-        const today = formatManilaISODate(manilaNow());
+        const minDate = new Date(`${minBookingDate}T00:00:00+08:00`);
         setSelectedPatientId("");
         setPatientSearch("");
         setCreateClinicId("");
@@ -194,14 +229,14 @@ export default function ScholarAppointmentsPage() {
         setSlots([]);
         setAvailableDates([]);
         setLeaveDates([]);
-        setAvailabilityMonth(manilaNow());
+        setAvailabilityMonth(minDate);
         setAvailabilityError(null);
         setOnLeaveDay(false);
-        setCreateDate(today);
+        setCreateDate(minBookingDate);
         setCreateTimeStart("");
         setCreateService("");
         setCreateRemarks("");
-    }, []);
+    }, [minBookingDate]);
 
     const loadPatientOptions = useCallback(async () => {
         try {
@@ -1057,7 +1092,7 @@ export default function ScholarAppointmentsPage() {
                                                             }
                                                         }}
                                                         disabled={(day) =>
-                                                            day < new Date(`${formatManilaISODate(manilaNow())}T00:00:00+08:00`)
+                                                            day < new Date(`${minBookingDate}T00:00:00+08:00`)
                                                         }
                                                         modifiers={{ available: availableDateObjects, leave: leaveDateObjects }}
                                                         modifiersClassNames={{

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
+import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
 import {
     formatManilaDateTime,
@@ -172,6 +173,12 @@ export default function ScholarAppointmentsPage() {
     const [slots, setSlots] = useState<SlotOption[]>([]);
     const [loadingSlots, setLoadingSlots] = useState(false);
     const [createTimeStart, setCreateTimeStart] = useState("");
+    const [availabilityMonth, setAvailabilityMonth] = useState<Date>(() => manilaNow());
+    const [availableDates, setAvailableDates] = useState<string[]>([]);
+    const [leaveDates, setLeaveDates] = useState<string[]>([]);
+    const [availabilityLoading, setAvailabilityLoading] = useState(false);
+    const [availabilityError, setAvailabilityError] = useState<string | null>(null);
+    const [onLeaveDay, setOnLeaveDay] = useState(false);
 
     const [createService, setCreateService] = useState("");
     const [createDate, setCreateDate] = useState(() => formatManilaISODate(manilaNow()));
@@ -185,6 +192,11 @@ export default function ScholarAppointmentsPage() {
         setCreateDoctorId("");
         setDoctors([]);
         setSlots([]);
+        setAvailableDates([]);
+        setLeaveDates([]);
+        setAvailabilityMonth(today instanceof Date ? today : manilaNow());
+        setAvailabilityError(null);
+        setOnLeaveDay(false);
         setCreateDate(today);
         setCreateTimeStart("");
         setCreateService("");
@@ -243,6 +255,58 @@ export default function ScholarAppointmentsPage() {
             setLoadingClinics(false);
         }
     }, []);
+
+    useEffect(() => {
+        if (!createDialogOpen || !createClinicId || !createDoctorId) {
+            setAvailableDates([]);
+            setLeaveDates([]);
+            setAvailabilityError(null);
+            return;
+        }
+
+        const monthKey = formatManilaISODate(availabilityMonth).slice(0, 7);
+        let cancelled = false;
+
+        (async () => {
+            try {
+                setAvailabilityLoading(true);
+                setAvailabilityError(null);
+                const params = new URLSearchParams({
+                    clinic_id: createClinicId,
+                    doctor_user_id: createDoctorId,
+                    month: monthKey,
+                });
+                const res = await fetch(`/api/meta/doctor-availability/calendar?${params.toString()}`);
+                const data = await res.json();
+
+                if (cancelled) return;
+
+                if (!res.ok) {
+                    setAvailableDates([]);
+                    setLeaveDates([]);
+                    setAvailabilityError(data?.message ?? "Unable to load availability overview");
+                    return;
+                }
+
+                setAvailableDates(Array.isArray(data?.availableDates) ? data.availableDates : []);
+                setLeaveDates(Array.isArray(data?.leaveDates) ? data.leaveDates : []);
+            } catch (err) {
+                if (cancelled) return;
+                console.error(err);
+                setAvailableDates([]);
+                setLeaveDates([]);
+                setAvailabilityError("Unable to load availability overview");
+            } finally {
+                if (!cancelled) {
+                    setAvailabilityLoading(false);
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [availabilityMonth, createClinicId, createDialogOpen, createDoctorId]);
 
     const loadAppointments = useCallback(async () => {
         try {
@@ -334,6 +398,7 @@ export default function ScholarAppointmentsPage() {
                 setSlots([]);
                 setCreateTimeStart("");
             }
+            setOnLeaveDay(false);
             return;
         }
 
@@ -364,6 +429,7 @@ export default function ScholarAppointmentsPage() {
                     return;
                 }
                 setSlots(Array.isArray(data?.slots) ? (data.slots as SlotOption[]) : []);
+                setOnLeaveDay(Boolean(data?.onLeave));
             } catch (err) {
                 console.error(err);
                 toast.error("Unable to load available slots");
@@ -384,6 +450,19 @@ export default function ScholarAppointmentsPage() {
     }, [createDoctorId, createDate, createDialogOpen]);
 
     const searchTerm = search.trim().toLowerCase();
+    const selectedDoctor = useMemo(
+        () => doctors.find((doctor) => doctor.user_id === createDoctorId) ?? null,
+        [createDoctorId, doctors]
+    );
+    const selectedDate = useMemo(() => (createDate ? new Date(`${createDate}T00:00:00+08:00`) : undefined), [createDate]);
+    const availableDateObjects = useMemo(
+        () => availableDates.map((value) => new Date(`${value}T00:00:00+08:00`)),
+        [availableDates]
+    );
+    const leaveDateObjects = useMemo(
+        () => leaveDates.map((value) => new Date(`${value}T00:00:00+08:00`)),
+        [leaveDates]
+    );
 
     const filteredAppointments = useMemo(() => {
         return appointments.filter((appointment) => {
@@ -857,6 +936,9 @@ export default function ScholarAppointmentsPage() {
                                             setCreateService("");
                                             setSlots([]);
                                             setCreateTimeStart("");
+                                            setAvailableDates([]);
+                                            setLeaveDates([]);
+                                            setAvailabilityError(null);
                                         }}
                                         disabled={loadingClinics}
                                     >
@@ -898,6 +980,9 @@ export default function ScholarAppointmentsPage() {
                                             setCreateService("");
                                             setSlots([]);
                                             setCreateTimeStart("");
+                                            setAvailableDates([]);
+                                            setLeaveDates([]);
+                                            setAvailabilityError(null);
                                         }}
                                         disabled={loadingDoctors || !createClinicId}
                                     >
@@ -937,53 +1022,139 @@ export default function ScholarAppointmentsPage() {
                                     </Select>
                                 </div>
 
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Date</Label>
-                                    <Input
-                                        type="date"
-                                        value={createDate}
-                                        onChange={(event) => setCreateDate(event.target.value)}
-                                        min={formatManilaISODate(manilaNow())}
-                                        className="rounded-xl border-primary/30"
-                                    />
-                                </div>
+                                <div className="space-y-4 rounded-2xl border border-primary/25 bg-primary/5 p-4 sm:col-span-2">
+                                    <div className="space-y-1">
+                                        <p className="text-sm font-semibold text-primary">Schedule</p>
+                                        <p className="text-sm text-muted-foreground">
+                                            Explore available dates and select an open time for this patient.
+                                        </p>
+                                    </div>
+                                    {!createDoctorId || !createClinicId ? (
+                                        <div className="rounded-2xl border border-dashed border-primary/30 bg-white/70 p-4 text-sm text-muted-foreground">
+                                            Choose a clinic and doctor to view availability.
+                                        </div>
+                                    ) : (
+                                        <div className="grid gap-4 md:grid-cols-[minmax(0,320px)_1fr]">
+                                            <div className="rounded-2xl border border-primary/20 bg-white/70 shadow-inner">
+                                                <div className="px-4 py-3">
+                                                    <p className="text-xs font-semibold uppercase tracking-wide text-primary">Month overview</p>
+                                                    <p className="text-sm text-muted-foreground">
+                                                        {selectedDoctor?.name ? `Availability for ${selectedDoctor.name}` : "Pick a doctor"}
+                                                    </p>
+                                                </div>
+                                                <div className="relative px-3 pb-4 pt-2 sm:px-4">
+                                                    {availabilityLoading ? (
+                                                        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/70 backdrop-blur-sm">
+                                                            <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                                                        </div>
+                                                    ) : null}
+                                                    <Calendar
+                                                        mode="single"
+                                                        month={availabilityMonth}
+                                                        onMonthChange={setAvailabilityMonth}
+                                                        selected={selectedDate}
+                                                        onSelect={(value) => {
+                                                            if (value) {
+                                                                setCreateDate(formatManilaISODate(value));
+                                                                setCreateTimeStart("");
+                                                                setAvailabilityMonth(value);
+                                                            }
+                                                        }}
+                                                        disabled={(day) =>
+                                                            day < new Date(`${formatManilaISODate(manilaNow())}T00:00:00+08:00`)
+                                                        }
+                                                        modifiers={{ available: availableDateObjects, leave: leaveDateObjects }}
+                                                        modifiersClassNames={{
+                                                            available:
+                                                                "[&>button]:border [&>button]:border-emerald-200 [&>button]:bg-emerald-50 [&>button]:text-emerald-700 [&>button[data-selected-single=true]]:!border-transparent [&>button[data-selected-single=true]]:!bg-emerald-500 [&>button[data-selected-single=true]]:!text-white",
+                                                            leave:
+                                                                "[&>button]:border [&>button]:border-amber-200 [&>button]:bg-amber-50 [&>button]:text-amber-700 [&>button[data-selected-single=true]]:!border-transparent [&>button[data-selected-single=true]]:!bg-amber-500 [&>button[data-selected-single=true]]:!text-white",
+                                                        }}
+                                                        className="mx-auto w-full max-w-sm [--cell-size:2.3rem] sm:[--cell-size:2.6rem]"
+                                                    />
+                                                    <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="h-2 w-2 rounded-full bg-emerald-500" /> Available date
+                                                        </div>
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="h-2 w-2 rounded-full bg-amber-500" /> Leave day
+                                                        </div>
+                                                    </div>
+                                                    {availabilityError ? (
+                                                        <p className="mt-3 text-xs text-rose-600">{availabilityError}</p>
+                                                    ) : null}
+                                                </div>
+                                            </div>
+                                            <div className="space-y-3">
+                                                <div className="space-y-1">
+                                                    <p className="text-xs font-semibold uppercase tracking-wide text-primary">Selected day</p>
+                                                    <h4 className="text-lg font-semibold text-slate-900">
+                                                        {selectedDate ? toManilaDateString(selectedDate) : "Choose a date"}
+                                                    </h4>
+                                                    <p className="text-sm text-muted-foreground">
+                                                        {!selectedDate
+                                                            ? "Pick a date to load available times."
+                                                            : onLeaveDay || leaveDates.includes(createDate)
+                                                                ? `${selectedDoctor?.name ?? "Doctor"} is on leave.`
+                                                                : slots.length > 0
+                                                                    ? "Select a time slot for this patient."
+                                                                    : "No open slots for this day."}
+                                                    </p>
+                                                </div>
 
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Time</Label>
-                                    <Select
-                                        value={createTimeStart || undefined}
-                                        onValueChange={setCreateTimeStart}
-                                        disabled={loadingSlots || !createDoctorId || !createDate}
-                                    >
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue
-                                                placeholder={
-                                                    !createDoctorId
-                                                        ? "Select a doctor first"
-                                                        : loadingSlots
-                                                            ? "Checking availability..."
-                                                            : "Select time slot"
-                                                }
-                                            />
-                                        </SelectTrigger>
-                                        <SelectContent className="max-h-60">
-                                            {loadingSlots ? (
-                                                <SelectItem value="loading" disabled>
-                                                    Checking availability...
-                                                </SelectItem>
-                                            ) : slots.length === 0 ? (
-                                                <SelectItem value="none" disabled>
-                                                    No open slots for the selected date
-                                                </SelectItem>
-                                            ) : (
-                                                slots.map((slot) => (
-                                                    <SelectItem key={`${slot.start}-${slot.end}`} value={slot.start}>
-                                                        {formatTimeRange(slot.start, slot.end)}
-                                                    </SelectItem>
-                                                ))
-                                            )}
-                                        </SelectContent>
-                                    </Select>
+                                                {!selectedDate ? (
+                                                    <div className="rounded-2xl border border-dashed border-primary/30 bg-primary/10/50 p-6 text-sm text-muted-foreground">
+                                                        Choose a date on the calendar to view available times.
+                                                    </div>
+                                                ) : loadingSlots ? (
+                                                    <div className="flex items-center gap-2 rounded-2xl border border-primary/25 bg-white p-3 text-sm text-muted-foreground">
+                                                        <Loader2 className="h-4 w-4 animate-spin" /> Checking availability...
+                                                    </div>
+                                                ) : availabilityError ? (
+                                                    <div className="rounded-2xl border border-rose-100 bg-rose-50/60 p-3 text-sm text-rose-700">
+                                                        Unable to load the schedule. Try again later.
+                                                    </div>
+                                                ) : onLeaveDay || leaveDates.includes(createDate) ? (
+                                                    <div className="rounded-2xl border border-amber-200 bg-amber-50/70 p-3 text-sm text-amber-800">
+                                                        This doctor is marked as on leave for this day.
+                                                    </div>
+                                                ) : slots.length > 0 ? (
+                                                    <div className="grid gap-2 sm:grid-cols-2">
+                                                        {slots.map((slot) => {
+                                                            const isSelected = createTimeStart === slot.start;
+                                                            return (
+                                                                <button
+                                                                    key={`${createDoctorId}-${slot.start}-${slot.end}`}
+                                                                    type="button"
+                                                                    onClick={() => selectedDoctor && setCreateTimeStart(slot.start)}
+                                                                    className={cn(
+                                                                        "flex w-full flex-col items-start gap-1 rounded-2xl border px-3 py-2 text-left text-sm font-medium transition",
+                                                                        "border-primary/25 bg-white text-primary hover:bg-primary/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+                                                                        isSelected && "border-primary bg-primary text-white hover:bg-primary/90 focus-visible:outline-primary"
+                                                                    )}
+                                                                    aria-pressed={isSelected}
+                                                                >
+                                                                    <span className="leading-tight">{formatTimeRange(slot.start, slot.end)}</span>
+                                                                    <span
+                                                                        className={cn(
+                                                                            "text-xs font-medium leading-tight",
+                                                                            isSelected ? "text-white/80" : "text-muted-foreground"
+                                                                        )}
+                                                                    >
+                                                                        {isSelected ? "Selected" : "Available"}
+                                                                    </span>
+                                                                </button>
+                                                            );
+                                                        })}
+                                                    </div>
+                                                ) : (
+                                                    <div className="rounded-2xl border border-rose-100 bg-rose-50/60 p-3 text-sm text-rose-700">
+                                                        No available slots for this date.
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
 
                                 <div className="space-y-2 sm:col-span-2">

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -850,7 +850,7 @@ export default function ScholarAppointmentsPage() {
                 </AppointmentPanel>
             </div>
             <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-                <DialogContent className="rounded-3xl sm:max-w-3xl max-h-[80vh] overflow-y-auto sm:overflow-visible sm:max-h-none">
+                <DialogContent className="max-h-[85vh] overflow-y-auto rounded-3xl sm:max-w-3xl">
                     <form onSubmit={handleCreateSubmit} className="space-y-6">
                         <DialogHeader>
                             <DialogTitle className="text-xl text-primary">

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -194,7 +194,7 @@ export default function ScholarAppointmentsPage() {
         setSlots([]);
         setAvailableDates([]);
         setLeaveDates([]);
-        setAvailabilityMonth(today instanceof Date ? today : manilaNow());
+        setAvailabilityMonth(manilaNow());
         setAvailabilityError(null);
         setOnLeaveDay(false);
         setCreateDate(today);
@@ -450,10 +450,6 @@ export default function ScholarAppointmentsPage() {
     }, [createDoctorId, createDate, createDialogOpen]);
 
     const searchTerm = search.trim().toLowerCase();
-    const selectedDoctor = useMemo(
-        () => doctors.find((doctor) => doctor.user_id === createDoctorId) ?? null,
-        [createDoctorId, doctors]
-    );
     const selectedDate = useMemo(() => (createDate ? new Date(`${createDate}T00:00:00+08:00`) : undefined), [createDate]);
     const availableDateObjects = useMemo(
         () => availableDates.map((value) => new Date(`${value}T00:00:00+08:00`)),
@@ -1089,7 +1085,7 @@ export default function ScholarAppointmentsPage() {
                                                 <div className="space-y-1">
                                                     <p className="text-xs font-semibold uppercase tracking-wide text-primary">Selected day</p>
                                                     <h4 className="text-lg font-semibold text-slate-900">
-                                                        {selectedDate ? toManilaDateString(selectedDate) : "Choose a date"}
+                                                        {selectedDate ? toManilaDateString(formatManilaISODate(selectedDate)) : "Choose a date"}
                                                     </h4>
                                                     <p className="text-sm text-muted-foreground">
                                                         {!selectedDate


### PR DESCRIPTION
## Summary
- add a calendar availability API endpoint that returns available and leave dates for doctors per clinic and month
- redesign the patient appointment request experience with a calendar-driven schedule picker, leave indicators, and preserved booking summary
- refresh the scholar walk-in scheduling dialog to mirror the calendar layout and time selection used in the nurse calendar

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929937c5bac832790d8c54651c2bfbe)