### PR TITLE
Enforce non-negative stock inputs for nurse inventory

### DIFF
--- a/src/app/api/nurse/inventory/route.ts
+++ b/src/app/api/nurse/inventory/route.ts
@@ -216,6 +216,10 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "Quantity must be greater than 0" }, { status: 400 });
         }
 
+        if (strength !== undefined && Number(strength) < 0) {
+            return NextResponse.json({ error: "Strength cannot be negative" }, { status: 400 });
+        }
+
         const expiryDate = new Date(expiry);
         if (isNaN(expiryDate.getTime()) || expiryDate < new Date()) {
             return NextResponse.json({ error: "Expiry date must be valid and in the future" }, { status: 400 });

--- a/src/app/nurse/inventory/page.tsx
+++ b/src/app/nurse/inventory/page.tsx
@@ -321,14 +321,33 @@ export default function NurseInventoryPage() {
                                                 const form = e.currentTarget as HTMLFormElement;
                                                 setSavingStock(true);
 
+                                                const quantity = Number(
+                                                    (form.elements.namedItem("quantity") as HTMLInputElement).value
+                                                );
+                                                const strengthRaw = (form.elements.namedItem("strength") as HTMLInputElement)
+                                                    .value;
+                                                const strength = strengthRaw === "" ? undefined : parseFloat(strengthRaw);
+
+                                                if (!Number.isFinite(quantity) || quantity < 1) {
+                                                    toast.error("Quantity must be at least 1");
+                                                    setSavingStock(false);
+                                                    return;
+                                                }
+
+                                                if (strength !== undefined && (!Number.isFinite(strength) || strength < 0)) {
+                                                    toast.error("Strength cannot be negative");
+                                                    setSavingStock(false);
+                                                    return;
+                                                }
+
                                                 const body = {
                                                     clinic_id: (form.elements.namedItem("clinic_id") as HTMLSelectElement).value,
                                                     item_name: (form.elements.namedItem("item_name") as HTMLInputElement).value,
-                                                    quantity: Number((form.elements.namedItem("quantity") as HTMLInputElement).value),
+                                                    quantity,
                                                     expiry: (form.elements.namedItem("expiry") as HTMLInputElement).value,
                                                     category: (form.elements.namedItem("category") as HTMLSelectElement).value,
                                                     item_type: (form.elements.namedItem("item_type") as HTMLSelectElement).value,
-                                                    strength: parseFloat((form.elements.namedItem("strength") as HTMLInputElement).value),
+                                                    strength,
                                                     unit: (form.elements.namedItem("unit") as HTMLSelectElement).value,
                                                 };
 
@@ -381,6 +400,7 @@ export default function NurseInventoryPage() {
                                                         type="number"
                                                         name="quantity"
                                                         required
+                                                        min={1}
                                                         className="h-10 rounded-xl border border-primary/20 bg-white text-sm focus-visible:ring-primary"
                                                     />
                                                 </div>
@@ -434,6 +454,7 @@ export default function NurseInventoryPage() {
                                                         step="0.01"
                                                         name="strength"
                                                         placeholder="e.g., 500"
+                                                        min={0}
                                                         className="h-10 rounded-xl border border-primary/20 bg-white text-sm focus-visible:ring-primary"
                                                     />
                                                 </div>


### PR DESCRIPTION
## Summary
- add client-side validation for nurse inventory stock form, preventing quantities below one and negative strengths
- set minimum numeric input limits so decrement arrows stop at valid values
- validate strength server-side to reject negative values during stock creation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c7df59948327a74b85a971267251)