### PR TITLE
Refine dashboard layouts for consistent responsiveness

### DIFF
--- a/src/app/doctor/page.tsx
+++ b/src/app/doctor/page.tsx
@@ -98,7 +98,7 @@ export default function DoctorDashboardPage() {
                 }}
             />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-6 xl:grid-cols-2">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">Operational checklist</CardTitle>

--- a/src/app/nurse/page.tsx
+++ b/src/app/nurse/page.tsx
@@ -44,6 +44,25 @@ const quickActions = [
     },
 ];
 
+const coordinationSteps = [
+    "Review pending appointments each morning and pre-stage charts and equipment for the care team.",
+    "Document every dispensing and inventory update as it happens to keep audit logs accurate.",
+    "Share schedule changes with doctors early so they can adjust consultations and follow-ups.",
+];
+
+const documentationLinks = [
+    {
+        label: "Open dispensing log",
+        href: "/nurse/dispense",
+        description: "Capture dispensing actions in real time to maintain an accurate ledger.",
+    },
+    {
+        label: "View clinic schedule",
+        href: "/nurse/clinic",
+        description: "Prepare rooms and resources ahead of busy clinic blocks.",
+    },
+];
+
 export default function NurseDashboardPage() {
     const { firstName } = useDashboardUser("Nurse");
 
@@ -74,24 +93,39 @@ export default function NurseDashboardPage() {
                 }}
             />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-6 xl:grid-cols-2">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">How to keep clinic flow steady</CardTitle>
                     </CardHeader>
