### PR TITLE
Create nurse appointments page and simplify patient records view

### DIFF
--- a/src/app/api/nurse/appointments/route.ts
+++ b/src/app/api/nurse/appointments/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma, Role } from "@prisma/client";
+
+import { handleAuthError, requireRole } from "@/lib/authorization";
+import prisma from "@/lib/prisma";
+import { endOfManilaDay, formatManilaISODate, startOfManilaDay } from "@/lib/time";
+
+function formatPersonName(user: {
+    username: string;
+    employee: { fname: string | null; lname: string | null } | null;
+    student: { fname: string | null; lname: string | null } | null;
+}) {
+    const firstName = user.employee?.fname ?? user.student?.fname;
+    const lastName = user.employee?.lname ?? user.student?.lname;
+
+    if (firstName && lastName) return `${firstName} ${lastName}`;
+    if (firstName) return firstName;
+    if (lastName) return lastName;
+    return user.username;
+}
+
+function formatPatientType(patient: {
+    student: { student_id: string | null } | null;
+    employee: { employee_id: string | null } | null;
+}) {
+    if (patient.student) return "Student";
+    if (patient.employee) return "Employee";
+    return "Patient";
+}
+
+function parseDateRange(dateParam: string | null) {
+    if (!dateParam) return null;
+    const parsed = new Date(`${dateParam}T00:00:00+08:00`);
+    if (Number.isNaN(parsed.getTime())) return null;
+
+    return {
+        start: startOfManilaDay(dateParam),
+        end: endOfManilaDay(dateParam),
+    };
+}
+
+export async function GET(req: NextRequest) {
+    try {
+        await requireRole([Role.NURSE]);
+
+        const url = new URL(req.url);
+        const staffRole = url.searchParams.get("staffRole");
+        const dateParam = url.searchParams.get("date");
+
+        const range = parseDateRange(dateParam);
+
+        const where: Prisma.AppointmentWhereInput = {};
+        if (range) {
+            where.appointment_timestart = { gte: range.start, lte: range.end };
+        }
+
+        const appointments = await prisma.appointment.findMany({
+            where,
+            orderBy: { appointment_timestart: "asc" },
+            include: {
+                clinic: { select: { clinic_name: true } },
+                doctor: {
+                    select: {
+                        username: true,
+                        employee: { select: { fname: true, lname: true } },
+                        student: { select: { fname: true, lname: true } },
+                    },
+                },
+                consultation: {
+                    select: {
+                        nurse: {
+                            select: {
+                                username: true,
+                                employee: { select: { fname: true, lname: true } },
+                                student: { select: { fname: true, lname: true } },
+                            },
+                        },
+                    },
+                },
+                patient: {
+                    select: {
+                        username: true,
+                        student: { select: { fname: true, lname: true, student_id: true } },
+                        employee: { select: { fname: true, lname: true, employee_id: true } },
+                    },
+                },
+                createdBy: {
+                    select: {
+                        role: true,
+                        username: true,
+                        employee: { select: { fname: true, lname: true } },
+                        student: { select: { fname: true, lname: true } },
+                    },
+                },
+            },
+        });
+
+        const payload = appointments
+            .map((appointment) => {
+                const nurse = appointment.consultation?.nurse;
+                const staffRoleLabel = nurse
+                    ? "Nurse"
+                    : appointment.createdBy?.role === Role.SCHOLAR
+                        ? "Scholar"
+                        : "Doctor";
+
+                return {
+                    id: appointment.appointment_id,
+                    date: formatManilaISODate(appointment.appointment_timestart),
+                    timestart: appointment.appointment_timestart.toISOString(),
+                    timeend: appointment.appointment_timeend.toISOString(),
+                    status: appointment.status,
+                    clinic: appointment.clinic.clinic_name,
+                    staffRole: staffRoleLabel,
+                    doctorName: formatPersonName(appointment.doctor),
+                    nurseName: nurse ? formatPersonName(nurse) : null,
+                    patientName: formatPersonName(appointment.patient),
+                    patientType: formatPatientType(appointment.patient),
+                    createdBy: appointment.createdBy
+                        ? {
+                              role: appointment.createdBy.role,
+                              name: formatPersonName(appointment.createdBy),
+                          }
+                        : null,
+                };
+            })
+            .filter((appointment) => {
+                if (!staffRole || staffRole === "all") return true;
+                return appointment.staffRole.toLowerCase() === staffRole.toLowerCase();
+            });
+
+        return NextResponse.json(payload);
+    } catch (err) {
+        const authResponse = handleAuthError(err);
+        if (authResponse) return authResponse;
+        console.error("[GET /api/nurse/appointments]", err);
+        return NextResponse.json({ error: "Failed to fetch appointments" }, { status: 500 });
+    }
+}

