### PR TITLE
Validate medical history before certificate generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "bun test",
     "postinstall": "prisma generate"
   },
   "dependencies": {

--- a/src/app/api/doctor/appointments/[id]/certificate/medical-history.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/medical-history.ts
@@ -1,0 +1,18 @@
+import {
+  parseMedicalHistory,
+  type MedicalHistoryValue,
+} from "@/lib/medical-history";
+
+export function resolveValidMedicalHistory(
+  rawMedicalCond: unknown
+): MedicalHistoryValue {
+  const parsed = parseMedicalHistory(rawMedicalCond);
+  const hasHistory =
+    parsed.conditions.length > 0 || (parsed.other?.trim()?.length ?? 0) > 0;
+
+  if (!hasHistory) {
+    throw new Error("Medical history is empty or invalid");
+  }
+
+  return parsed;
+}

--- a/src/app/api/doctor/appointments/[id]/certificate/route.ts
+++ b/src/app/api/doctor/appointments/[id]/certificate/route.ts
@@ -12,7 +12,8 @@ import {
   Role,
 } from "@prisma/client";
 import { formatManilaDateTime, manilaNow } from "@/lib/time";
-import { parseMedicalHistory } from "@/lib/medical-history";
+import type { MedicalHistoryValue } from "@/lib/medical-history";
+import { resolveValidMedicalHistory } from "./medical-history";
 import {
   buildConditionList,
   CertificateContext,
@@ -229,7 +230,22 @@ export async function GET(
       data: { status: MedcertStatus.Expired },
     });
 
-    const medicalHistory = parseMedicalHistory(studentProfile.medical_cond);
+    const latestMedicalHistory = await prisma.student.findUnique({
+      where: { user_id: appointment.patient_user_id },
+      select: { medical_cond: true },
+    });
+
+    let medicalHistory: MedicalHistoryValue;
+    try {
+      medicalHistory = resolveValidMedicalHistory(
+        latestMedicalHistory?.medical_cond ?? studentProfile.medical_cond
+      );
+    } catch {
+      return NextResponse.json(
+        { error: "Student medical history is missing or invalid." },
+        { status: 400 }
+      );
+    }
     const age = computeAge(studentProfile.date_of_birth, now);
     const sex = studentProfile.gender ? titleCase(studentProfile.gender) : "";
     const program = titleCase(studentProfile.program);

--- a/tests/certificate.test.ts
+++ b/tests/certificate.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveValidMedicalHistory } from "../src/app/api/doctor/appointments/[id]/certificate/medical-history";
+import { hasMedicalCondition } from "../src/lib/medical-history";
+import type { CertificateContext } from "../src/lib/medical-certificate";
+import { renderCertificateHtml } from "../src/lib/medical-certificate";
+
+describe("certificate generation", () => {
+  it("marks recorded medical history options when present", () => {
+    const medicalHistory = resolveValidMedicalHistory(["Asthma"]);
+
+    const context: CertificateContext = {
+      certificateId: "CERT-123",
+      certificateType: "medical",
+      issueDate: new Date("2024-01-01T00:00:00Z"),
+      validUntil: new Date("2025-01-01T00:00:00Z"),
+      issueDateDisplay: "January 1, 2024",
+      patientName: "Test Patient",
+      patientType: "Student",
+      age: "20",
+      sex: "Female",
+      address: "123 Main St",
+      program: "Nursing",
+      department: "Health Sciences",
+      yearLevel: "3rd Year",
+      clinicName: "College Clinic",
+      consultationDate: "January 1, 2024 08:00 AM",
+      diagnosis: "Minor cold",
+      findings: "Rest recommended",
+      reason: "Checkup",
+      allergies: [],
+      medicalHistory,
+      doctorName: "Dr. Smith",
+      doctorTitle: "Attending Physician",
+      licenseNumber: "",
+      ptrNumber: "",
+    };
+
+    const html = renderCertificateHtml(context);
+
+    expect(medicalHistory.conditions).toEqual(["Asthma"]);
+    expect(hasMedicalCondition(context.medicalHistory, "Asthma")).toBe(true);
+    expect(html).toMatch(/checkbox checked[\s\S]*<span class="text">Asthma<\/span>/);
+  });
+});


### PR DESCRIPTION
## Summary
- validate student medical history before issuing medical certificates and return an error when missing
- reuse validated medical history when rendering certificates to ensure checkbox accuracy
- add a bun-based test confirming recorded conditions propagate into certificate rendering

## Testing
- bun test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933efdc7d008327b8fc0da58868d1a7)