### PR TITLE
Add global theme provider and toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,6 +43,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html
       lang="en"
       data-scroll-behavior="smooth"
+      suppressHydrationWarning
       className={`${poppins.variable} ${inter.variable}`}
     >
       <body className="antialiased min-h-screen flex flex-col font-sans">

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,9 @@ import { useRouter } from "next/navigation";
 import { SessionProvider, useSession, signOut } from "next-auth/react";
 import { Toaster, toast } from "sonner";
 
+import { ThemeProvider } from "@/components/theme-provider";
+import { ThemeToggle } from "@/components/theme-toggle";
+
 /**
  * Monitors the session and signs out users whose accounts become inactive.
  */
@@ -65,10 +68,13 @@ export default function Providers({ children }: { children: ReactNode }) {
     }, []);
 
     return (
-        <SessionProvider>
-            {children}
-            <Toaster richColors position="top-center" />
-            <SessionWatcher /> {/* runs globally */}
-        </SessionProvider>
+        <ThemeProvider>
+            <SessionProvider>
+                {children}
+                <ThemeToggle className="fixed bottom-6 right-6 z-50" />
+                <Toaster richColors position="top-center" />
+                <SessionWatcher /> {/* runs globally */}
+            </SessionProvider>
+        </ThemeProvider>
     );
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ReactNode } from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+/**
+ * Provides a single theme controller for light and dark modes across the app.
+ */
+export function ThemeProvider({ children }: { children: ReactNode }) {
+    return (
+        <NextThemesProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+            {children}
+        </NextThemesProvider>
+    );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Laptop, MoonStar, SunMedium } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const themes = [
+    { label: "Light", value: "light", icon: SunMedium },
+    { label: "Dark", value: "dark", icon: MoonStar },
+    { label: "System", value: "system", icon: Laptop },
+] as const;
+
+/**
+ * A compact, reusable toggle for switching themes across the site.
+ */
+export function ThemeToggle({ className }: { className?: string }) {
+    const { setTheme, resolvedTheme, theme } = useTheme();
+    const [mounted, setMounted] = useState(false);
+
+    useEffect(() => setMounted(true), []);
+
+    const activeTheme = theme === "system" ? resolvedTheme : theme;
+
+    return (
+        <div
+            className={cn(
+                "flex items-center gap-1 rounded-full border bg-card/80 p-1 text-xs shadow-lg backdrop-blur", 
+                "supports-[backdrop-filter]:backdrop-blur", 
+                className,
+            )}
+            aria-label="Switch theme"
+        >
+            {themes.map(({ label, value, icon: Icon }) => {
+                const isActive = mounted ? activeTheme === value || theme === value : value === "system";
+
+                return (
+                    <Button
+                        key={value}
+                        variant={isActive ? "secondary" : "ghost"}
+                        size="sm"
+                        className={cn(
+                            "flex items-center gap-2 rounded-full px-3 transition", 
+                            !isActive && "text-muted-foreground hover:text-foreground",
+                        )}
+                        onClick={() => setTheme(value)}
+                        aria-pressed={isActive}
+                    >
+                        <Icon className="h-4 w-4" />
+                        <span className="hidden sm:inline">{label}</span>
+                    </Button>
+                );
+            })}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared ThemeProvider using next-themes so light and dark modes are applied consistently across the app
- introduce a reusable ThemeToggle control and surface it globally for every page
- suppress hydration warnings on the root layout for seamless theme class updates

## Testing
- `npm run lint` *(fails: npm is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932a58480d083279520c800c1217045)