### PR TITLE
Introduce shared pagination across patient tables

### DIFF
--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -270,61 +270,52 @@ export default function DoctorPatientsPage() {
                             <div className="space-y-1">
                                 <CardTitle className="text-xl text-primary">Patient directory</CardTitle>
                                 <p className="text-sm text-muted-foreground">
-                                    Filter student and employee details before handing off to nurses or doctors.
+                                    Filter clinic records and open charts directly for quick bedside coordination.
                                 </p>
                             </div>
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Patient type</Label>
-                                    <Select value={typeFilter} onValueChange={setTypeFilter}>
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue placeholder="All types" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="All">All</SelectItem>
-                                            <SelectItem value="Student">Students</SelectItem>
-                                            <SelectItem value="Employee">Employees</SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                            <div className="space-y-1 md:w-72">
+                                <Label className="text-sm font-semibold text-primary">Search Records</Label>
+                                <div className="relative">
+                                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                    <Input
+                                        placeholder="Search by name or ID"
+                                        value={search}
+                                        onChange={(event) => setSearch(event.target.value)}
+                                        className="h-9 w-full pl-10 pr-4"
+                                    />
                                 </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Account status</Label>
-                                    <Select value={statusFilter} onValueChange={setStatusFilter}>
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue placeholder="Status" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="All">All</SelectItem>
-                                            <SelectItem value="Active">Active</SelectItem>
-                                            <SelectItem value="Inactive">Inactive</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Appointment link</Label>
-                                    <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue placeholder="Appointments" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="All">All</SelectItem>
-                                            <SelectItem value="With">With appointment</SelectItem>
-                                            <SelectItem value="Without">No appointment</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Search records</Label>
-                                    <div className="relative">
-                                        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                                        <Input
-                                            placeholder="Search by name or ID"
-                                            value={search}
-                                            onChange={(event) => setSearch(event.target.value)}
-                                            className="rounded-xl border-primary/30 pl-9"
-                                        />
-                                    </div>
-                                </div>
+                            </div>
+                            <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row md:items-center">
+                                <Select value={typeFilter} onValueChange={setTypeFilter}>
+                                    <SelectTrigger className="h-10 w-full">
+                                        <SelectValue placeholder="All types" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="All">All Types</SelectItem>
+                                        <SelectItem value="Student">Students</SelectItem>
+                                        <SelectItem value="Employee">Employees</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                                    <SelectTrigger className="h-10 w-full">
+                                        <SelectValue placeholder="Status" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="All">All Status</SelectItem>
+                                        <SelectItem value="Active">Active</SelectItem>
+                                        <SelectItem value="Inactive">Inactive</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
+                                    <SelectTrigger className="h-10 w-full">
+                                        <SelectValue placeholder="Appointments" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="All">All Appointments</SelectItem>
+                                        <SelectItem value="With">With appointment</SelectItem>
+                                        <SelectItem value="Without">No appointment</SelectItem>
+                                    </SelectContent>
+                                </Select>
                             </div>
                         </CardHeader>
                         <CardContent className="pt-4">

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -23,6 +23,7 @@ import DoctorPatientsLoading from "./loading";
 import { PatientDirectoryTable } from "@/app/nurse/records/patient-directory-table";
 import type { RecordDetailsDialogTab } from "@/app/nurse/records/patient-record-dialog";
 import type { PatientRecord } from "@/app/nurse/records/types";
+import { usePagination } from "@/hooks/use-pagination";
 
 const RecordDetailsDialog = dynamic(
     () => import("@/app/nurse/records/patient-record-dialog").then((mod) => mod.RecordDetailsDialog),
@@ -47,8 +48,6 @@ export default function DoctorPatientsPage() {
     const [activeTab, setActiveTab] = useState<RecordDetailsDialogTab>("details");
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
-    const [currentPage, setCurrentPage] = useState(1);
-    const pageSize = 10;
     const [isRefreshing, startTransition] = useTransition();
 
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
@@ -108,21 +107,9 @@ export default function DoctorPatientsPage() {
         });
     }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
 
-    useEffect(() => {
-        setCurrentPage(1);
-    }, [appointmentFilter, deferredSearch, statusFilter, typeFilter]);
-
-    useEffect(() => {
-        const maxPage = Math.max(1, Math.ceil(filteredRecords.length / pageSize));
-        if (currentPage > maxPage) {
-            setCurrentPage(maxPage);
-        }
-    }, [currentPage, filteredRecords.length, pageSize]);
-
-    const paginatedRecords = useMemo(() => {
-        const start = (currentPage - 1) * pageSize;
-        return filteredRecords.slice(start, start + pageSize);
-    }, [currentPage, filteredRecords, pageSize]);
+    const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
+        resetDeps: [appointmentFilter, deferredSearch, statusFilter, typeFilter],
+    });
 
     const totalPatients = records.length;
     const withAppointments = useMemo(
@@ -348,7 +335,7 @@ export default function DoctorPatientsPage() {
                                 totalRecords={filteredRecords.length}
                                 pageSize={pageSize}
                                 currentPage={currentPage}
-                                onPageChange={setCurrentPage}
+                                onPageChange={setPage}
                             />
                         </CardContent>
                     </Card>

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -70,6 +70,8 @@ import type { AccountPasswordResult } from "@/components/account/account-passwor
 import { validateAndNormalizeContacts } from "@/lib/validation";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 import { cn } from "@/lib/utils";
+import { usePagination } from "@/hooks/use-pagination";
+import { TablePagination } from "@/components/table-pagination";
 
 import NurseAccountsLoading from "./loading";
 import {
@@ -138,8 +140,6 @@ export function NurseAccountsPageClient({
 
     const [profileLoaded, setProfileLoaded] = useState(initialProfileLoaded);
     const [usersLoaded, setUsersLoaded] = useState(initialUsersLoaded);
-
-    const [currentPage, setCurrentPage] = useState(1);
 
     const [originalProfile, setOriginalProfile] = useState<NurseAccountProfile | null>(initialProfile);
 
@@ -346,10 +346,6 @@ export function NurseAccountsPageClient({
     }, [role]);
 
     useEffect(() => {
-        setCurrentPage(1);
-    }, [roleFilter, statusFilter, scholarFilter]);
-
-    useEffect(() => {
         if (profile?.gender) {
             setTempGender("");
         }
@@ -382,6 +378,10 @@ export function NurseAccountsPageClient({
             return matchesQuery && matchesRole && matchesStatus && matchesScholar;
         });
     }, [deferredSearch, roleFilter, scholarFilter, statusFilter, users]);
+
+    const { pageItems: paginatedUsers, currentPage, pageSize, setPage } = usePagination(filteredUsers, {
+        resetDeps: [deferredSearch, roleFilter, scholarFilter, statusFilter],
+    });
 
     // Create user
     function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -1497,7 +1497,7 @@ export function NurseAccountsPageClient({
                                     value={search}
                                     onChange={(e) => {
                                         setSearch(e.target.value);
-                                        setCurrentPage(1);
+                                        setPage(1);
                                     }}
                                     className="pl-8"
                                     disabled={loading || isRefreshingUsers}
@@ -1577,13 +1577,11 @@ export function NurseAccountsPageClient({
                                             </TableCell>
                                         </TableRow>
                                     ) : filteredUsers.length > 0 ? (
-                                        filteredUsers
-                                            .slice((currentPage - 1) * 8, currentPage * 8)
-                                            .map((user) => {
-                                                const isStatusUpdating = pendingStatusIds.includes(user.accountId);
-                                                return (
-                                                    <TableRow key={`${user.accountId}-${user.role}`} className="hover:bg-emerald-50/60 transition">
-                                                        <TableCell className="whitespace-nowrap text-xs sm:text-sm font-semibold text-emerald-900">{user.user_id}</TableCell>
+                                        paginatedUsers.map((user) => {
+                                            const isStatusUpdating = pendingStatusIds.includes(user.accountId);
+                                            return (
+                                                <TableRow key={`${user.accountId}-${user.role}`} className="hover:bg-emerald-50/60 transition">
+                                                    <TableCell className="whitespace-nowrap text-xs sm:text-sm font-semibold text-emerald-900">{user.user_id}</TableCell>
                                                         <TableCell className="whitespace-nowrap">
                                                             <div className="flex flex-col">
                                                                 <span className="font-medium text-gray-900">{user.role}</span>
@@ -1729,28 +1727,13 @@ export function NurseAccountsPageClient({
                             </Table>
                         </div>
 
-                        {/* Pagination */}
-                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mt-4 pt-4 border-t text-sm sm:text-base">
-                            <span className="text-muted-foreground">Page {currentPage} of {Math.ceil(filteredUsers.length / 8) || 1}</span>
-                            <div className="flex gap-2">
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
-                                    disabled={currentPage === 1}
-                                >
-                                    Previous
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => setCurrentPage((prev) => Math.min(prev + 1, Math.ceil(filteredUsers.length / 8)))}
-                                    disabled={currentPage === Math.ceil(filteredUsers.length / 8) || filteredUsers.length === 0}
-                                >
-                                    Next
-                                </Button>
-                            </div>
-                        </div>
+                        <TablePagination
+                            currentPage={currentPage}
+                            totalItems={filteredUsers.length}
+                            pageSize={pageSize}
+                            loading={isRefreshingUsers}
+                            onPageChange={setPage}
+                        />
                     </CardContent>
                 </Card>
             </section>

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -24,6 +24,7 @@ import NurseRecordsLoading from "./loading";
 import { PatientDirectoryTable } from "./patient-directory-table";
 import type { RecordDetailsDialogTab } from "./patient-record-dialog";
 import type { PatientRecord } from "./types";
+import { usePagination } from "@/hooks/use-pagination";
 
 const RecordDetailsDialog = dynamic(
     () => import("./patient-record-dialog").then((mod) => mod.RecordDetailsDialog),
@@ -53,8 +54,6 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
     const [activeTab, setActiveTab] = useState<RecordDetailsDialogTab>("details");
     const [updatingPatientId, setUpdatingPatientId] = useState<string | null>(null);
     const [savingNotesPatientId, setSavingNotesPatientId] = useState<string | null>(null);
-    const [currentPage, setCurrentPage] = useState(1);
-    const pageSize = 10;
     const [isRefreshing, startTransition] = useTransition();
 
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
@@ -116,21 +115,9 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
         });
     }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
 
-    useEffect(() => {
-        setCurrentPage(1);
-    }, [appointmentFilter, deferredSearch, statusFilter, typeFilter]);
-
-    useEffect(() => {
-        const maxPage = Math.max(1, Math.ceil(filteredRecords.length / pageSize));
-        if (currentPage > maxPage) {
-            setCurrentPage(maxPage);
-        }
-    }, [currentPage, filteredRecords.length, pageSize]);
-
-    const paginatedRecords = useMemo(() => {
-        const start = (currentPage - 1) * pageSize;
-        return filteredRecords.slice(start, start + pageSize);
-    }, [currentPage, filteredRecords, pageSize]);
+    const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
+        resetDeps: [appointmentFilter, deferredSearch, statusFilter, typeFilter],
+    });
 
     const totalPatients = records.length;
     const withAppointments = useMemo(
@@ -369,7 +356,7 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
                                 totalRecords={filteredRecords.length}
                                 pageSize={pageSize}
                                 currentPage={currentPage}
-                                onPageChange={setCurrentPage}
+                                onPageChange={setPage}
                             />
                         </CardContent>
                     </Card>

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -294,58 +294,49 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
                                     Filter clinic records and open charts directly for quick bedside coordination.
                                 </p>
                             </div>
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Patient type</Label>
-                                    <Select value={typeFilter} onValueChange={setTypeFilter}>
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue placeholder="All types" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="All">All</SelectItem>
-                                            <SelectItem value="Student">Students</SelectItem>
-                                            <SelectItem value="Employee">Employees</SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                            <div className="space-y-1 md:w-72">
+                                <Label className="text-sm font-semibold text-primary">Search Records</Label>
+                                <div className="relative">
+                                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                    <Input
+                                        placeholder="Search by name or ID"
+                                        value={search}
+                                        onChange={(event) => setSearch(event.target.value)}
+                                        className="h-9 w-full pl-10 pr-4"
+                                    />
                                 </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Account status</Label>
-                                    <Select value={statusFilter} onValueChange={setStatusFilter}>
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue placeholder="Status" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="All">All</SelectItem>
-                                            <SelectItem value="Active">Active</SelectItem>
-                                            <SelectItem value="Inactive">Inactive</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Appointment link</Label>
-                                    <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
-                                        <SelectTrigger className="rounded-xl border-primary/30">
-                                            <SelectValue placeholder="Appointments" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="All">All</SelectItem>
-                                            <SelectItem value="With">With appointment</SelectItem>
-                                            <SelectItem value="Without">No appointment</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div className="space-y-2">
-                                    <Label className="text-sm font-medium text-primary">Search records</Label>
-                                    <div className="relative">
-                                        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                                        <Input
-                                            placeholder="Search by name or ID"
-                                            value={search}
-                                            onChange={(event) => setSearch(event.target.value)}
-                                            className="rounded-xl border-primary/30 pl-9"
-                                        />
-                                    </div>
-                                </div>
+                            </div>
+                            <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row md:items-center">
+                                <Select value={typeFilter} onValueChange={setTypeFilter}>
+                                    <SelectTrigger className="h-10 w-full">
+                                        <SelectValue placeholder="All types" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="All">All Types</SelectItem>
+                                        <SelectItem value="Student">Students</SelectItem>
+                                        <SelectItem value="Employee">Employees</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <Select value={statusFilter} onValueChange={setStatusFilter}>
+                                    <SelectTrigger className="h-10 w-full">
+                                        <SelectValue placeholder="Status" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="All">All Status</SelectItem>
+                                        <SelectItem value="Active">Active</SelectItem>
+                                        <SelectItem value="Inactive">Inactive</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
+                                    <SelectTrigger className="h-10 w-full">
+                                        <SelectValue placeholder="Appointments" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="All">All Appointments</SelectItem>
+                                        <SelectItem value="With">With appointment</SelectItem>
+                                        <SelectItem value="Without">No appointment</SelectItem>
+                                    </SelectContent>
+                                </Select>
                             </div>
                         </CardHeader>
                         <CardContent className="pt-4">

--- a/src/app/nurse/records/patient-directory-table.tsx
+++ b/src/app/nurse/records/patient-directory-table.tsx
@@ -3,7 +3,6 @@
 import { memo, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
 import {
     Table,
     TableBody,
@@ -22,6 +21,7 @@ import {
     formatYearLevel,
     PATIENT_STATUS_CLASSES,
 } from "@/lib/patient-format";
+import { TablePagination } from "@/components/table-pagination";
 
 import type { PatientRecord } from "./types";
 
@@ -129,10 +129,6 @@ function PatientDirectoryTableComponent({
         });
     }, [records, onOpenDetails]);
 
-    const totalPages = Math.max(1, Math.ceil(totalRecords / pageSize));
-    const startIndex = totalRecords === 0 ? 0 : (currentPage - 1) * pageSize + 1;
-    const endIndex = totalRecords === 0 ? 0 : Math.min(startIndex + records.length - 1, totalRecords);
-
     return (
         <div className="overflow-x-auto">
             <Table className="min-w-full text-sm">
@@ -166,35 +162,13 @@ function PatientDirectoryTableComponent({
                     )}
                 </TableBody>
             </Table>
-
-            <div className="mt-4 flex flex-col gap-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-                <span>
-                    Showing {startIndex}-{endIndex} of {totalRecords}
-                </span>
-                <div className="flex items-center gap-2">
-                    <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={loading || currentPage <= 1}
-                        onClick={() => onPageChange(Math.max(1, currentPage - 1))}
-                    >
-                        Previous
-                    </Button>
-                    <span className="text-xs">
-                        Page {currentPage} of {totalPages}
-                    </span>
-                    <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={loading || currentPage >= totalPages}
-                        onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
-                    >
-                        Next
-                    </Button>
-                </div>
-            </div>
+            <TablePagination
+                currentPage={currentPage}
+                totalItems={totalRecords}
+                pageSize={pageSize}
+                loading={loading}
+                onPageChange={onPageChange}
+            />
         </div>
     );
 }

--- a/src/app/scholar/patients/page.client.tsx
+++ b/src/app/scholar/patients/page.client.tsx
@@ -17,10 +17,12 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { TablePagination } from "@/components/table-pagination";
 
 import ScholarPatientsLoading from "./loading";
 import { PatientsTable } from "./patients-table";
 import { preparePatientRecords, type PreparedPatientRecord } from "./types";
+import { usePagination } from "@/hooks/use-pagination";
 
 const PatientDetailDialog = dynamic(
     () => import("./patient-detail-dialog").then((mod) => mod.PatientDetailDialog),
@@ -107,6 +109,10 @@ export function ScholarPatientsPageClient({ initialRecords, initialLoaded }: Sch
             return record.searchText.includes(deferredSearch);
         });
     }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
+
+    const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
+        resetDeps: [appointmentFilter, deferredSearch, statusFilter, typeFilter],
+    });
 
     const totalPatients = records.length;
     const withAppointments = useMemo(
@@ -240,9 +246,16 @@ export function ScholarPatientsPageClient({ initialRecords, initialLoaded }: Sch
                     </CardHeader>
                     <CardContent className="pt-4">
                         <PatientsTable
-                            records={filteredRecords}
+                            records={paginatedRecords}
                             loading={loading}
                             onSelect={openDetails}
+                        />
+                        <TablePagination
+                            currentPage={currentPage}
+                            totalItems={filteredRecords.length}
+                            pageSize={pageSize}
+                            loading={loading || isRefreshing}
+                            onPageChange={setPage}
                         />
                     </CardContent>
                 </Card>

--- a/src/components/table-pagination.tsx
+++ b/src/components/table-pagination.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface TablePaginationProps {
+    currentPage: number;
+    totalItems: number;
+    onPageChange: (page: number) => void;
+    pageSize?: number;
+    loading?: boolean;
+    className?: string;
+}
+
+export function TablePagination({
+    currentPage,
+    totalItems,
+    onPageChange,
+    pageSize = 10,
+    loading = false,
+    className,
+}: TablePaginationProps) {
+    const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+    const startIndex = totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+    const endIndex = totalItems === 0 ? 0 : Math.min(currentPage * pageSize, totalItems);
+
+    return (
+        <div
+            className={cn(
+                "mt-4 flex flex-col gap-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between",
+                className
+            )}
+        >
+            <span>
+                Showing {startIndex}-{endIndex} of {totalItems}
+            </span>
+            <div className="flex items-center gap-2">
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={loading || currentPage <= 1}
+                    onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+                >
+                    Previous
+                </Button>
+                <span className="text-xs">Page {currentPage} of {totalPages}</span>
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={loading || currentPage >= totalPages}
+                    onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+                >
+                    Next
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -1,0 +1,44 @@
+import { DependencyList, useEffect, useMemo, useState } from "react";
+
+interface UsePaginationOptions {
+    pageSize?: number;
+    resetDeps?: DependencyList;
+}
+
+export function usePagination<T>(items: T[], options: UsePaginationOptions = {}) {
+    const { pageSize = 10, resetDeps = [] } = options;
+    const [currentPage, setCurrentPage] = useState(1);
+
+    useEffect(() => {
+        setCurrentPage(1);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, resetDeps);
+
+    const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+
+    useEffect(() => {
+        if (currentPage > totalPages) {
+            setCurrentPage(totalPages);
+        }
+    }, [currentPage, totalPages]);
+
+    const pageItems = useMemo(() => {
+        const start = (currentPage - 1) * pageSize;
+        return items.slice(start, start + pageSize);
+    }, [currentPage, items, pageSize]);
+
+    const startIndex = items.length === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+    const endIndex = items.length === 0 ? 0 : Math.min(currentPage * pageSize, items.length);
+
+    return {
+        currentPage,
+        pageSize,
+        totalPages,
+        pageItems,
+        startIndex,
+        endIndex,
+        setPage: setCurrentPage,
+        goToPrevious: () => setCurrentPage((page) => Math.max(page - 1, 1)),
+        goToNext: () => setCurrentPage((page) => Math.min(page + 1, totalPages)),
+    };
+}


### PR DESCRIPTION
## Summary
- add shared pagination hook and table footer component to standardize 10-row pages
- update nurse accounts plus nurse, doctor, and scholar patient directories to reuse shared pagination behavior
- ensure pagination resets or clamps when filters or searches change

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692daf4fa74483278ca637c7a35eadbb)