+                    <CardContent className="space-y-4 text-sm text-muted-foreground">
+                        <ul className="space-y-3">
+                            {coordinationSteps.map((step) => (
+                                <li key={step} className="flex items-start gap-3 rounded-2xl bg-primary/5 p-3">
+                                    <span className="mt-1 h-2.5 w-2.5 rounded-full bg-primary" />
+                                    <span>{step}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </CardContent>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
+                    <CardHeader>
+                        <CardTitle className="text-lg text-primary">Documentation shortcuts</CardTitle>
+                    </CardHeader>
                     <CardContent className="space-y-3 text-sm text-muted-foreground">
-                        <p>
-                            Review pending appointments each morning and pre-stage the necessary charts and equipment so care teams can begin on time.
-                        </p>
-                        <p>
-                            Document every dispensing and inventory update as it happens. Accurate logs keep compliance effortless during audits.
-                        </p>
-                        <Button asChild variant="outline" className="w-full rounded-xl border-primary/30 text-primary hover:bg-primary/10">
-                            <Link href="/nurse/dispense">Open dispensing log</Link>
-                        </Button>
-                        <Button asChild variant="ghost" className="w-full rounded-xl bg-primary/10 text-primary hover:bg-primary/20">
-                            <Link href="/nurse/clinic">View clinic schedule</Link>
-                        </Button>
+                        {documentationLinks.map(({ label, href, description }) => (
+                            <div key={label} className="space-y-2 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                <div className="flex items-center justify-between gap-3">
+                                    <p className="font-semibold text-primary">{label}</p>
+                                    <Button asChild variant="link" className="h-auto p-0 text-sm font-semibold text-primary">
+                                        <Link href={href}>Open</Link>
+                                    </Button>
+                                </div>
+                                <p>{description}</p>
+                            </div>
+                        ))}
                     </CardContent>
                 </Card>
             </section>

--- a/src/app/patient/page.tsx
+++ b/src/app/patient/page.tsx
@@ -79,7 +79,7 @@ export default function PatientDashboardPage() {
                 }}
             />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-6 xl:grid-cols-2">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">How to prepare for your next appointment</CardTitle>

--- a/src/app/scholar/page.tsx
+++ b/src/app/scholar/page.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
 import Link from "next/link";
-import { useSession } from "next-auth/react";
-import {
-    CalendarDays,
-    ClipboardList,
-    FileSpreadsheet,
-    NotebookPen,
-    Users2,
-} from "lucide-react";
+import { CalendarDays, ClipboardList, FileSpreadsheet, NotebookPen, Users2 } from "lucide-react";
 
+import { DashboardWelcome } from "@/components/dashboard/dashboard-welcome";
+import { QuickActionsGrid } from "@/components/dashboard/quick-actions-grid";
 import ScholarLayout from "@/components/scholar/scholar-layout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDashboardUser } from "@/hooks/use-dashboard-user";
 
 const workflowHighlights = [
     {
@@ -40,7 +35,7 @@ const workflowHighlights = [
         icon: ClipboardList,
         cta: "Manage account",
     },
-] as const;
+];
 
 const supportChecklist = [
     "Confirm the day’s appointment roster at least one hour before clinic opening.",
@@ -51,7 +46,7 @@ const supportChecklist = [
 const documentationTips = [
     {
         label: "Schedule walk-ins",
-        description: "Document walk-in for visibility across the clinic.",
+        description: "Document walk-ins for visibility across the clinic team.",
         href: "/scholar/appointments",
     },
     {
@@ -64,12 +59,15 @@ const documentationTips = [
         description: "Review your profile and confirm that emergency contacts are current.",
         href: "/scholar/account",
     },
-] as const;
+];
+
+const coordinationHighlights = [
+    "Share status updates in the clinic chat when appointment queues change so the medical team can adapt their rounds.",
+    "Keep intake forms organized before handoff—complete profiles help nurses and doctors focus on care instead of paperwork.",
+];
 
 export default function ScholarDashboardPage() {
-    const { data: session } = useSession();
-    const fullName = session?.user?.name ?? "Working Scholar";
-    const firstName = useMemo(() => fullName.split(" ")[0] || fullName, [fullName]);
+    const { firstName } = useDashboardUser("Working Scholar");
 
     return (
         <ScholarLayout
@@ -84,81 +82,35 @@ export default function ScholarDashboardPage() {
                 </Button>
             }
         >
-            <section className="rounded-3xl border border-primary/20 bg-linear-to-r from-primary/10 via-white to-primary/5 p-6 shadow-sm">
-                <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-                    <div className="space-y-3">
-                        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary/80">Welcome back</p>
-                        <h3 className="text-3xl font-semibold text-primary md:text-4xl">Good day, Scholar {firstName}</h3>
-                        <p className="max-w-2xl text-sm text-muted-foreground">
-                            Keep the clinic desk synchronized—double-check booking requests, guide students through intake, and
-                            flag any priority concerns early so the team can respond quickly.
-                        </p>
-                    </div>
-                </div>
-            </section>
+            <DashboardWelcome
+                heading={`Good day, Scholar ${firstName}`}
+                description="Keep the clinic desk synchronized—double-check booking requests, guide students through intake, and flag priority concerns early so the team can respond quickly."
+            />
 
-            <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-                {workflowHighlights.map(({ title, description, href, icon: Icon, cta }) => (
-                    <Card
-                        key={title}
-                        className="h-full rounded-3xl border-primary/20 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
-                    >
-                        <CardHeader className="flex flex-row items-start justify-between gap-3">
-                            <div className="space-y-1">
-                                <CardTitle className="flex items-center gap-3 text-lg text-primary">
-                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                        <Icon className="h-5 w-5" />
-                                    </span>
-                                    {title}
-                                </CardTitle>
-                                <p className="text-sm font-normal text-muted-foreground">{description}</p>
-                            </div>
-                        </CardHeader>
-                        <CardContent>
-                            <Button
-                                asChild
-                                variant="ghost"
-                                className="rounded-xl bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20"
-                            >
-                                <Link href={href}>{cta}</Link>
-                            </Button>
-                        </CardContent>
-                    </Card>
-                ))}
-                <Card className="h-full rounded-3xl border-primary/20 bg-linear-to-br from-primary via-emerald-500 to-emerald-400 text-primary-foreground shadow-md">
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-3 text-lg">
-                            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/15">
-                                <NotebookPen className="h-5 w-5" />
-                            </span>
-                            Coordination insights
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3 text-sm leading-relaxed text-white/90">
-                        <p>
-                            Share status updates in the clinic chat when appointment queues change so the medical team can adapt their rounds.
-                        </p>
-                        <p>
-                            Keep intake forms organized before handoff—complete profiles help nurses and doctors focus on care instead of paperwork.
-                        </p>
-                    </CardContent>
-                </Card>
-            </section>
+            <QuickActionsGrid
+                actions={workflowHighlights}
+                highlight={{
+                    title: "Coordination insights",
+                    icon: NotebookPen,
+                    description: coordinationHighlights,
+                }}
+            />
 
-            <section className="grid gap-5 lg:grid-cols-[1.5fr_1fr]">
+            <section className="grid gap-6 xl:grid-cols-2">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">Checklist for smooth clinic flow</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3 text-sm text-muted-foreground">
                         {supportChecklist.map((item) => (
-                            <div key={item} className="flex gap-3">
+                            <div key={item} className="flex gap-3 rounded-2xl bg-primary/5 p-3">
                                 <FileSpreadsheet className="mt-1 h-4 w-4 text-primary" />
                                 <p>{item}</p>
                             </div>
                         ))}
                     </CardContent>
                 </Card>
+
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
                     <CardHeader>
                         <CardTitle className="text-lg text-primary">Documentation shortcuts</CardTitle>

--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -235,80 +235,82 @@ export function PanelLayout({
                 </TooltipProvider>
             </aside>
 
-            <div className="flex min-h-screen flex-1 flex-col px-4 pb-8 pt-6 md:px-6 lg:px-10">
-                <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-primary/15 bg-white px-4 py-4 shadow-sm md:px-6">
-                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                        <div className="space-y-3">
-                            <p className="text-xs font-semibold uppercase tracking-wider text-primary/80">{panelLabel}</p>
-                            <h2 className="text-2xl font-semibold text-primary md:text-3xl">{title}</h2>
-                            {description ? <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
-                        </div>
+            <div className="flex min-h-screen flex-1 justify-center bg-white">
+                <div className="flex w-full max-w-6xl flex-col px-4 pb-10 pt-6 md:px-6 lg:px-10">
+                    <header className="sticky top-0 z-30 mb-6 rounded-3xl border border-primary/15 bg-white px-4 py-4 shadow-sm backdrop-blur md:px-6">
+                        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                            <div className="space-y-3">
+                                <p className="text-xs font-semibold uppercase tracking-wider text-primary/80">{panelLabel}</p>
+                                <h2 className="text-2xl font-semibold text-primary md:text-3xl">{title}</h2>
+                                {description ? <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
+                            </div>
 
-                        <div className="flex items-center gap-3 self-start md:self-auto">
-                            {actions}
-                            <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-                                <SheetTrigger asChild>
-                                    <Button
-                                        variant="outline"
-                                        size="icon"
-                                        className="rounded-xl border-primary/20 text-primary hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
-                                        aria-label={sheetAriaLabel}
-                                    >
-                                        <Menu className="h-5 w-5" />
-                                    </Button>
-                                </SheetTrigger>
-                                <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-primary/15 bg-white p-0">
-                                    <SheetHeader className="border-b border-primary/15 bg-white/80 p-6">
-                                        <SheetTitle className="flex items-center gap-3 text-lg text-primary">
-                                            <Menu className="h-5 w-5" />
-                                            {sheetTitle}
-                                        </SheetTitle>
-                                    </SheetHeader>
-                                    <div className="flex h-full flex-col gap-6 overflow-y-auto px-6 py-6">
-                                        <div className="flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-4">
-                                            <Avatar className="h-11 w-11 border border-primary/15">
-                                                <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
-                                                <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
-                                            </Avatar>
-                                            <div>
-                                                <p className="text-xs text-primary/80">Signed in as</p>
-                                                <p className="text-sm font-semibold text-primary">{fullName}</p>
-                                            </div>
-                                        </div>
-
-                                        {navLinks}
-
+                            <div className="flex items-center gap-3 self-start md:self-auto">
+                                {actions}
+                                <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+                                    <SheetTrigger asChild>
                                         <Button
-                                            variant="default"
-                                            className="w-full gap-2 rounded-xl bg-primary font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
-                                            onClick={handleLogout}
-                                            disabled={isLoggingOut}
+                                            variant="outline"
+                                            size="icon"
+                                            className="rounded-xl border-primary/20 text-primary hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white lg:hidden"
+                                            aria-label={sheetAriaLabel}
                                         >
-                                            {isLoggingOut ? (
-                                                "Signing out..."
-                                            ) : (
-                                                <>
-                                                    <LogOut className="h-4 w-4" />
-                                                    Logout
-                                                </>
-                                            )}
+                                            <Menu className="h-5 w-5" />
                                         </Button>
-                                    </div>
-                                </SheetContent>
-                            </Sheet>
+                                    </SheetTrigger>
+                                    <SheetContent side="right" className="w-80 max-w-[85vw] border-l border-primary/15 bg-white p-0">
+                                        <SheetHeader className="border-b border-primary/15 bg-white/80 p-6">
+                                            <SheetTitle className="flex items-center gap-3 text-lg text-primary">
+                                                <Menu className="h-5 w-5" />
+                                                {sheetTitle}
+                                            </SheetTitle>
+                                        </SheetHeader>
+                                        <div className="flex h-full flex-col gap-6 overflow-y-auto px-6 py-6">
+                                            <div className="flex items-center gap-3 rounded-2xl border border-primary/15 bg-primary/5 p-4">
+                                                <Avatar className="h-11 w-11 border border-primary/15">
+                                                    <AvatarImage src={session?.user?.image ?? undefined} alt={fullName} />
+                                                    <AvatarFallback className="bg-primary/15 text-primary">{avatarFallback}</AvatarFallback>
+                                                </Avatar>
+                                                <div>
+                                                    <p className="text-xs text-primary/80">Signed in as</p>
+                                                    <p className="text-sm font-semibold text-primary">{fullName}</p>
+                                                </div>
+                                            </div>
+
+                                            {navLinks}
+
+                                            <Button
+                                                variant="default"
+                                                className="w-full gap-2 rounded-xl bg-primary font-semibold text-primary-foreground shadow-sm hover:bg-primary/90"
+                                                onClick={handleLogout}
+                                                disabled={isLoggingOut}
+                                            >
+                                                {isLoggingOut ? (
+                                                    "Signing out..."
+                                                ) : (
+                                                    <>
+                                                        <LogOut className="h-4 w-4" />
+                                                        Logout
+                                                    </>
+                                                )}
+                                            </Button>
+                                        </div>
+                                    </SheetContent>
+                                </Sheet>
+                            </div>
                         </div>
-                    </div>
-                </header>
+                    </header>
 
-                <main className="flex-1 space-y-6">{children}</main>
+                    <main className="flex-1 space-y-6">{children}</main>
 
-                <footer className="mt-10 rounded-3xl border border-primary/15 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
-                    {footerNote ?? (
-                        <>
-                            © {new Date().getFullYear()} HNU Clinic Health Record &amp; Appointment System – {panelLabel}
-                        </>
-                    )}
-                </footer>
+                    <footer className="mt-10 rounded-3xl border border-primary/15 bg-white/80 px-6 py-4 text-center text-sm text-muted-foreground shadow-sm backdrop-blur">
+                        {footerNote ?? (
+                            <>
+                                © {new Date().getFullYear()} HNU Clinic Health Record &amp; Appointment System – {panelLabel}
+                            </>
+                        )}
+                    </footer>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- Center panel content within a max-width container while keeping the left sidebar
- Align nurse, doctor, scholar, and patient dashboards to share the same responsive grid patterns
- Update scholar dashboard to use the shared welcome and quick actions components for consistency

## Testing
- npm run lint *(fails: npm command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328ab018548327b22e59924bccc9ea)