### PR TITLE
Configure Prisma for new datasource handling

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,9 @@ const nextConfig: NextConfig = {
   env: {
     TZ: "Asia/Manila",
   },
+  experimental: {
+    serverComponentsExternalPackages: ["@prisma/adapter-pg", "pg"],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@prisma/adapter-pg": "^7.1.0",
         "@hookform/resolvers": "^5.2.2",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^7.1.0",
@@ -54,6 +55,7 @@
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
         "node-fetch": "^3.3.2",
+        "pg": "^8.13.1",
         "puppeteer-core": "^24.32.0",
         "react": "^18.3.1",
         "react-day-picker": "^9.11.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@next-auth/prisma-adapter": "^1.0.7",
-    "@prisma/adapter-pg": "^7.1.1",
+    "@prisma/adapter-pg": "^7.1.0",
     "@prisma/client": "^7.1.0",
     "@prisma/extension-accelerate": "^3.0.1",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@next-auth/prisma-adapter": "^1.0.7",
+    "@prisma/adapter-pg": "^7.1.1",
     "@prisma/client": "^7.1.0",
     "@prisma/extension-accelerate": "^3.0.1",
     "@radix-ui/react-accordion": "^1.2.12",
@@ -55,6 +56,7 @@
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
     "node-fetch": "^3.3.2",
+    "pg": "^8.13.1",
     "puppeteer-core": "^24.32.0",
     "react": "^18.3.1",
     "react-day-picker": "^9.11.3",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, env } from "@prisma/config";
+
+export default defineConfig({
+  schema: "./prisma/schema.prisma",
+  engine: "classic",
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model Clinic {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,11 +1,20 @@
 // src/lib/prisma.ts
 import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+});
+
+const adapter = new PrismaPg(pool);
 
 export const prisma =
     globalForPrisma.prisma ??
     new PrismaClient({
+        adapter,
         log: ["error", "warn"], // keep logs lightweight in prod
     });
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -73,7 +73,7 @@ function allowRequest() {
 /**
  * Guards protected routes by validating the session token and role access.
  */
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
     const { pathname } = req.nextUrl;
 
     if (req.method === "OPTIONS") {
@@ -110,6 +110,8 @@ export async function middleware(req: NextRequest) {
 
     return allowRequest();
 }
+
+export default proxy;
 
 // Apply only to protected routes
 export const config = {


### PR DESCRIPTION
## Summary
- move datasource connection configuration into a new `prisma.config.ts` for Prisma 7
- adjust the Prisma client to use the PostgreSQL adapter with the DATABASE_URL
- declare adapter and driver dependencies for direct database connections

## Testing
- npm install *(fails: registry access returned 403 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930de6e8b4c83278eaf8b301779c6ba)