### PR TITLE
Configure Prisma Accelerate support

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,5 +1,5 @@
 // src/lib/prisma.ts
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { withAccelerate } from "@prisma/extension-accelerate";
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
@@ -7,7 +7,7 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient };
 const accelerateUrl = process.env.PRISMA_ACCELERATE_URL;
 
 const prismaClientSingleton = () => {
-    const log = ["error", "warn"] as const; // keep logs lightweight in prod
+    const log: (Prisma.LogLevel | Prisma.LogDefinition)[] = ["error", "warn"]; // keep logs lightweight in prod
 
     if (accelerateUrl) {
         return new PrismaClient({

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,7 +7,7 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient };
 const accelerateUrl = process.env.PRISMA_ACCELERATE_URL;
 
 const prismaClientSingleton = () => {
-    const log: (Prisma.LogLevel | Prisma.LogDefinition)[] = ["error", "warn"]; // keep logs lightweight in prod
+    const log: Prisma.PrismaClientOptions["log"] = ["error", "warn"]; // keep logs lightweight in prod
 
     if (accelerateUrl) {
         return new PrismaClient({
@@ -16,11 +16,15 @@ const prismaClientSingleton = () => {
         }).$extends(withAccelerate());
     }
 
-    // Explicitly use the native engine when Accelerate is not configured to avoid
-    // Prisma defaulting to the client engine, which requires an adapter or accelerateUrl.
+    // Explicitly avoid the client engine (which needs an adapter/Accelerate) when
+    // Accelerate is not configured by forcing Prisma to use the native library
+    // engine via the environment variable expected by Prisma.
+    if (!process.env.PRISMA_CLIENT_ENGINE_TYPE) {
+        process.env.PRISMA_CLIENT_ENGINE_TYPE = "library";
+    }
+
     return new PrismaClient({
         log,
-        engineType: "library",
     });
 };
 

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,12 +1,26 @@
 // src/lib/prisma.ts
 import { PrismaClient } from "@prisma/client";
+import { withAccelerate } from "@prisma/extension-accelerate";
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
-export const prisma =
-    globalForPrisma.prisma ??
-    new PrismaClient({
-        log: ["error", "warn"], // keep logs lightweight in prod
+const accelerateUrl = process.env.PRISMA_ACCELERATE_URL;
+
+const prismaClientSingleton = () => {
+    const log = ["error", "warn"] as const; // keep logs lightweight in prod
+
+    if (accelerateUrl) {
+        return new PrismaClient({
+            log,
+            accelerateUrl,
+        }).$extends(withAccelerate());
+    }
+
+    return new PrismaClient({
+        log,
     });
+};
+
+export const prisma = globalForPrisma.prisma ?? prismaClientSingleton();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -16,8 +16,11 @@ const prismaClientSingleton = () => {
         }).$extends(withAccelerate());
     }
 
+    // Explicitly use the native engine when Accelerate is not configured to avoid
+    // Prisma defaulting to the client engine, which requires an adapter or accelerateUrl.
     return new PrismaClient({
         log,
+        engineType: "library",
     });
 };
 


### PR DESCRIPTION
## Summary
- add optional Prisma Accelerate configuration that uses PRISMA_ACCELERATE_URL when available
- keep Prisma client singleton setup with lightweight logging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930ede116f883278ea93c9b9bc7fcfd)