--- a/src/app/api/nurse/appointments/route.ts
+++ b/src/app/api/nurse/appointments/route.ts
@@ -89,7 +89,7 @@ export async function GET(req: NextRequest) {
                         role: true,
                         username: true,
                         employee: { select: { fname: true, lname: true } },
-                        student: { select: { fname: true, lname: true } },
+                        student: { select: { fname: true, lname: true, is_working_scholar: true } },
                     },
                 },
             },
@@ -100,7 +100,7 @@ export async function GET(req: NextRequest) {
                 const nurse = appointment.consultation?.nurse;
                 const staffRoleLabel = nurse
                     ? "Nurse"
-                    : appointment.createdBy?.role === Role.SCHOLAR
+                    : appointment.createdBy?.student?.is_working_scholar
                         ? "Scholar"
                         : "Doctor";
 

--- a/src/app/nurse/appointments/page.tsx
+++ b/src/app/nurse/appointments/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { CalendarClock, Filter, RefreshCcw } from "lucide-react";
+
+import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { formatAppointmentWindow, humanizeEnumValue } from "@/lib/patient-format";
+
+const STAFF_ROLES = [
+    { label: "All staff", value: "all" },
+    { label: "Doctors", value: "doctor" },
+    { label: "Nurses", value: "nurse" },
+    { label: "Scholars", value: "scholar" },
+] as const;
+
+type NurseAppointment = {
+    id: string;
+    date: string;
+    timestart: string;
+    timeend: string;
+    status: string;
+    clinic: string;
+    staffRole: string;
+    doctorName: string;
+    nurseName: string | null;
+    patientName: string;
+    patientType: string;
+    createdBy: { role: string; name: string } | null;
+};
+
+export default function NurseAppointmentsPage() {
+    const [appointments, setAppointments] = useState<NurseAppointment[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [staffRole, setStaffRole] = useState<string>("all");
+    const [date, setDate] = useState<string>("");
+    const [error, setError] = useState<string | null>(null);
+
+    const filteredAppointments = useMemo(() => {
+        const selectedRole = staffRole.toLowerCase();
+        return appointments.filter((appointment) => {
+            const matchesRole =
+                selectedRole === "all" || appointment.staffRole.toLowerCase() === selectedRole;
+            const matchesDate = !date || appointment.date === date;
+            return matchesRole && matchesDate;
+        });
+    }, [appointments, date, staffRole]);
+
+    async function fetchAppointments() {
+        setLoading(true);
+        setError(null);
+        try {
+            const params = new URLSearchParams();
+            if (staffRole && staffRole !== "all") params.set("staffRole", staffRole);
+            if (date) params.set("date", date);
+            const res = await fetch(`/api/nurse/appointments?${params.toString()}`, { cache: "no-store" });
+            if (!res.ok) throw new Error("Failed to load appointments");
+            const data: NurseAppointment[] = await res.json();
+            setAppointments(data);
+        } catch (err) {
+            console.error(err);
+            setError("Unable to load appointments. Please try again.");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        void fetchAppointments();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <NurseLayout
+            title="Appointments"
+            description="View scheduled visits separately from the patient registry. Filter bookings by staff role or date."
+            actions={
+                <Button
+                    variant="outline"
+                    className="rounded-xl border-primary/30 text-primary hover:bg-primary/10"
+                    onClick={fetchAppointments}
+                    disabled={loading}
+                >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    {loading ? "Refreshing..." : "Refresh list"}
+                </Button>
+            }
+        >
+            <div className="space-y-6">
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                        <div className="space-y-1">
+                            <CardTitle className="text-xl text-primary">Appointment filters</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                Quickly narrow down bookings by staff assignment and date.
+                            </p>
+                        </div>
+                        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-end">
+                            <div className="space-y-2">
+                                <Label className="text-sm font-semibold text-primary">Staff role</Label>
+                                <div className="flex items-center gap-2">
+                                    <Filter className="h-4 w-4 text-muted-foreground" />
+                                    <select
+                                        className="h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none"
+                                        value={staffRole}
+                                        onChange={(event) => setStaffRole(event.target.value)}
+                                    >
+                                        {STAFF_ROLES.map((role) => (
+                                            <option key={role.value} value={role.value}>
+                                                {role.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+                            <div className="space-y-2">
+                                <Label className="text-sm font-semibold text-primary">Date</Label>
+                                <Input
+                                    type="date"
+                                    value={date}
+                                    onChange={(event) => setDate(event.target.value)}
+                                    className="h-10"
+                                />
+                            </div>
+                            <Button className="md:self-end" onClick={fetchAppointments} disabled={loading}>
+                                <CalendarClock className="mr-2 h-4 w-4" /> Apply filters
+                            </Button>
+                        </div>
+                    </CardHeader>
+                </Card>
+
+                <Card className="rounded-3xl border-primary/20 bg-white/90 shadow-sm">
+                    <CardHeader className="flex items-start justify-between gap-3 md:items-center">
+                        <div className="space-y-1">
+                            <CardTitle className="text-xl text-primary">Scheduled bookings</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                Manage appointments independently from patient records.
+                            </p>
+                        </div>
+                        <Badge variant="secondary" className="rounded-full bg-primary/10 text-primary">
+                            {filteredAppointments.length} result{filteredAppointments.length === 1 ? "" : "s"}
+                        </Badge>
+                    </CardHeader>
+                    <CardContent>
+                        {error ? (
+                            <p className="text-sm text-red-600">{error}</p>
+                        ) : (
+                            <div className="overflow-x-auto">
+                                <Table className="min-w-full text-sm">
+                                    <TableHeader>
+                                        <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
+                                            <TableHead className="min-w-[160px]">Patient</TableHead>
+                                            <TableHead className="min-w-[140px]">Type</TableHead>
+                                            <TableHead className="min-w-[200px]">Schedule</TableHead>
+                                            <TableHead className="min-w-[160px]">Clinic</TableHead>
+                                            <TableHead className="min-w-[120px]">Staff role</TableHead>
+                                            <TableHead className="min-w-[160px]">Assigned staff</TableHead>
+                                            <TableHead className="min-w-[140px]">Status</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {loading ? (
+                                            <TableRow>
+                                                <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                                                    Loading appointments...
+                                                </TableCell>
+                                            </TableRow>
+                                        ) : filteredAppointments.length === 0 ? (
+                                            <TableRow>
+                                                <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                                                    No appointments found for the selected filters.
+                                                </TableCell>
+                                            </TableRow>
+                                        ) : (
+                                            filteredAppointments.map((appointment) => (
+                                                <TableRow key={appointment.id}>
+                                                    <TableCell>{appointment.patientName}</TableCell>
+                                                    <TableCell>{appointment.patientType}</TableCell>
+                                                    <TableCell>
+                                                        {formatAppointmentWindow({
+                                                            timestart: appointment.timestart,
+                                                            timeend: appointment.timeend,
+                                                        })}
+                                                    </TableCell>
+                                                    <TableCell>{appointment.clinic}</TableCell>
+                                                    <TableCell>{appointment.staffRole}</TableCell>
+                                                    <TableCell>
+                                                        {appointment.staffRole === "Nurse"
+                                                            ? appointment.nurseName || "—"
+                                                            : appointment.doctorName}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Badge className="rounded-full border-primary/30 bg-primary/10 text-primary">
+                                                            {humanizeEnumValue(appointment.status)}
+                                                        </Badge>
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))
+                                        )}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </NurseLayout>
+    );
+}

--- a/src/app/nurse/appointments/page.tsx
+++ b/src/app/nurse/appointments/page.tsx
@@ -109,21 +109,6 @@ export default function NurseAppointmentsPage() {
                         </div>
                         <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-end">
                             <div className="space-y-2">
-                                <Label className="text-sm font-semibold text-primary">Staff role</Label>
-                                <div className="flex items-center gap-2">
-                                    <Filter className="h-4 w-4 text-muted-foreground" />
-                                    <select
-                                        className="h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none"
-                                        value={staffRole}
-                                        onChange={(event) => setStaffRole(event.target.value)}
-                                    >
-                                        {STAFF_ROLES.map((role) => (
-                                            <option key={role.value} value={role.value}>
-                                                {role.label}
-                                            </option>
-                                        ))}
-                                    </select>
-                                </div>
                             </div>
                             <div className="space-y-2">
                                 <Label className="text-sm font-semibold text-primary">Date</Label>
@@ -161,13 +146,13 @@ export default function NurseAppointmentsPage() {
                                 <Table className="min-w-full text-sm">
                                     <TableHeader>
                                         <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
-                                            <TableHead className="min-w-[160px]">Patient</TableHead>
-                                            <TableHead className="min-w-[140px]">Type</TableHead>
-                                            <TableHead className="min-w-[200px]">Schedule</TableHead>
-                                            <TableHead className="min-w-[160px]">Clinic</TableHead>
-                                            <TableHead className="min-w-[120px]">Staff role</TableHead>
-                                            <TableHead className="min-w-[160px]">Assigned staff</TableHead>
-                                            <TableHead className="min-w-[140px]">Status</TableHead>
+                                            <TableHead className="min-w-40">Patient</TableHead>
+                                            <TableHead className="min-w-35">Type</TableHead>
+                                            <TableHead className="min-w-50">Schedule</TableHead>
+                                            <TableHead className="min-w-40">Clinic</TableHead>
+                                            <TableHead className="min-w-30">Staff role</TableHead>
+                                            <TableHead className="min-w-40">Assigned staff</TableHead>
+                                            <TableHead className="min-w-35">Status</TableHead>
                                         </TableRow>
                                     </TableHeader>
                                     <TableBody>

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -46,7 +46,6 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("All");
     const [typeFilter, setTypeFilter] = useState("All");
-    const [appointmentFilter, setAppointmentFilter] = useState("All");
     const [loadingRecords, setLoadingRecords] = useState(false);
     const [initializing, setInitializing] = useState(!initialRecords);
     const [detailOpen, setDetailOpen] = useState(false);
@@ -90,7 +89,7 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
     }, [records, selectedRecord]);
 
     const filteredRecords = useMemo(() => {
-        if (!deferredSearch && statusFilter === "All" && typeFilter === "All" && appointmentFilter === "All") {
+        if (!deferredSearch && statusFilter === "All" && typeFilter === "All") {
             return records;
         }
 
@@ -106,17 +105,12 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
 
             const matchesStatus = statusFilter === "All" || record.status === statusFilter;
             const matchesType = typeFilter === "All" || record.patientType === typeFilter;
-            const matchesAppointment =
-                appointmentFilter === "All" ||
-                (appointmentFilter === "With" && record.latestAppointment) ||
-                (appointmentFilter === "Without" && !record.latestAppointment);
-
-            return matchesSearch && matchesStatus && matchesType && matchesAppointment;
+            return matchesSearch && matchesStatus && matchesType;
         });
-    }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
+    }, [deferredSearch, records, statusFilter, typeFilter]);
 
     const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
-        resetDeps: [appointmentFilter, deferredSearch, statusFilter, typeFilter],
+        resetDeps: [deferredSearch, statusFilter, typeFilter],
     });
 
     const totalPatients = records.length;
@@ -125,7 +119,6 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
         [records]
     );
     const withoutAppointments = totalPatients - withAppointments;
-
     function openDetails(record: PatientRecord, tab: RecordDetailsDialogTab = "details") {
         setSelectedRecord(record);
         setActiveTab(tab);
@@ -325,16 +318,6 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
                                         <SelectItem value="All">All Status</SelectItem>
                                         <SelectItem value="Active">Active</SelectItem>
                                         <SelectItem value="Inactive">Inactive</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                                <Select value={appointmentFilter} onValueChange={setAppointmentFilter}>
-                                    <SelectTrigger className="h-10 w-full">
-                                        <SelectValue placeholder="Appointments" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="All">All Appointments</SelectItem>
-                                        <SelectItem value="With">With appointment</SelectItem>
-                                        <SelectItem value="Without">No appointment</SelectItem>
                                     </SelectContent>
                                 </Select>
                             </div>

--- a/src/app/nurse/records/patient-directory-table.tsx
+++ b/src/app/nurse/records/patient-directory-table.tsx
@@ -13,14 +13,7 @@ import {
 } from "@/components/ui/table";
 import { Loader2 } from "lucide-react";
 
-import {
-    formatAppointmentWindow,
-    formatDepartment,
-    formatProgram,
-    formatStaffName,
-    formatYearLevel,
-    PATIENT_STATUS_CLASSES,
-} from "@/lib/patient-format";
+import { formatDepartment, formatProgram, formatYearLevel, PATIENT_STATUS_CLASSES } from "@/lib/patient-format";
 import { TablePagination } from "@/components/table-pagination";
 
 import type { PatientRecord } from "./types";
@@ -109,21 +102,6 @@ function PatientDirectoryTableComponent({
                     <TableCell>
                         <Badge className={`rounded-full px-2 py-1 text-xs ${statusClasses}`}>{record.status}</Badge>
                     </TableCell>
-                    <TableCell className="whitespace-pre-wrap">
-                        {record.latestAppointment?.timestart ? (
-                            <div className="flex flex-col">
-                                <span>{formatAppointmentWindow(record.latestAppointment)}</span>
-                                <span className="text-xs text-muted-foreground">
-                                    Doctor: {formatStaffName(record.latestAppointment.doctor)}
-                                </span>
-                                <span className="text-xs text-muted-foreground">
-                                    Nurse: {formatStaffName(record.latestAppointment.consultation?.nurse)}
-                                </span>
-                            </div>
-                        ) : (
-                            <span className="text-muted-foreground">—</span>
-                        )}
-                    </TableCell>
                 </TableRow>
             );
         });
@@ -139,13 +117,12 @@ function PatientDirectoryTableComponent({
                         <TableHead className="min-w-[120px]">Type</TableHead>
                         <TableHead className="min-w-[220px]">Program / Department</TableHead>
                         <TableHead className="min-w-[120px]">Status</TableHead>
-                        <TableHead className="min-w-[220px]">Latest appointment</TableHead>
                     </TableRow>
                 </TableHeader>
                 <TableBody>
                     {loading ? (
                         <TableRow>
-                            <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                            <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
                                 <div className="flex items-center justify-center gap-2 text-sm">
                                     <Loader2 className="h-4 w-4 animate-spin" /> Loading patient records...
                                 </div>
@@ -153,7 +130,7 @@ function PatientDirectoryTableComponent({
                         </TableRow>
                     ) : rows.length === 0 ? (
                         <TableRow>
-                            <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                            <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
                                 No patient records match your filters.
                             </TableCell>
                         </TableRow>

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -820,13 +820,13 @@ export default function ScholarAppointmentsPage() {
                             <Table>
                                 <TableHeader>
                                     <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
-                                        <TableHead className="min-w-[120px]">Patient</TableHead>
-                                        <TableHead className="min-w-[120px]">Clinic</TableHead>
-                                        <TableHead className="min-w-[120px]">Doctor</TableHead>
-                                        <TableHead className="min-w-[120px]">Date</TableHead>
-                                        <TableHead className="min-w-[120px]">Time</TableHead>
-                                        <TableHead className="min-w-[120px]">Status</TableHead>
-                                        <TableHead className="min-w-[120px]">Service</TableHead>
+                                        <TableHead className="min-w-30">Patient</TableHead>
+                                        <TableHead className="min-w-30">Clinic</TableHead>
+                                        <TableHead className="min-w-30">Doctor</TableHead>
+                                        <TableHead className="min-w-30">Date</TableHead>
+                                        <TableHead className="min-w-30">Time</TableHead>
+                                        <TableHead className="min-w-30">Status</TableHead>
+                                        <TableHead className="min-w-30">Service</TableHead>
                                     </TableRow>
                                 </TableHeader>
                                 <TableBody>
@@ -1228,7 +1228,7 @@ export default function ScholarAppointmentsPage() {
                                         value={createRemarks}
                                         onChange={(event) => setCreateRemarks(event.target.value)}
                                         placeholder="Optional details for the care team"
-                                        className="min-h-[90px] rounded-xl border-primary/30"
+                                        className="min-h-22.5 rounded-xl border-primary/30"
                                     />
                                     <p className="text-xs text-muted-foreground">
                                         Add context such as symptoms reported during the walk-in or follow-up instructions.

--- a/src/components/nurse/nurse-layout.tsx
+++ b/src/components/nurse/nurse-layout.tsx
@@ -2,6 +2,7 @@
 
 import {
     CalendarCheck,
+    CalendarClock,
     FileBarChart2,
     ClipboardList,
     Home,
@@ -22,6 +23,7 @@ const NAV_ITEMS = [
     { href: "/nurse/clinic", label: "Clinic", icon: ClipboardList },
     { href: "/nurse/dispense", label: "Dispense", icon: Pill },
     { href: "/nurse/inventory", label: "Inventory", icon: Package },
+    { href: "/nurse/appointments", label: "Appointments", icon: CalendarClock },
     { href: "/nurse/records", label: "Records", icon: CalendarCheck },
     { href: "/nurse/reports", label: "Reports", icon: FileBarChart2 },
 ] as const satisfies readonly PanelNavItem[];


### PR DESCRIPTION
## Summary
- remove appointment-specific filters and columns from the nurse patient records table
- add a nurse navigation link and backend endpoint for viewing appointments separately
- build a dedicated nurse appointments page with staff-role/date filtering

## Testing
- npm run lint (fails: ESLint config circular reference)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694620bb13f08327919399b05ff75ef9)