### PR TITLE
Refine sidebar layout

### DIFF
--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -199,17 +199,8 @@ export function PanelLayout({
                                             </TooltipTrigger>
                                             <TooltipContent
                                                 side="right"
-                                                className="flex items-center gap-3 border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
+                                                className="rounded-xl border border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
                                             >
-                                                <span
-                                                    className={cn(
-                                                        "flex h-8 w-8 items-center justify-center rounded-full border border-primary/10",
-                                                        isActive ? "bg-primary text-primary-foreground" : "bg-primary/5 text-primary"
-                                                    )}
-                                                    aria-hidden
-                                                >
-                                                    <Icon className="h-4 w-4" />
-                                                </span>
                                                 <p className="text-sm font-semibold leading-none">{item.label}</p>
                                             </TooltipContent>
                                         </Tooltip>
@@ -232,11 +223,8 @@ export function PanelLayout({
                             </TooltipTrigger>
                             <TooltipContent
                                 side="right"
-                                className="flex items-center gap-3 border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
+                                className="rounded-xl border border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
                             >
-                                <span className="flex h-8 w-8 items-center justify-center rounded-full border border-primary/10 bg-primary/5 text-primary">
-                                    <LogOut className="h-4 w-4" />
-                                </span>
                                 <p className="text-sm font-semibold leading-none">Logout</p>
                             </TooltipContent>
                         </Tooltip>

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -161,9 +161,18 @@ export function PanelLayout({
                                     <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
                                 </Avatar>
                             </TooltipTrigger>
-                            <TooltipContent side="right" className="border-primary/10 bg-white text-primary shadow-sm">
-                                <p className="text-sm font-semibold leading-none">{fullName}</p>
-                                <p className="text-xs text-muted-foreground">Signed in</p>
+                            <TooltipContent
+                                side="right"
+                                className="flex items-center gap-3 border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
+                            >
+                                <Avatar className="h-8 w-8 border border-primary/10 bg-primary/5">
+                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                                    <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                                </Avatar>
+                                <div className="space-y-0.5">
+                                    <p className="text-sm font-semibold leading-none">{fullName}</p>
+                                    <p className="text-xs text-muted-foreground">Signed in</p>
+                                </div>
                             </TooltipContent>
                         </Tooltip>
 
@@ -188,7 +197,19 @@ export function PanelLayout({
                                                     <Icon className="h-5 w-5" />
                                                 </Link>
                                             </TooltipTrigger>
-                                            <TooltipContent side="right" className="border-primary/10 bg-white text-primary shadow-sm">
+                                            <TooltipContent
+                                                side="right"
+                                                className="flex items-center gap-3 border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
+                                            >
+                                                <span
+                                                    className={cn(
+                                                        "flex h-8 w-8 items-center justify-center rounded-full border border-primary/10",
+                                                        isActive ? "bg-primary text-primary-foreground" : "bg-primary/5 text-primary"
+                                                    )}
+                                                    aria-hidden
+                                                >
+                                                    <Icon className="h-4 w-4" />
+                                                </span>
                                                 <p className="text-sm font-semibold leading-none">{item.label}</p>
                                             </TooltipContent>
                                         </Tooltip>
@@ -209,7 +230,13 @@ export function PanelLayout({
                                     {isLoggingOut ? "…" : <LogOut className="h-5 w-5" />}
                                 </Button>
                             </TooltipTrigger>
-                            <TooltipContent side="right" className="border-primary/10 bg-white text-primary shadow-sm">
+                            <TooltipContent
+                                side="right"
+                                className="flex items-center gap-3 border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
+                            >
+                                <span className="flex h-8 w-8 items-center justify-center rounded-full border border-primary/10 bg-primary/5 text-primary">
+                                    <LogOut className="h-4 w-4" />
+                                </span>
                                 <p className="text-sm font-semibold leading-none">Logout</p>
                             </TooltipContent>
                         </Tooltip>

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -80,7 +80,7 @@ export function PanelLayout({
 
     if (status === "loading") {
         return (
-            <div className="flex min-h-screen items-center justify-center bg-linear-to-br from-primary/10 via-white to-primary/5 p-6" aria-busy>
+            <div className="flex min-h-screen items-center justify-center bg-white p-6" aria-busy>
                 <p className="text-sm font-medium text-muted-foreground">Verifying your session…</p>
             </div>
         );
@@ -114,14 +114,14 @@ export function PanelLayout({
                         key={item.href}
                         href={item.href}
                         className={cn(
-                            "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-semibold transition-colors",
+                            "flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold transition-colors",
                             "hover:bg-primary/10 hover:text-primary",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-primary/10",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
                             isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : "text-muted-foreground"
                         )}
                         onClick={() => setMobileOpen(false)}
                     >
-                        <Icon className={cn("h-4 w-4", isActive ? "text-primary-foreground" : "text-primary")} />
+                        <Icon className={cn("h-5 w-5", isActive ? "text-primary-foreground" : "text-primary")} />
                         <span>{item.label}</span>
                     </Link>
                 );
@@ -130,45 +130,66 @@ export function PanelLayout({
     );
 
     return (
-        <div className="relative min-h-screen bg-linear-to-br from-primary/10 via-white to-primary/5">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_10%_20%,rgba(34,197,94,0.12),transparent_30%),radial-gradient(circle_at_90%_10%,rgba(16,185,129,0.12),transparent_28%),radial-gradient(circle_at_20%_80%,rgba(34,197,94,0.1),transparent_25%)]" aria-hidden />
-            <div className="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 pb-8 pt-6 md:flex-row md:gap-8 md:px-6 lg:px-8">
-                <aside className="hidden w-72 shrink-0 flex-col rounded-3xl border border-primary/15 bg-white/90 p-6 shadow-sm backdrop-blur supports-backdrop-filter:bg-white/70 lg:sticky lg:top-6 lg:flex lg:max-h-[calc(100vh-3rem)]">
-                    <div className="flex h-full flex-col overflow-hidden">
-                        <div className="flex items-center gap-3 pb-6">
-                            <span className="relative inline-flex h-11 w-11 items-center justify-center">
-                                <Image
-                                    src="/clinic-illustration.svg"
-                                    alt="HNU Clinic Health Record & Appointment System emblem"
-                                    width={44}
-                                    height={44}
-                                    className="h-9 w-9 object-contain"
-                                />
-                            </span>
-                            <div className="flex flex-col leading-tight text-left">
-                                <span className="text-sm font-semibold text-primary">HNU Clinic</span>
-                                <span className="text-xs font-medium text-primary/80">
-                                    Health Record &amp; Appointment System
-                                </span>
-                            </div>
+        <div className="relative flex min-h-screen bg-white">
+            <aside className="group/aside sticky left-0 top-0 hidden h-screen w-16 flex-col border-r border-primary/10 bg-white py-6 transition-[width] duration-300 ease-in-out hover:w-64 lg:flex">
+                <div className="flex h-full flex-col">
+                    <div className="flex items-center gap-3 px-4 pb-6">
+                        <span className="relative inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/5">
+                            <Image
+                                src="/clinic-illustration.svg"
+                                alt="HNU Clinic Health Record & Appointment System emblem"
+                                width={44}
+                                height={44}
+                                className="h-9 w-9 object-contain"
+                            />
+                        </span>
+                        <div className="hidden flex-col leading-tight text-left transition-opacity duration-200 group-hover/aside:flex">
+                            <span className="text-sm font-semibold text-primary">HNU Clinic</span>
+                            <span className="text-xs font-medium text-primary/80">Health Record &amp; Appointment System</span>
                         </div>
-                        <div className="mb-6 flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-4">
-                            <Avatar className="h-12 w-12 border border-primary/15">
-                                <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                                <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
-                            </Avatar>
-                            <div>
-                                <p className="text-xs text-primary/80">Signed in as</p>
-                                <p className="text-sm font-semibold text-primary">{fullName}</p>
-                            </div>
+                    </div>
+                    <div className="mb-6 flex items-center gap-3 px-4">
+                        <Avatar className="h-12 w-12 border border-primary/15">
+                            <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                            <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                        </Avatar>
+                        <div className="hidden min-w-0 flex-1 transition-opacity duration-200 group-hover/aside:block">
+                            <p className="truncate text-xs text-primary/80">Signed in as</p>
+                            <p className="truncate text-sm font-semibold text-primary">{fullName}</p>
                         </div>
-                        <div className="flex-1 overflow-y-auto pr-2">
-                            {navLinks}
-                        </div>
-                        <Separator className="my-6" />
+                    </div>
+                    <div className="flex-1 space-y-4 overflow-y-auto px-2 pb-4">
+                        <Separator className="hidden group-hover/aside:block" />
+                        <nav className="flex flex-col gap-1">
+                            {navItems.map((item) => {
+                                const Icon = item.icon;
+                                const activeMatcher = isNavItemActive ?? ((href: string, current: string) => current === href);
+                                const isActive = activeMatcher(item.href, pathname);
+
+                                return (
+                                    <Link
+                                        key={item.href}
+                                        href={item.href}
+                                        className={cn(
+                                            "group/nav flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold transition-colors",
+                                            "hover:bg-primary/10 hover:text-primary",
+                                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                                            isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : "text-muted-foreground"
+                                        )}
+                                        onClick={() => setMobileOpen(false)}
+                                    >
+                                        <Icon className={cn("h-5 w-5", isActive ? "text-primary-foreground" : "text-primary")} />
+                                        <span className="hidden whitespace-nowrap group-hover/aside:inline">{item.label}</span>
+                                    </Link>
+                                );
+                            })}
+                        </nav>
+                    </div>
+                    <div className="mt-auto space-y-4 px-2 pb-2">
+                        <Separator className="hidden group-hover/aside:block" />
                         <Button
                             variant="default"
-                            className="mt-auto w-full gap-2 rounded-xl bg-primary font-semibold text-primary-foreground shadow-sm transition-transform hover:-translate-y-0.5 hover:bg-primary/90"
+                            className="w-full gap-2 rounded-2xl bg-primary font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
                             onClick={handleLogout}
                             disabled={isLoggingOut}
                         >
@@ -177,18 +198,19 @@ export function PanelLayout({
                             ) : (
                                 <>
                                     <LogOut className="h-4 w-4" />
-                                    Logout
+                                    <span className="hidden group-hover/aside:inline">Logout</span>
                                 </>
                             )}
                         </Button>
                     </div>
-                </aside>
+                </div>
+            </aside>
 
-                <div className="flex flex-1 flex-col">
-                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-primary/15 bg-white/85 px-4 py-4 shadow-sm backdrop-blur supports-backdrop-filter:bg-white/65 md:px-6">
-                        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                            <div className="space-y-3">
-                                <p className="text-xs font-semibold uppercase tracking-wider text-primary/80">{panelLabel}</p>
+            <div className="flex min-h-screen flex-1 flex-col px-4 pb-8 pt-6 md:px-6 lg:px-10">
+                <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-primary/15 bg-white px-4 py-4 shadow-sm md:px-6">
+                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div className="space-y-3">
+                            <p className="text-xs font-semibold uppercase tracking-wider text-primary/80">{panelLabel}</p>
                                 <h2 className="text-2xl font-semibold text-primary md:text-3xl">{title}</h2>
                                 {description ? (
                                     <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
@@ -207,7 +229,7 @@ export function PanelLayout({
                                             <Menu className="h-5 w-5" />
                                         </Button>
                                     </SheetTrigger>
-                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-primary/15 bg-linear-to-b from-white to-primary/5 p-0">
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-primary/15 bg-white p-0">
                                         <SheetHeader className="border-b border-primary/15 bg-white/80 p-6">
                                             <SheetTitle className="flex items-center gap-3 text-lg text-primary">
                                                 <Menu className="h-5 w-5" />

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -17,6 +17,12 @@ import {
     SheetTitle,
     SheetTrigger,
 } from "@/components/ui/sheet";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export type PanelNavItem = {
@@ -136,56 +142,79 @@ export function PanelLayout({
     return (
         <div className="relative flex min-h-screen bg-white">
             <aside className="sticky left-0 top-0 hidden h-screen w-16 flex-col items-center border-r border-primary/10 bg-white py-6 lg:flex">
-                <div className="relative flex h-full w-full flex-col items-center gap-6 px-3">
-                    <div className="flex h-12 w-12 items-center justify-center">
-                        <Image
-                            src="/clinic-illustration.svg"
-                            alt="HNU Clinic Health Record & Appointment System emblem"
-                            width={44}
-                            height={44}
-                            className="h-9 w-9 object-contain"
-                        />
+                <TooltipProvider delayDuration={75}>
+                    <div className="relative flex h-full w-full flex-col items-center gap-6 px-3">
+                        <div className="flex h-12 w-12 items-center justify-center">
+                            <Image
+                                src="/clinic-illustration.svg"
+                                alt="HNU Clinic Health Record & Appointment System emblem"
+                                width={44}
+                                height={44}
+                                className="h-9 w-9 object-contain"
+                            />
+                        </div>
+
+                        <Tooltip delayDuration={0}>
+                            <TooltipTrigger asChild>
+                                <Avatar className="h-12 w-12 border border-primary/15">
+                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                                    <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                                </Avatar>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" className="border-primary/10 bg-white text-primary shadow-sm">
+                                <p className="text-sm font-semibold leading-none">{fullName}</p>
+                                <p className="text-xs text-muted-foreground">Signed in</p>
+                            </TooltipContent>
+                        </Tooltip>
+
+                        <div className="flex-1 space-y-2 overflow-y-auto pb-4">
+                            <nav className="flex flex-col items-center gap-3">
+                                {navItems.map((item) => {
+                                    const Icon = item.icon;
+                                    const isActive = isActiveNav(item.href);
+
+                                    return (
+                                        <Tooltip key={item.href} delayDuration={0}>
+                                            <TooltipTrigger asChild>
+                                                <Link
+                                                    href={item.href}
+                                                    className={cn(
+                                                        "flex h-12 w-12 items-center justify-center rounded-2xl text-primary transition",
+                                                        "hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                                                        isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : ""
+                                                    )}
+                                                    aria-label={item.label}
+                                                >
+                                                    <Icon className="h-5 w-5" />
+                                                </Link>
+                                            </TooltipTrigger>
+                                            <TooltipContent side="right" className="border-primary/10 bg-white text-primary shadow-sm">
+                                                <p className="text-sm font-semibold leading-none">{item.label}</p>
+                                            </TooltipContent>
+                                        </Tooltip>
+                                    );
+                                })}
+                            </nav>
+                        </div>
+
+                        <Tooltip delayDuration={0}>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="ghost"
+                                    className="flex h-12 w-12 items-center justify-center rounded-2xl text-primary hover:bg-primary/10"
+                                    onClick={handleLogout}
+                                    disabled={isLoggingOut}
+                                    aria-label="Logout"
+                                >
+                                    {isLoggingOut ? "…" : <LogOut className="h-5 w-5" />}
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" className="border-primary/10 bg-white text-primary shadow-sm">
+                                <p className="text-sm font-semibold leading-none">Logout</p>
+                            </TooltipContent>
+                        </Tooltip>
                     </div>
-
-                    <Avatar className="h-12 w-12 border border-primary/15">
-                        <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                        <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
-                    </Avatar>
-
-                    <div className="flex-1 space-y-2 overflow-y-auto pb-4">
-                        <nav className="flex flex-col items-center gap-3">
-                            {navItems.map((item) => {
-                                const Icon = item.icon;
-                                const isActive = isActiveNav(item.href);
-
-                                return (
-                                    <Link
-                                        key={item.href}
-                                        href={item.href}
-                                        className={cn(
-                                            "flex h-12 w-12 items-center justify-center rounded-2xl text-primary transition",
-                                            "hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-                                            isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : ""
-                                        )}
-                                        aria-label={item.label}
-                                    >
-                                        <Icon className="h-5 w-5" />
-                                    </Link>
-                                );
-                            })}
-                        </nav>
-                    </div>
-
-                    <Button
-                        variant="ghost"
-                        className="flex h-12 w-12 items-center justify-center rounded-2xl text-primary hover:bg-primary/10"
-                        onClick={handleLogout}
-                        disabled={isLoggingOut}
-                        aria-label="Logout"
-                    >
-                        {isLoggingOut ? "…" : <LogOut className="h-5 w-5" />}
-                    </Button>
-                </div>
+                </TooltipProvider>
             </aside>
 
             <div className="flex min-h-screen flex-1 flex-col px-4 pb-8 pt-6 md:px-6 lg:px-10">

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -102,12 +102,16 @@ export function PanelLayout({
         }
     }
 
+    const isActiveNav = (href: string) => {
+        const matcher = isNavItemActive ?? ((itemHref: string, current: string) => current === itemHref);
+        return matcher(href, pathname);
+    };
+
     const navLinks = (
         <nav className="flex flex-col gap-1">
             {navItems.map((item) => {
                 const Icon = item.icon;
-                const activeMatcher = isNavItemActive ?? ((href: string, current: string) => current === href);
-                const isActive = activeMatcher(item.href, pathname);
+                const isActive = isActiveNav(item.href);
 
                 return (
                     <Link
@@ -122,7 +126,7 @@ export function PanelLayout({
                         onClick={() => setMobileOpen(false)}
                     >
                         <Icon className={cn("h-5 w-5", isActive ? "text-primary-foreground" : "text-primary")} />
-                        <span>{item.label}</span>
+                        <span className="whitespace-nowrap">{item.label}</span>
                     </Link>
                 );
             })}
@@ -131,80 +135,130 @@ export function PanelLayout({
 
     return (
         <div className="relative flex min-h-screen bg-white">
-            <aside className="group/aside sticky left-0 top-0 hidden h-screen w-16 flex-col border-r border-primary/10 bg-white py-6 transition-[width] duration-300 ease-in-out hover:w-64 lg:flex">
-                <div className="flex h-full flex-col">
-                    <div className="flex items-center gap-3 px-4 pb-6">
-                        <span className="relative inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/5">
-                            <Image
-                                src="/clinic-illustration.svg"
-                                alt="HNU Clinic Health Record & Appointment System emblem"
-                                width={44}
-                                height={44}
-                                className="h-9 w-9 object-contain"
-                            />
-                        </span>
-                        <div className="hidden flex-col leading-tight text-left transition-opacity duration-200 group-hover/aside:flex">
-                            <span className="text-sm font-semibold text-primary">HNU Clinic</span>
-                            <span className="text-xs font-medium text-primary/80">Health Record &amp; Appointment System</span>
-                        </div>
+            <aside className="group/aside sticky left-0 top-0 hidden h-screen w-16 flex-col items-center border-r border-primary/10 bg-white py-6 lg:flex">
+                <div className="relative flex h-full w-full flex-col items-center gap-6 px-3">
+                    <div className="flex h-12 w-12 items-center justify-center">
+                        <Image
+                            src="/clinic-illustration.svg"
+                            alt="HNU Clinic Health Record & Appointment System emblem"
+                            width={44}
+                            height={44}
+                            className="h-9 w-9 object-contain"
+                        />
                     </div>
 
-                    <div className="mb-6 flex items-center gap-3 px-4">
-                        <Avatar className="h-12 w-12 border border-primary/15">
-                            <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                            <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
-                        </Avatar>
-                        <div className="hidden min-w-0 flex-1 transition-opacity duration-200 group-hover/aside:block">
-                            <p className="truncate text-xs text-primary/80">Signed in as</p>
-                            <p className="truncate text-sm font-semibold text-primary">{fullName}</p>
-                        </div>
-                    </div>
+                    <Avatar className="h-12 w-12 border border-primary/15">
+                        <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                        <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                    </Avatar>
 
-                    <div className="flex-1 space-y-4 overflow-y-auto px-2 pb-4">
-                        <Separator className="hidden group-hover/aside:block" />
-                        <nav className="flex flex-col gap-1">
+                    <div className="flex-1 space-y-2 overflow-y-auto pb-4">
+                        <nav className="flex flex-col items-center gap-3">
                             {navItems.map((item) => {
                                 const Icon = item.icon;
-                                const activeMatcher = isNavItemActive ?? ((href: string, current: string) => current === href);
-                                const isActive = activeMatcher(item.href, pathname);
+                                const isActive = isActiveNav(item.href);
 
                                 return (
                                     <Link
                                         key={item.href}
                                         href={item.href}
                                         className={cn(
-                                            "group/nav flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold transition-colors",
-                                            "hover:bg-primary/10 hover:text-primary",
-                                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-                                            isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : "text-muted-foreground"
+                                            "flex h-12 w-12 items-center justify-center rounded-2xl text-primary transition",
+                                            "hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                                            isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : ""
                                         )}
-                                        onClick={() => setMobileOpen(false)}
+                                        aria-label={item.label}
                                     >
-                                        <Icon className={cn("h-5 w-5", isActive ? "text-primary-foreground" : "text-primary")} />
-                                        <span className="hidden whitespace-nowrap group-hover/aside:inline">{item.label}</span>
+                                        <Icon className="h-5 w-5" />
                                     </Link>
                                 );
                             })}
                         </nav>
                     </div>
 
-                    <div className="mt-auto space-y-4 px-2 pb-2">
-                        <Separator className="hidden group-hover/aside:block" />
-                        <Button
-                            variant="default"
-                            className="w-full gap-2 rounded-2xl bg-primary font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
-                            onClick={handleLogout}
-                            disabled={isLoggingOut}
-                        >
-                            {isLoggingOut ? (
-                                "Signing out..."
-                            ) : (
-                                <>
-                                    <LogOut className="h-4 w-4" />
-                                    <span className="hidden group-hover/aside:inline">Logout</span>
-                                </>
-                            )}
-                        </Button>
+                    <Button
+                        variant="ghost"
+                        className="flex h-12 w-12 items-center justify-center rounded-2xl text-primary hover:bg-primary/10"
+                        onClick={handleLogout}
+                        disabled={isLoggingOut}
+                        aria-label="Logout"
+                    >
+                        {isLoggingOut ? "…" : <LogOut className="h-5 w-5" />}
+                    </Button>
+
+                    <div className="pointer-events-none absolute left-full top-0 z-20 h-full w-64 -translate-x-3 opacity-0 transition-all duration-200 ease-out group-hover/aside:pointer-events-auto group-hover/aside:translate-x-0 group-hover/aside:opacity-100">
+                        <div className="flex h-full flex-col rounded-3xl border border-primary/10 bg-white px-4 py-6 shadow-xl">
+                            <div className="mb-6 flex items-center gap-3">
+                                <Image
+                                    src="/clinic-illustration.svg"
+                                    alt="HNU Clinic Health Record & Appointment System emblem"
+                                    width={44}
+                                    height={44}
+                                    className="h-9 w-9 object-contain"
+                                />
+                                <div className="flex min-w-0 flex-col leading-tight text-left">
+                                    <span className="truncate text-sm font-semibold text-primary">HNU Clinic</span>
+                                    <span className="truncate text-xs font-medium text-primary/80">Health Record &amp; Appointment System</span>
+                                </div>
+                            </div>
+
+                            <div className="mb-6 flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-3">
+                                <Avatar className="h-11 w-11 border border-primary/15">
+                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                                    <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                                </Avatar>
+                                <div className="min-w-0">
+                                    <p className="truncate text-xs text-primary/80">Signed in as</p>
+                                    <p className="truncate text-sm font-semibold text-primary">{fullName}</p>
+                                </div>
+                            </div>
+
+                            <div className="flex-1 space-y-4 overflow-y-auto pb-4">
+                                <Separator />
+                                <nav className="flex flex-col gap-1">
+                                    {navItems.map((item) => {
+                                        const Icon = item.icon;
+                                        const isActive = isActiveNav(item.href);
+
+                                        return (
+                                            <Link
+                                                key={item.href}
+                                                href={item.href}
+                                                className={cn(
+                                                    "group/nav flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold transition-colors",
+                                                    "hover:bg-primary/10 hover:text-primary",
+                                                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                                                    isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : "text-muted-foreground"
+                                                )}
+                                                onClick={() => setMobileOpen(false)}
+                                            >
+                                                <Icon className={cn("h-5 w-5", isActive ? "text-primary-foreground" : "text-primary")} />
+                                                <span className="whitespace-nowrap">{item.label}</span>
+                                            </Link>
+                                        );
+                                    })}
+                                </nav>
+                            </div>
+
+                            <div className="mt-auto space-y-4">
+                                <Separator />
+                                <Button
+                                    variant="default"
+                                    className="w-full gap-2 rounded-2xl bg-primary font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+                                    onClick={handleLogout}
+                                    disabled={isLoggingOut}
+                                >
+                                    {isLoggingOut ? (
+                                        "Signing out..."
+                                    ) : (
+                                        <>
+                                            <LogOut className="h-4 w-4" />
+                                            Logout
+                                        </>
+                                    )}
+                                </Button>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </aside>

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -163,6 +163,7 @@ export function PanelLayout({
                             </TooltipTrigger>
                             <TooltipContent
                                 side="right"
+                                hideArrow
                                 className="flex items-center gap-3 border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
                             >
                                 <Avatar className="h-8 w-8 border border-primary/10 bg-primary/5">
@@ -199,6 +200,7 @@ export function PanelLayout({
                                             </TooltipTrigger>
                                             <TooltipContent
                                                 side="right"
+                                                hideArrow
                                                 className="rounded-xl border border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
                                             >
                                                 <p className="text-sm font-semibold leading-none">{item.label}</p>
@@ -223,6 +225,7 @@ export function PanelLayout({
                             </TooltipTrigger>
                             <TooltipContent
                                 side="right"
+                                hideArrow
                                 className="rounded-xl border border-primary/10 bg-white px-3 py-2 text-primary shadow-lg"
                             >
                                 <p className="text-sm font-semibold leading-none">Logout</p>

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -135,7 +135,7 @@ export function PanelLayout({
 
     return (
         <div className="relative flex min-h-screen bg-white">
-            <aside className="group/aside sticky left-0 top-0 hidden h-screen w-16 flex-col items-center border-r border-primary/10 bg-white py-6 lg:flex">
+            <aside className="sticky left-0 top-0 hidden h-screen w-16 flex-col items-center border-r border-primary/10 bg-white py-6 lg:flex">
                 <div className="relative flex h-full w-full flex-col items-center gap-6 px-3">
                     <div className="flex h-12 w-12 items-center justify-center">
                         <Image
@@ -185,81 +185,6 @@ export function PanelLayout({
                     >
                         {isLoggingOut ? "…" : <LogOut className="h-5 w-5" />}
                     </Button>
-
-                    <div className="pointer-events-none absolute left-full top-0 z-20 h-full w-64 -translate-x-3 opacity-0 transition-all duration-200 ease-out group-hover/aside:pointer-events-auto group-hover/aside:translate-x-0 group-hover/aside:opacity-100">
-                        <div className="flex h-full flex-col rounded-3xl border border-primary/10 bg-white px-4 py-6 shadow-xl">
-                            <div className="mb-6 flex items-center gap-3">
-                                <Image
-                                    src="/clinic-illustration.svg"
-                                    alt="HNU Clinic Health Record & Appointment System emblem"
-                                    width={44}
-                                    height={44}
-                                    className="h-9 w-9 object-contain"
-                                />
-                                <div className="flex min-w-0 flex-col leading-tight text-left">
-                                    <span className="truncate text-sm font-semibold text-primary">HNU Clinic</span>
-                                    <span className="truncate text-xs font-medium text-primary/80">Health Record &amp; Appointment System</span>
-                                </div>
-                            </div>
-
-                            <div className="mb-6 flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-3">
-                                <Avatar className="h-11 w-11 border border-primary/15">
-                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                                    <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
-                                </Avatar>
-                                <div className="min-w-0">
-                                    <p className="truncate text-xs text-primary/80">Signed in as</p>
-                                    <p className="truncate text-sm font-semibold text-primary">{fullName}</p>
-                                </div>
-                            </div>
-
-                            <div className="flex-1 space-y-4 overflow-y-auto pb-4">
-                                <Separator />
-                                <nav className="flex flex-col gap-1">
-                                    {navItems.map((item) => {
-                                        const Icon = item.icon;
-                                        const isActive = isActiveNav(item.href);
-
-                                        return (
-                                            <Link
-                                                key={item.href}
-                                                href={item.href}
-                                                className={cn(
-                                                    "group/nav flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold transition-colors",
-                                                    "hover:bg-primary/10 hover:text-primary",
-                                                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-                                                    isActive ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20" : "text-muted-foreground"
-                                                )}
-                                                onClick={() => setMobileOpen(false)}
-                                            >
-                                                <Icon className={cn("h-5 w-5", isActive ? "text-primary-foreground" : "text-primary")} />
-                                                <span className="whitespace-nowrap">{item.label}</span>
-                                            </Link>
-                                        );
-                                    })}
-                                </nav>
-                            </div>
-
-                            <div className="mt-auto space-y-4">
-                                <Separator />
-                                <Button
-                                    variant="default"
-                                    className="w-full gap-2 rounded-2xl bg-primary font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
-                                    onClick={handleLogout}
-                                    disabled={isLoggingOut}
-                                >
-                                    {isLoggingOut ? (
-                                        "Signing out..."
-                                    ) : (
-                                        <>
-                                            <LogOut className="h-4 w-4" />
-                                            Logout
-                                        </>
-                                    )}
-                                </Button>
-                            </div>
-                        </div>
-                    </div>
                 </div>
             </aside>
 

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -148,6 +148,7 @@ export function PanelLayout({
                             <span className="text-xs font-medium text-primary/80">Health Record &amp; Appointment System</span>
                         </div>
                     </div>
+
                     <div className="mb-6 flex items-center gap-3 px-4">
                         <Avatar className="h-12 w-12 border border-primary/15">
                             <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
@@ -158,6 +159,7 @@ export function PanelLayout({
                             <p className="truncate text-sm font-semibold text-primary">{fullName}</p>
                         </div>
                     </div>
+
                     <div className="flex-1 space-y-4 overflow-y-auto px-2 pb-4">
                         <Separator className="hidden group-hover/aside:block" />
                         <nav className="flex flex-col gap-1">
@@ -185,6 +187,7 @@ export function PanelLayout({
                             })}
                         </nav>
                     </div>
+
                     <div className="mt-auto space-y-4 px-2 pb-2">
                         <Separator className="hidden group-hover/aside:block" />
                         <Button
@@ -211,73 +214,75 @@ export function PanelLayout({
                     <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                         <div className="space-y-3">
                             <p className="text-xs font-semibold uppercase tracking-wider text-primary/80">{panelLabel}</p>
-                                <h2 className="text-2xl font-semibold text-primary md:text-3xl">{title}</h2>
-                                {description ? (
-                                    <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
-                                ) : null}
-                            </div>
-                            <div className="flex items-center gap-3 self-start md:self-auto">
-                                {actions}
-                                <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-                                    <SheetTrigger asChild>
-                                        <Button
-                                            variant="outline"
-                                            size="icon"
-                                            className="rounded-xl border-primary/20 text-primary hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
-                                            aria-label={sheetAriaLabel}
-                                        >
-                                            <Menu className="h-5 w-5" />
-                                        </Button>
-                                    </SheetTrigger>
-                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-primary/15 bg-white p-0">
-                                        <SheetHeader className="border-b border-primary/15 bg-white/80 p-6">
-                                            <SheetTitle className="flex items-center gap-3 text-lg text-primary">
-                                                <Menu className="h-5 w-5" />
-                                                {sheetTitle}
-                                            </SheetTitle>
-                                        </SheetHeader>
-                                        <div className="flex h-full flex-col gap-6 overflow-y-auto px-6 py-6">
-                                            <div className="flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-4">
-                                                <Avatar className="h-11 w-11 border border-primary/15">
-                                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                                                    <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
-                                                </Avatar>
-                                                <div>
-                                                    <p className="text-xs text-primary/80">Signed in as</p>
-                                                    <p className="text-sm font-semibold text-primary">{fullName}</p>
-                                                </div>
-                                            </div>
-                                            {navLinks}
-                                            <Button
-                                                variant="default"
-                                                className="w-full gap-2 rounded-xl bg-primary font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
-                                                onClick={handleLogout}
-                                                disabled={isLoggingOut}
-                                            >
-                                                {isLoggingOut ? (
-                                                    "Signing out..."
-                                                ) : (
-                                                    <>
-                                                        <LogOut className="h-4 w-4" />
-                                                        Logout
-                                                    </>
-                                                )}
-                                            </Button>
-                                        </div>
-                                    </SheetContent>
-                                </Sheet>
-                            </div>
+                            <h2 className="text-2xl font-semibold text-primary md:text-3xl">{title}</h2>
+                            {description ? <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
                         </div>
-                    </header>
 
-                    <main className="flex-1 space-y-6">{children}</main>
+                        <div className="flex items-center gap-3 self-start md:self-auto">
+                            {actions}
+                            <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+                                <SheetTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        size="icon"
+                                        className="rounded-xl border-primary/20 text-primary hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                        aria-label={sheetAriaLabel}
+                                    >
+                                        <Menu className="h-5 w-5" />
+                                    </Button>
+                                </SheetTrigger>
+                                <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-primary/15 bg-white p-0">
+                                    <SheetHeader className="border-b border-primary/15 bg-white/80 p-6">
+                                        <SheetTitle className="flex items-center gap-3 text-lg text-primary">
+                                            <Menu className="h-5 w-5" />
+                                            {sheetTitle}
+                                        </SheetTitle>
+                                    </SheetHeader>
+                                    <div className="flex h-full flex-col gap-6 overflow-y-auto px-6 py-6">
+                                        <div className="flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                            <Avatar className="h-11 w-11 border border-primary/15">
+                                                <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                                                <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                                            </Avatar>
+                                            <div>
+                                                <p className="text-xs text-primary/80">Signed in as</p>
+                                                <p className="text-sm font-semibold text-primary">{fullName}</p>
+                                            </div>
+                                        </div>
 
-                    <footer className="mt-10 rounded-3xl border border-primary/15 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
-                        {footerNote ?? <>
+                                        {navLinks}
+
+                                        <Button
+                                            variant="default"
+                                            className="w-full gap-2 rounded-xl bg-primary font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+                                            onClick={handleLogout}
+                                            disabled={isLoggingOut}
+                                        >
+                                            {isLoggingOut ? (
+                                                "Signing out..."
+                                            ) : (
+                                                <>
+                                                    <LogOut className="h-4 w-4" />
+                                                    Logout
+                                                </>
+                                            )}
+                                        </Button>
+                                    </div>
+                                </SheetContent>
+                            </Sheet>
+                        </div>
+                    </div>
+                </header>
+
+                <main className="flex-1 space-y-6">{children}</main>
+
+                <footer className="mt-10 rounded-3xl border border-primary/15 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
+                    {footerNote ?? (
+                        <>
                             © {new Date().getFullYear()} HNU Clinic Health Record &amp; Appointment System – {panelLabel}
-                        </>}
-                    </footer>
-                </div>
+                        </>
+                    )}
+                </footer>
             </div>
         </div>
     );

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -34,12 +34,19 @@ function TooltipTrigger({
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
+type TooltipContentProps = React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  hideArrow?: boolean
+  arrowClassName?: string
+}
+
 function TooltipContent({
   className,
   sideOffset = 0,
+  hideArrow = false,
+  arrowClassName,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: TooltipContentProps) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -52,7 +59,14 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]" />
+        {!hideArrow ? (
+          <TooltipPrimitive.Arrow
+            className={cn(
+              "z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground",
+              arrowClassName
+            )}
+          />
+        ) : null}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
## Summary
- redesign the panel sidebar into a left-aligned collapsed rail that expands on hover with icon-first navigation
- simplify layout backgrounds to a clean white surface across loading, headers, and sheets
- refresh mobile navigation link styling to match the updated sidebar look

## Testing
- npm run lint *(fails: ESLint config error: TypeError: Converting circular structure to JSON)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932428f917c8327afb588f6befc5485)