### PR TITLE
Define medical history enum and improve medical history parsing

### DIFF
--- a/prisma/generated/enums.ts
+++ b/prisma/generated/enums.ts
@@ -33,6 +33,20 @@ export const MedcertStatus = {
 export type MedcertStatus = (typeof MedcertStatus)[keyof typeof MedcertStatus]
 
 
+export const MedicalHistoryCondition = {
+  Asthma: 'Asthma',
+  Hypertension: 'Hypertension',
+  Cancer: 'Cancer',
+  Epilepsy: 'Epilepsy',
+  Diabetes: 'Diabetes',
+  HeartDisease: 'Heart Disease',
+  KidneyDisease: 'Kidney Disease',
+  NervousMentalDisorder: 'Nervous/Mental Disorder'
+} as const
+
+export type MedicalHistoryCondition = (typeof MedicalHistoryCondition)[keyof typeof MedicalHistoryCondition]
+
+
 export const Role = {
   NURSE: 'NURSE',
   DOCTOR: 'DOCTOR',

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,7 @@ model Student {
   contactno            String?       @unique
   address              String?
   allergies            String?
-  medical_cond         String?
+  medical_cond         MedicalHistoryCondition[] @default([])
   emergencyco_name     String?
   emergencyco_num      String?
   emergencyco_relation String?
@@ -81,7 +81,7 @@ model Employee {
   contactno            String?               @unique
   address              String?
   allergies            String?
-  medical_cond         String?
+  medical_cond         MedicalHistoryCondition[] @default([])
   emergencyco_name     String?
   emergencyco_num      String?
   emergencyco_relation String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -248,6 +248,17 @@ model MedCert {
   patient           Users         @relation("PatientCertificates", fields: [patient_user_id], references: [user_id], onDelete: Cascade)
 }
 
+enum MedicalHistoryCondition {
+  Asthma
+  Hypertension
+  Cancer
+  Epilepsy
+  Diabetes
+  HeartDisease @map("Heart Disease")
+  KidneyDisease @map("Kidney Disease")
+  NervousMentalDisorder @map("Nervous/Mental Disorder")
+}
+
 enum Gender {
   Male
   Female

--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { parseMedicalHistory } from "@/lib/medical-history";
 import { Role, Gender, BloodType, Prisma, Employee } from "@prisma/client";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
@@ -52,6 +53,16 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
     return undefined;
 }
 
+function normalizeMedicalConditions(
+    value: unknown
+): Prisma.EmployeeUpdatemedical_condInput | undefined {
+    if (value === undefined) return undefined;
+
+    const conditions = parseMedicalHistory(value as string | string[] | null).conditions;
+
+    return { set: conditions };
+}
+
 function buildEmployeeUpdateInput(
     raw: Record<string, unknown>
 ): Prisma.EmployeeUpdateInput {
@@ -67,7 +78,7 @@ function buildEmployeeUpdateInput(
     data.contactno = stringField("contactno");
     data.address = stringField("address");
     data.allergies = stringField("allergies");
-    data.medical_cond = normalizeStringOrNull(raw.medical_cond);
+    data.medical_cond = normalizeMedicalConditions(raw.medical_cond);
     data.emergencyco_name = stringField("emergencyco_name");
     data.emergencyco_num = stringField("emergencyco_num");
     data.emergencyco_relation = stringField("emergencyco_relation");

--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -55,7 +55,7 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
 
 function normalizeMedicalConditions(
     value: unknown
-): Prisma.EmployeeUpdatemedical_condInput | undefined {
+): Prisma.EmployeeUpdateInput["medical_cond"] | undefined {
     if (value === undefined) return undefined;
 
     const conditions = parseMedicalHistory(value as string | string[] | null).conditions;

--- a/src/app/api/nurse/accounts/me/route.ts
+++ b/src/app/api/nurse/accounts/me/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { parseMedicalHistory } from "@/lib/medical-history";
 import { Role, Gender, Prisma, BloodType } from "@prisma/client";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
@@ -52,6 +53,16 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
     return undefined;
 }
 
+function normalizeMedicalConditions(
+    value: unknown
+): Prisma.EmployeeUpdatemedical_condInput | undefined {
+    if (value === undefined) return undefined;
+
+    const conditions = parseMedicalHistory(value as string | string[] | null).conditions;
+
+    return { set: conditions };
+}
+
 function buildEmployeeUpdateInput(raw: Record<string, unknown>): Prisma.EmployeeUpdateInput {
     const data: Prisma.EmployeeUpdateInput = {};
 
@@ -67,7 +78,7 @@ function buildEmployeeUpdateInput(raw: Record<string, unknown>): Prisma.Employee
     if (typeof raw.contactno === "string") data.contactno = raw.contactno;
     if (typeof raw.address === "string") data.address = raw.address;
     if (typeof raw.allergies === "string") data.allergies = raw.allergies;
-    const medicalCond = normalizeStringOrNull(raw.medical_cond);
+    const medicalCond = normalizeMedicalConditions(raw.medical_cond);
     if (medicalCond !== undefined) data.medical_cond = medicalCond;
     if (typeof raw.emergencyco_name === "string") data.emergencyco_name = raw.emergencyco_name;
     if (typeof raw.emergencyco_num === "string") data.emergencyco_num = raw.emergencyco_num;

--- a/src/app/api/nurse/accounts/me/route.ts
+++ b/src/app/api/nurse/accounts/me/route.ts
@@ -55,7 +55,7 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
 
 function normalizeMedicalConditions(
     value: unknown
-): Prisma.EmployeeUpdatemedical_condInput | undefined {
+): Prisma.EmployeeUpdateInput["medical_cond"] | undefined {
     if (value === undefined) return undefined;
 
     const conditions = parseMedicalHistory(value as string | string[] | null).conditions;

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { customAlphabet } from "nanoid";
 import bcrypt from "bcryptjs";
+import { parseMedicalHistory } from "@/lib/medical-history";
 import { Prisma, BloodType, Department, Role, AccountStatus } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
 
@@ -99,6 +100,8 @@ export async function POST(req: Request) {
         const plainPassword = generatePassword();
         const hashedPassword = await bcrypt.hash(plainPassword, 10);
 
+        const medicalConditions = parseMedicalHistory(payload.medical_cond).conditions;
+
         // Shared fields
         const sharedProfileData = {
             fname: payload.fname,
@@ -107,7 +110,7 @@ export async function POST(req: Request) {
             bloodtype: bloodTypeMap[payload.bloodtype] || null,
             address: payload.address ?? null,
             allergies: payload.allergies ?? null,
-            medical_cond: payload.medical_cond ?? null,
+            medical_cond: { set: medicalConditions },
             emergencyco_name: payload.emergencyco_name ?? null,
             emergencyco_num: payload.emergencyco_num ?? null,
             emergencyco_relation: payload.emergencyco_relation ?? null,

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -131,8 +131,8 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
 function normalizeMedicalConditions(
     value: unknown
 ):
-    | Prisma.StudentUpdatemedical_condInput
-    | Prisma.EmployeeUpdatemedical_condInput
+    | Prisma.StudentUpdateInput["medical_cond"]
+    | Prisma.EmployeeUpdateInput["medical_cond"]
     | undefined {
     if (value === undefined) return undefined;
 

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { parseMedicalHistory } from "@/lib/medical-history";
 import {
     Role,
     Gender,
@@ -127,6 +128,19 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
     return undefined;
 }
 
+function normalizeMedicalConditions(
+    value: unknown
+):
+    | Prisma.StudentUpdatemedical_condInput
+    | Prisma.EmployeeUpdatemedical_condInput
+    | undefined {
+    if (value === undefined) return undefined;
+
+    const conditions = parseMedicalHistory(value as string | string[] | null).conditions;
+
+    return { set: conditions };
+}
+
 // ---------------- UPDATE INPUT BUILDERS ----------------
 function buildStudentUpdateInput(raw: Record<string, unknown>): Prisma.StudentUpdateInput {
     const data: Prisma.StudentUpdateInput = {};
@@ -156,7 +170,7 @@ function buildStudentUpdateInput(raw: Record<string, unknown>): Prisma.StudentUp
     if (typeof raw.contactno === "string") data.contactno = raw.contactno;
     if (typeof raw.address === "string") data.address = raw.address;
     if (typeof raw.allergies === "string") data.allergies = raw.allergies;
-    const medicalCond = normalizeStringOrNull(raw.medical_cond);
+    const medicalCond = normalizeMedicalConditions(raw.medical_cond);
     if (medicalCond !== undefined) data.medical_cond = medicalCond;
     if (typeof raw.emergencyco_name === "string")
         data.emergencyco_name = raw.emergencyco_name;
@@ -208,7 +222,7 @@ function buildEmployeeUpdateInput(
     const allergies = stringField("allergies");
     if (allergies !== undefined) data.allergies = allergies;
 
-    const medicalCond = normalizeStringOrNull(raw.medical_cond);
+    const medicalCond = normalizeMedicalConditions(raw.medical_cond);
     if (medicalCond !== undefined) data.medical_cond = medicalCond;
 
     const emergencyName = stringField("emergencyco_name");

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { parseMedicalHistory } from "@/lib/medical-history";
 import {
     Role,
     Gender,
@@ -97,6 +98,16 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
     return undefined;
 }
 
+function normalizeMedicalConditions(
+    value: unknown
+): Prisma.StudentUpdatemedical_condInput | undefined {
+    if (value === undefined) return undefined;
+
+    const conditions = parseMedicalHistory(value as string | string[] | null).conditions;
+
+    return { set: conditions };
+}
+
 /** ---------- BUILD UPDATE INPUT (Student) ---------- */
 function buildStudentUpdateInput(
     raw: Record<string, unknown>
@@ -124,7 +135,7 @@ function buildStudentUpdateInput(
     if (typeof raw.contactno === "string") data.contactno = raw.contactno;
     if (typeof raw.address === "string") data.address = raw.address;
     if (typeof raw.allergies === "string") data.allergies = raw.allergies;
-    const medicalCond = normalizeStringOrNull(raw.medical_cond);
+    const medicalCond = normalizeMedicalConditions(raw.medical_cond);
     if (medicalCond !== undefined) data.medical_cond = medicalCond;
     if (typeof raw.emergencyco_name === "string")
         data.emergencyco_name = raw.emergencyco_name;

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -100,7 +100,7 @@ function normalizeStringOrNull(value: unknown): string | null | undefined {
 
 function normalizeMedicalConditions(
     value: unknown
-): Prisma.StudentUpdatemedical_condInput | undefined {
+): Prisma.StudentUpdateInput["medical_cond"] | undefined {
     if (value === undefined) return undefined;
 
     const conditions = parseMedicalHistory(value as string | string[] | null).conditions;

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -206,7 +206,7 @@ export default function DoctorAccountPage() {
             const { medicalHistory, ...restProfile } = updatedProfile;
             const payload = {
                 ...restProfile,
-                medical_cond: serializeMedicalHistory(medicalHistory),
+                medical_cond: serializeMedicalHistory(medicalHistory) ?? [],
                 bloodtype: reverseBloodTypeEnumMap[updatedProfile.bloodtype || ""] || null,
             };
 
@@ -637,7 +637,7 @@ export default function DoctorAccountPage() {
                                                                             setProfileLoading(true);
                                                                             const payload = {
                                                                                 ...updatedProfile,
-                                                                                medical_cond: serializeMedicalHistory(updatedProfile.medicalHistory),
+                                                                                medical_cond: serializeMedicalHistory(updatedProfile.medicalHistory) ?? [],
                                                                                 bloodtype: reverseBloodTypeEnumMap[updatedProfile.bloodtype || ""] || null,
                                                                             };
 

--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -138,7 +138,7 @@ export default function DoctorPatientsPage() {
         const form = event.currentTarget;
         const rawMedicalCond = (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value;
         const medicalHistory = parseMedicalHistory(rawMedicalCond);
-        const serializedMedicalCond = serializeMedicalHistory(medicalHistory) ?? "";
+        const serializedMedicalCond = serializeMedicalHistory(medicalHistory) ?? [];
 
         const payload = {
             type: selectedRecord.patientType,

--- a/src/app/nurse/accounts/types.ts
+++ b/src/app/nurse/accounts/types.ts
@@ -38,7 +38,7 @@ export type NurseAccountProfileApi = {
         address?: string | null;
         bloodtype?: string | null;
         allergies?: string | null;
-        medical_cond?: string | null;
+        medical_cond?: string | string[] | null;
         emergencyco_name?: string | null;
         emergencyco_num?: string | null;
         emergencyco_relation?: string | null;
@@ -166,7 +166,7 @@ export function normalizeNurseAccountProfile(
         address: response.profile?.address || "",
         bloodtype: bloodTypeValue,
         allergies: response.profile?.allergies || "",
-        medicalHistory: parseMedicalHistory(response.profile?.medical_cond || ""),
+        medicalHistory: parseMedicalHistory(response.profile?.medical_cond),
         emergencyco_name: response.profile?.emergencyco_name || "",
         emergencyco_num: response.profile?.emergencyco_num || "",
         emergencyco_relation: response.profile?.emergencyco_relation || "",
@@ -175,6 +175,6 @@ export function normalizeNurseAccountProfile(
 
 export function serializeNurseMedicalHistory(
     value: MedicalHistoryValue
-): string | null {
+): (readonly string[]) | null {
     return serializeMedicalHistory(value);
 }

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -146,7 +146,7 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
         const form = event.currentTarget;
         const rawMedicalCond = (form.elements.namedItem("medical_cond") as HTMLInputElement)?.value;
         const medicalHistory = parseMedicalHistory(rawMedicalCond);
-        const serializedMedicalCond = serializeMedicalHistory(medicalHistory) ?? "";
+        const serializedMedicalCond = serializeMedicalHistory(medicalHistory) ?? [];
 
         const body = {
             type: selectedRecord.patientType,

--- a/src/app/nurse/records/types.ts
+++ b/src/app/nurse/records/types.ts
@@ -49,7 +49,7 @@ export type PatientRecord = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medical_cond?: string | string[] | null;
     emergency?: {
         name?: string | null;
         num?: string | null;

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -20,7 +20,7 @@ export type PatientAccountProfileApi = {
         address?: string | null;
         bloodtype?: string | null;
         allergies?: string | null;
-        medical_cond?: string | null;
+        medical_cond?: string | string[] | null;
         gender?: string | null;
         department_office?: string | null;
         department?: string | null;
@@ -149,7 +149,7 @@ export function normalizePatientAccountProfile(
         address: raw.address || "",
         bloodtype: raw.bloodtype ? patientBloodTypeEnumMap[raw.bloodtype] || raw.bloodtype : "",
         allergies: raw.allergies || "",
-        medicalHistory: parseMedicalHistory(raw.medical_cond || ""),
+        medicalHistory: parseMedicalHistory(raw.medical_cond),
         gender: raw.gender || "",
         department_office: raw.department_office || "",
         department: normalizedDepartment,
@@ -168,6 +168,6 @@ export function normalizePatientAccountProfile(
 
 export function serializePatientMedicalHistory(
     value: MedicalHistoryValue
-): string | null {
+): (readonly string[]) | null {
     return serializeMedicalHistory(value);
 }

--- a/src/app/scholar/patients/types.ts
+++ b/src/app/scholar/patients/types.ts
@@ -48,7 +48,7 @@ export type PatientRecord = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medical_cond?: string | string[] | null;
     emergency?: {
         name?: string | null;
         num?: string | null;

--- a/src/lib/medical-history.ts
+++ b/src/lib/medical-history.ts
@@ -1,15 +1,17 @@
-export const MEDICAL_HISTORY_OPTIONS = [
-    "Asthma",
-    "Hypertension",
-    "Cancer",
-    "Epilepsy",
-    "Diabetes",
-    "Heart Disease",
-    "Kidney Disease",
-    "Nervous/Mental Disorder",
-] as const;
+import { MedicalHistoryCondition } from "../../prisma/generated/enums";
 
-export type MedicalHistoryOption = (typeof MEDICAL_HISTORY_OPTIONS)[number];
+export const MEDICAL_HISTORY_OPTIONS = [
+    MedicalHistoryCondition.Asthma,
+    MedicalHistoryCondition.Hypertension,
+    MedicalHistoryCondition.Cancer,
+    MedicalHistoryCondition.Epilepsy,
+    MedicalHistoryCondition.Diabetes,
+    MedicalHistoryCondition.HeartDisease,
+    MedicalHistoryCondition.KidneyDisease,
+    MedicalHistoryCondition.NervousMentalDisorder,
+] as const satisfies readonly MedicalHistoryCondition[];
+
+export type MedicalHistoryOption = MedicalHistoryCondition;
 
 export type MedicalHistoryValue = {
     conditions: MedicalHistoryOption[];
@@ -42,25 +44,50 @@ function normalizeOptions(options: unknown): MedicalHistoryOption[] {
     return normalized;
 }
 
+function parseJsonLenient(raw: string): unknown | null {
+    const attempts = [raw];
+    if (raw.includes("'")) {
+        attempts.push(raw.replace(/'/g, '"'));
+    }
+
+    for (const candidate of attempts) {
+        try {
+            return JSON.parse(candidate);
+        } catch {
+            // continue trying remaining candidates
+        }
+    }
+
+    return null;
+}
+
 export function parseMedicalHistory(raw?: string | null): MedicalHistoryValue {
     if (!raw) {
         return { conditions: [], other: "" };
     }
 
-    try {
-        const parsed = JSON.parse(raw) as {
-            conditions?: unknown;
-            other?: unknown;
-        };
-        const conditions = normalizeOptions(parsed.conditions);
-        const other =
-            typeof parsed.other === "string" ? sanitizeFreeText(parsed.other) : "";
-        return {
-            conditions,
-            other,
-        };
-    } catch {
-        // fall through to legacy parsing
+    const parsed = parseJsonLenient(raw);
+
+    if (parsed) {
+        // Legacy payload stored as a plain JSON array, e.g. ["Asthma", "Diabetes"]
+        if (Array.isArray(parsed)) {
+            return {
+                conditions: normalizeOptions(parsed),
+                other: "",
+            };
+        }
+
+        if (typeof parsed === "object") {
+            const { conditions, other } = (parsed ?? {}) as {
+                conditions?: unknown;
+                other?: unknown;
+            };
+
+            return {
+                conditions: normalizeOptions(conditions),
+                other: typeof other === "string" ? sanitizeFreeText(other) : "",
+            };
+        }
     }
 
     const segments = raw

--- a/src/lib/medical-history.ts
+++ b/src/lib/medical-history.ts
@@ -61,9 +61,15 @@ function parseJsonLenient(raw: string): unknown | null {
     return null;
 }
 
-export function parseMedicalHistory(raw?: string | null): MedicalHistoryValue {
+export function parseMedicalHistory(
+    raw?: string | MedicalHistoryOption[] | null
+): MedicalHistoryValue {
     if (!raw) {
         return { conditions: [], other: "" };
+    }
+
+    if (Array.isArray(raw)) {
+        return { conditions: normalizeOptions(raw), other: "" };
     }
 
     const parsed = parseJsonLenient(raw);
@@ -117,7 +123,9 @@ export function parseMedicalHistory(raw?: string | null): MedicalHistoryValue {
     };
 }
 
-export function serializeMedicalHistory(value: MedicalHistoryValue | null | undefined): string | null {
+export function serializeMedicalHistory(
+    value: MedicalHistoryValue | null | undefined
+): MedicalHistoryOption[] | null {
     if (!value) {
         return null;
     }
@@ -129,10 +137,7 @@ export function serializeMedicalHistory(value: MedicalHistoryValue | null | unde
         return null;
     }
 
-    return JSON.stringify({
-        conditions,
-        other,
-    });
+    return conditions;
 }
 
 export function formatMedicalHistory(value: MedicalHistoryValue | null | undefined): string {

--- a/src/lib/patient-records-update.ts
+++ b/src/lib/patient-records-update.ts
@@ -1,5 +1,7 @@
 import prisma from "@/lib/prisma";
+import { parseMedicalHistory } from "@/lib/medical-history";
 import { z } from "zod";
+import { MedicalHistoryCondition } from "@prisma/client";
 
 export const BLOOD_TYPES = [
     "A_POS",
@@ -18,7 +20,13 @@ export const patientRecordPatchSchema = z.object({
     address: z.string().optional(),
     bloodtype: z.enum(BLOOD_TYPES).nullable().optional(),
     allergies: z.string().optional(),
-    medical_cond: z.string().optional(),
+    medical_cond: z
+        .union([
+            z.string(),
+            z.array(z.nativeEnum(MedicalHistoryCondition)),
+            z.array(z.string()),
+        ])
+        .optional(),
     emergency: z
         .object({
             name: z.string().optional(),
@@ -33,12 +41,22 @@ export type PatientRecordPatchInput = z.infer<typeof patientRecordPatchSchema>;
 export async function updatePatientRecordEntry(id: string, input: PatientRecordPatchInput) {
     const { type, ...data } = input;
 
+    const medicalHistory =
+        data.medical_cond !== undefined
+            ? parseMedicalHistory(data.medical_cond).conditions
+            : undefined;
+
     const commonData = {
         contactno: data.contactno ?? undefined,
         address: data.address ?? undefined,
         bloodtype: data.bloodtype !== undefined ? { set: data.bloodtype } : undefined,
         allergies: data.allergies ?? undefined,
-        medical_cond: data.medical_cond ?? undefined,
+        medical_cond:
+            medicalHistory !== undefined
+                ? {
+                      set: medicalHistory,
+                  }
+                : undefined,
         emergencyco_name: data.emergency?.name ?? undefined,
         emergencyco_num: data.emergency?.num ?? undefined,
         emergencyco_relation: data.emergency?.relation ?? undefined,

--- a/src/lib/patient-records.ts
+++ b/src/lib/patient-records.ts
@@ -51,7 +51,7 @@ export type PatientRecordEntry = {
     address?: string | null;
     bloodtype?: string | null;
     allergies?: string | null;
-    medical_cond?: string | null;
+    medical_cond?: string | string[] | null;
     emergency?: {
         name?: string | null;
         num?: string | null;
@@ -217,7 +217,7 @@ export async function fetchPatientRecords(options?: { specialization?: DoctorSpe
             address: student.address,
             bloodtype: student.bloodtype,
             allergies: student.allergies,
-            medical_cond: student.medical_cond,
+    medical_cond: student.medical_cond,
             emergency: {
                 name: student.emergencyco_name,
                 num: student.emergencyco_num,
@@ -246,7 +246,7 @@ export async function fetchPatientRecords(options?: { specialization?: DoctorSpe
             address: employee.address,
             bloodtype: employee.bloodtype,
             allergies: employee.allergies,
-            medical_cond: employee.medical_cond,
+    medical_cond: employee.medical_cond,
             emergency: {
                 name: employee.emergencyco_name,
                 num: employee.emergencyco_num,


### PR DESCRIPTION
## Summary
- add a schema-backed MedicalHistoryCondition enum for medical history options
- align medical history helpers with the new enum values
- parse legacy single-quoted medical history payloads so conditions like Asthma render on certificates

## Testing
- Not run (npm is not available in the container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340fee0fb88327bc5559a6747b6418)