### PR TITLE
Fix PDF generation fallbacks for medical certificates and nurse reports

### DIFF
--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -32,6 +32,29 @@ export async function GET(
   context: { params: Promise<{ id: string }> }
 ) {
   const isLocal = !process.env.AWS_REGION && !process.env.VERCEL;
+  const getExecutablePath = async () => {
+    if (process.env.CHROME_EXECUTABLE_PATH) {
+      return process.env.CHROME_EXECUTABLE_PATH;
+    }
+
+    const chromiumPath = await chromium.executablePath();
+    if (chromiumPath) {
+      return chromiumPath;
+    }
+
+    if (!isLocal) {
+      throw new Error("Unable to resolve chromium executable path");
+    }
+
+    switch (process.platform) {
+      case "win32":
+        return "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+      case "darwin":
+        return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+      default:
+        return "/usr/bin/google-chrome";
+    }
+  };
   const { id } = await context.params;
   try {
     const session = await getServerSession(authOptions);
@@ -268,11 +291,7 @@ export async function GET(
     const browser = await puppeteer.launch({
       args: chromium.args,
       defaultViewport: { width: 1280, height: 720 },
-      executablePath: isLocal
-        ? process.platform === "win32"
-          ? "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
-          : "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        : await chromium.executablePath(),
+      executablePath: await getExecutablePath(),
       headless: true,
     });
 

--- a/src/app/api/nurse/reports/pdf/route.ts
+++ b/src/app/api/nurse/reports/pdf/route.ts
@@ -29,6 +29,32 @@ import {
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const isLocal = !process.env.AWS_REGION && !process.env.VERCEL;
+
+async function getExecutablePath() {
+    if (process.env.CHROME_EXECUTABLE_PATH) {
+        return process.env.CHROME_EXECUTABLE_PATH;
+    }
+
+    const chromiumPath = await chromium.executablePath();
+    if (chromiumPath) {
+        return chromiumPath;
+    }
+
+    if (!isLocal) {
+        throw new Error("Unable to resolve chromium executable path");
+    }
+
+    switch (process.platform) {
+        case "win32":
+            return "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+        case "darwin":
+            return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+        default:
+            return "/usr/bin/google-chrome";
+    }
+}
+
 function escapeHtml(value: string) {
     return value.replace(/[&<>"]|'/g, (char) => {
         switch (char) {
@@ -498,7 +524,7 @@ async function getHandler(request: RateLimitedRequest) {
 
         browser = await puppeteer.launch({
             args: chromium.args,
-            executablePath: await chromium.executablePath(),
+            executablePath: await getExecutablePath(),
             headless: true,
         });
 


### PR DESCRIPTION
## Summary
- add shared chromium executable path resolution for doctor medical certificate generation
- reuse chromium executable resolution for nurse quarterly report PDF generation
- ensure PDF generation works in local and deployed environments with sensible fallbacks

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69318b7fe58483279e270d3c4c0c1270)