### PR TITLE
Improve dashboard responsiveness for role pages

### DIFF
--- a/src/app/doctor/page.tsx
+++ b/src/app/doctor/page.tsx
@@ -98,7 +98,7 @@ export default function DoctorDashboardPage() {
                 }}
             />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-5 lg:grid-cols-2 xl:grid-cols-[1.4fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">Operational checklist</CardTitle>

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -765,7 +765,10 @@ export function NurseAccountsPageClient({
                 {/* My Account */}
                 {profile ? (
                     <div className="space-y-8">
-                        <AccountSummaryGrid items={summaryItems} />
+                        <AccountSummaryGrid
+                            items={summaryItems}
+                            className="grid-cols-1 sm:grid-cols-2 xl:grid-cols-3"
+                        />
                         <AccountCard
                             title="My Account"
                             description="Review and update your clinic profile details, emergency contacts, and credentials."

--- a/src/app/nurse/page.tsx
+++ b/src/app/nurse/page.tsx
@@ -74,7 +74,7 @@ export default function NurseDashboardPage() {
                 }}
             />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-5 lg:grid-cols-2 xl:grid-cols-[1.4fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">How to keep clinic flow steady</CardTitle>

--- a/src/app/patient/page.tsx
+++ b/src/app/patient/page.tsx
@@ -79,7 +79,7 @@ export default function PatientDashboardPage() {
                 }}
             />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-5 lg:grid-cols-2 xl:grid-cols-[1.4fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">How to prepare for your next appointment</CardTitle>

--- a/src/app/scholar/page.tsx
+++ b/src/app/scholar/page.tsx
@@ -97,7 +97,7 @@ export default function ScholarDashboardPage() {
                 </div>
             </section>
 
-            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+            <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 xl:auto-rows-fr">
                 {workflowHighlights.map(({ title, description, href, icon: Icon, cta }) => (
                     <Card
                         key={title}
@@ -145,7 +145,7 @@ export default function ScholarDashboardPage() {
                 </Card>
             </section>
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-5 lg:grid-cols-2 xl:grid-cols-[1.4fr_1fr]">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">Checklist for smooth clinic flow</CardTitle>

--- a/src/components/dashboard/quick-actions-grid.tsx
+++ b/src/components/dashboard/quick-actions-grid.tsx
@@ -30,7 +30,12 @@ export function QuickActionsGrid({ actions, highlight, className }: QuickActions
     const { title, icon: HighlightIcon, description: highlightDescription, className: highlightClassName } = highlight;
 
     return (
-        <section className={cn("grid gap-5 md:grid-cols-2 xl:grid-cols-3", className)}>
+        <section
+            className={cn(
+                "grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 xl:auto-rows-fr",
+                className
+            )}
+        >
             {actions.map(({ title: actionTitle, description, href, icon: Icon, cta }) => (
                 <Card
                     key={actionTitle}


### PR DESCRIPTION
## Summary
- adjust shared quick actions grid to use consistent responsive columns and row heights
- align nurse, doctor, patient, and scholar dashboard sections to a unified two-column responsive layout
- ensure grid content stretches evenly to avoid overlap on narrow screens

## Testing
- Not run (npm is unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69327eca963083279a14201488e61487)