### PR TITLE
Add pagination to clinic history and appointment tables

### DIFF
--- a/src/app/doctor/appointments/page.tsx
+++ b/src/app/doctor/appointments/page.tsx
@@ -46,6 +46,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { TablePagination } from "@/components/table-pagination";
 import { formatManilaDateTime, formatManilaISODate, formatTimeString12, manilaNow } from "@/lib/time";
 
 import DoctorAppointmentsLoading from "./loading";
@@ -184,6 +185,8 @@ export default function DoctorAppointmentsPage() {
     const [statusFilter, setStatusFilter] = useState<string>("active");
     const [fromDate, setFromDate] = useState("");
     const [toDate, setToDate] = useState("");
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [specialization, setSpecialization] = useState<DoctorSpecialization | null>(null);
     const [certificateLoadingId, setCertificateLoadingId] = useState<string | null>(null);
     const preferredMoveStartRef = useRef("");
@@ -335,6 +338,22 @@ export default function DoctorAppointmentsPage() {
             return haystack.includes(searchTerm);
         });
     }, [appointments, searchTerm, statusFilter, fromDate, toDate]);
+
+    const paginatedAppointments = useMemo(
+        () => filteredAppointments.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+        [currentPage, filteredAppointments, pageSize]
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [searchTerm, statusFilter, fromDate, toDate]);
+
+    useEffect(() => {
+        const totalPages = Math.max(1, Math.ceil(filteredAppointments.length / pageSize));
+        if (currentPage > totalPages) {
+            setCurrentPage(totalPages);
+        }
+    }, [currentPage, filteredAppointments.length, pageSize]);
 
     const selectedMoveSlot = useMemo(
         () => moveSlots.find((slot) => slot.start === newTimeStart) ?? null,
@@ -760,7 +779,7 @@ export default function DoctorAppointmentsPage() {
                                             </TableCell>
                                         </TableRow>
                                     ) : (
-                                        filteredAppointments.map((appointment) => {
+                                        paginatedAppointments.map((appointment) => {
                                             const status = normalizeStatus(appointment.status);
                                             const statusLabel = status ? STATUS_LABELS[status] : appointment.status;
                                             const statusClasses = status
@@ -887,6 +906,13 @@ export default function DoctorAppointmentsPage() {
                                 </TableBody>
                             </Table>
                         </div>
+                        <TablePagination
+                            currentPage={currentPage}
+                            totalItems={filteredAppointments.length}
+                            pageSize={pageSize}
+                            loading={loading}
+                            onPageChange={setCurrentPage}
+                        />
                     </div>
                 </AppointmentPanel>
             </div>

--- a/src/app/doctor/dispense/page.tsx
+++ b/src/app/doctor/dispense/page.tsx
@@ -20,6 +20,7 @@ import { formatManilaDateTime } from "@/lib/time";
 import { summarizeDispenses } from "@/lib/dispense-summary";
 import { formatProfileName } from "@/lib/staff-name";
 import { DispenseHistoryRow, DispenseHistoryTable } from "@/components/dispense/dispense-history-table";
+import { TablePagination } from "@/components/table-pagination";
 
 import DoctorDispenseLoading from "./loading";
 
@@ -92,6 +93,8 @@ export default function DoctorDispensePage() {
     const [consultations, setConsultations] = useState<ConsultationOption[]>([]);
     const [medicines, setMedicines] = useState<MedicineOption[]>([]);
     const [initializing, setInitializing] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [form, setForm] = useState({
         consultation_id: "",
         med_id: "",
@@ -128,6 +131,15 @@ export default function DoctorDispensePage() {
             })),
         [dispenses]
     );
+
+    const paginatedRows = useMemo(
+        () => tableRows.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+        [currentPage, pageSize, tableRows]
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [dispenses]);
 
     const selectedMedicine = useMemo(
         () => medicines.find((med) => med.med_id === form.med_id) || null,
@@ -200,6 +212,7 @@ export default function DoctorDispensePage() {
             }
 
             setDispenses((prev) => [data as DispenseRecord, ...prev]);
+            setCurrentPage(1);
             setMedicines((prev) =>
                 prev.map((med) =>
                     med.med_id === form.med_id
@@ -415,7 +428,14 @@ export default function DoctorDispensePage() {
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="pt-4">
-                            <DispenseHistoryTable rows={tableRows} loading={loading} />
+                            <DispenseHistoryTable rows={paginatedRows} loading={loading} />
+                            <TablePagination
+                                currentPage={currentPage}
+                                totalItems={tableRows.length}
+                                pageSize={pageSize}
+                                loading={loading}
+                                onPageChange={setCurrentPage}
+                            />
                         </CardContent>
                     </Card>
                 </section>

--- a/src/app/nurse/appointments/page.tsx
+++ b/src/app/nurse/appointments/page.tsx
@@ -19,6 +19,7 @@ import {
     TableRow,
 } from "@/components/ui/table";
 import { formatAppointmentWindow, humanizeEnumValue } from "@/lib/patient-format";
+import { TablePagination } from "@/components/table-pagination";
 
 const STAFF_ROLES = [
     { label: "All staff", value: "all" },
@@ -48,6 +49,8 @@ export default function NurseAppointmentsPage() {
     const [fromDate, setFromDate] = useState<string>("");
     const [toDate, setToDate] = useState<string>("");
     const [error, setError] = useState<string | null>(null);
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
 
     const filteredAppointments = useMemo(() => {
         const selectedRole = staffRole.toLowerCase();
@@ -60,6 +63,22 @@ export default function NurseAppointmentsPage() {
             return matchesRole;
         });
     }, [appointments, fromDate, staffRole, toDate]);
+
+    const paginatedAppointments = useMemo(
+        () => filteredAppointments.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+        [currentPage, filteredAppointments, pageSize]
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [staffRole, fromDate, toDate]);
+
+    useEffect(() => {
+        const totalPages = Math.max(1, Math.ceil(filteredAppointments.length / pageSize));
+        if (currentPage > totalPages) {
+            setCurrentPage(totalPages);
+        }
+    }, [currentPage, filteredAppointments.length, pageSize]);
 
     async function fetchAppointments() {
         setLoading(true);
@@ -208,7 +227,7 @@ export default function NurseAppointmentsPage() {
                                                 </TableCell>
                                             </TableRow>
                                         ) : (
-                                            filteredAppointments.map((appointment) => (
+                                            paginatedAppointments.map((appointment) => (
                                                 <TableRow key={appointment.id}>
                                                     <TableCell>{appointment.patientName}</TableCell>
                                                     <TableCell>{appointment.patientType}</TableCell>
@@ -236,6 +255,13 @@ export default function NurseAppointmentsPage() {
                                     </TableBody>
                                 </Table>
                             </div>
+                            <TablePagination
+                                currentPage={currentPage}
+                                totalItems={filteredAppointments.length}
+                                pageSize={pageSize}
+                                loading={loading}
+                                onPageChange={setCurrentPage}
+                            />
                         )}
                     </CardContent>
                 </Card>

--- a/src/app/nurse/appointments/page.tsx
+++ b/src/app/nurse/appointments/page.tsx
@@ -200,7 +200,7 @@ export default function NurseAppointmentsPage() {
                         {error ? (
                             <p className="text-sm text-red-600">{error}</p>
                         ) : (
-                            <div className="overflow-x-auto">
+                            <><div className="overflow-x-auto">
                                 <Table className="min-w-full text-sm">
                                     <TableHeader>
                                         <TableRow className="text-xs uppercase tracking-wide text-muted-foreground">
@@ -254,14 +254,12 @@ export default function NurseAppointmentsPage() {
                                         )}
                                     </TableBody>
                                 </Table>
-                            </div>
-                            <TablePagination
-                                currentPage={currentPage}
-                                totalItems={filteredAppointments.length}
-                                pageSize={pageSize}
-                                loading={loading}
-                                onPageChange={setCurrentPage}
-                            />
+                            </div><TablePagination
+                                    currentPage={currentPage}
+                                    totalItems={filteredAppointments.length}
+                                    pageSize={pageSize}
+                                    loading={loading}
+                                    onPageChange={setCurrentPage} /></>
                         )}
                     </CardContent>
                 </Card>

--- a/src/app/nurse/dispense/page.tsx
+++ b/src/app/nurse/dispense/page.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from "lucide-react";
 
 import { NurseLayout } from "@/components/nurse/nurse-layout";
 import { DispenseHistoryTable, DispenseHistoryRow } from "@/components/dispense/dispense-history-table";
+import { TablePagination } from "@/components/table-pagination";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -93,6 +94,8 @@ export default function NurseDispensePage() {
     const [consultations, setConsultations] = useState<ConsultationOption[]>([]);
     const [medicines, setMedicines] = useState<MedicineOption[]>([]);
     const [initializing, setInitializing] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [form, setForm] = useState({
         consultation_id: "",
         med_id: "",
@@ -129,6 +132,15 @@ export default function NurseDispensePage() {
             })),
         [dispenses]
     );
+
+    const paginatedRows = useMemo(
+        () => tableRows.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+        [currentPage, pageSize, tableRows]
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [dispenses]);
 
     const selectedMedicine = useMemo(
         () => medicines.find((med) => med.med_id === form.med_id) || null,
@@ -197,6 +209,7 @@ export default function NurseDispensePage() {
             }
 
             setDispenses((prev) => [data as DispenseRecord, ...prev]);
+            setCurrentPage(1);
             setMedicines((prev) =>
                 prev.map((med) =>
                     med.med_id === form.med_id
@@ -415,7 +428,14 @@ export default function NurseDispensePage() {
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="flex-1 flex flex-col pt-4">
-                        <DispenseHistoryTable rows={tableRows} loading={loading} />
+                        <DispenseHistoryTable rows={paginatedRows} loading={loading} />
+                        <TablePagination
+                            currentPage={currentPage}
+                            totalItems={tableRows.length}
+                            pageSize={pageSize}
+                            loading={loading}
+                            onPageChange={setCurrentPage}
+                        />
                     </CardContent>
                 </Card>
             </section>

--- a/src/app/nurse/inventory/page.tsx
+++ b/src/app/nurse/inventory/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Archive, Loader2, PackageSearch, Plus, ShieldAlert } from "lucide-react";
 
 import { NurseLayout } from "@/components/nurse/nurse-layout";
+import { TablePagination } from "@/components/table-pagination";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -84,6 +85,10 @@ export default function NurseInventoryPage() {
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("All");
     const [clinicFilter, setClinicFilter] = useState("All");
+    const [inventoryPage, setInventoryPage] = useState(1);
+    const [archivedPage, setArchivedPage] = useState(1);
+    const inventoryPageSize = 10;
+    const archivedPageSize = 10;
 
     // Separate loading states
     const [loadingInventory, setLoadingInventory] = useState(false);
@@ -203,6 +208,26 @@ export default function NurseInventoryPage() {
             return a.clinic.clinic_name.localeCompare(b.clinic.clinic_name);
         });
 
+    const paginatedInventory = useMemo(
+        () =>
+            filteredItems.slice(
+                (inventoryPage - 1) * inventoryPageSize,
+                inventoryPage * inventoryPageSize
+            ),
+        [filteredItems, inventoryPage, inventoryPageSize]
+    );
+
+    useEffect(() => {
+        setInventoryPage(1);
+    }, [search, statusFilter, clinicFilter]);
+
+    useEffect(() => {
+        const totalPages = Math.max(1, Math.ceil(filteredItems.length / inventoryPageSize));
+        if (inventoryPage > totalPages) {
+            setInventoryPage(totalPages);
+        }
+    }, [filteredItems.length, inventoryPage, inventoryPageSize]);
+
     const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
 
     useEffect(() => {
@@ -218,6 +243,26 @@ export default function NurseInventoryPage() {
             return filteredItems[0];
         });
     }, [filteredItems]);
+
+    const paginatedArchived = useMemo(
+        () =>
+            archivedBatches.slice(
+                (archivedPage - 1) * archivedPageSize,
+                archivedPage * archivedPageSize
+            ),
+        [archivedBatches, archivedPage, archivedPageSize]
+    );
+
+    useEffect(() => {
+        const totalPages = Math.max(1, Math.ceil(archivedBatches.length / archivedPageSize));
+        if (archivedPage > totalPages) {
+            setArchivedPage(totalPages);
+        }
+    }, [archivedBatches.length, archivedPage, archivedPageSize]);
+
+    useEffect(() => {
+        setArchivedPage(1);
+    }, [archivedBatches.length]);
 
     const totalInventoryQuantity = items.reduce((total, item) => total + item.quantity, 0);
     const expiringSoonCount = items.reduce(
@@ -546,7 +591,7 @@ export default function NurseInventoryPage() {
                                             </TableHeader>
                                             <TableBody>
                                                 {filteredItems.length > 0 ? (
-                                                    filteredItems.map((item) => {
+                                                    paginatedInventory.map((item) => {
                                                         const activeBatches = item.replenishments.filter(
                                                             (rep) => rep.status !== "Expired"
                                                         );
@@ -623,6 +668,14 @@ export default function NurseInventoryPage() {
                                         </Table>
                                     </div>
                                 </div>
+
+                                <TablePagination
+                                    currentPage={inventoryPage}
+                                    totalItems={filteredItems.length}
+                                    pageSize={inventoryPageSize}
+                                    loading={loadingInventory}
+                                    onPageChange={setInventoryPage}
+                                />
 
                                 <div className="rounded-2xl border border-primary/20 bg-white/70 p-4 shadow-sm shadow-primary/20">
                                     <div className="flex items-center justify-between gap-3 border-b border-primary/10 pb-3">
@@ -716,7 +769,7 @@ export default function NurseInventoryPage() {
                                     </TableHeader>
                                     <TableBody>
                                         {archivedBatches.length > 0 ? (
-                                            archivedBatches.map((batch) => (
+                                            paginatedArchived.map((batch) => (
                                                 <TableRow key={batch.replenishment_id} className="transition hover:bg-primary/10/70">
                                                     <TableCell className="text-sm font-medium text-slate-900">
                                                         {batch.clinic?.clinic_name ?? "-"}
@@ -746,6 +799,13 @@ export default function NurseInventoryPage() {
                                     </TableBody>
                                 </Table>
                             </div>
+                            <TablePagination
+                                currentPage={archivedPage}
+                                totalItems={archivedBatches.length}
+                                pageSize={archivedPageSize}
+                                loading={loadingInventory}
+                                onPageChange={setArchivedPage}
+                            />
                         </div>
                     </CardContent>
                 </Card>

--- a/src/app/scholar/appointments/page.tsx
+++ b/src/app/scholar/appointments/page.tsx
@@ -38,6 +38,7 @@ import {
     toManilaDateString,
 } from "@/lib/time";
 import { getServiceOptionsForSpecialization, resolveServiceType } from "@/lib/service-options";
+import { TablePagination } from "@/components/table-pagination";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 
 import ScholarAppointmentsLoading from "./loading";
@@ -162,6 +163,8 @@ export default function ScholarAppointmentsPage() {
     const [initializing, setInitializing] = useState(true);
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState<string>("active");
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [createSubmitting, setCreateSubmitting] = useState(false);
     const [minBookingDate, setMinBookingDate] = useState(() => computeMinBookingDate());
@@ -528,6 +531,22 @@ export default function ScholarAppointmentsPage() {
         });
     }, [appointments, searchTerm, statusFilter]);
 
+    const paginatedAppointments = useMemo(
+        () => filteredAppointments.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+        [currentPage, filteredAppointments, pageSize]
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [searchTerm, statusFilter]);
+
+    useEffect(() => {
+        const totalPages = Math.max(1, Math.ceil(filteredAppointments.length / pageSize));
+        if (currentPage > totalPages) {
+            setCurrentPage(totalPages);
+        }
+    }, [currentPage, filteredAppointments.length, pageSize]);
+
     const statusCounts = useMemo(() => {
         const counts: Record<AppointmentStatus, number> = {
             Pending: 0,
@@ -845,7 +864,7 @@ export default function ScholarAppointmentsPage() {
                                             </TableCell>
                                         </TableRow>
                                     ) : (
-                                        filteredAppointments.map((appointment) => (
+                                        paginatedAppointments.map((appointment) => (
                                             <TableRow key={appointment.id} className="text-sm">
                                                 <TableCell className="font-medium text-primary">
                                                     <div className="flex flex-col">
@@ -881,6 +900,13 @@ export default function ScholarAppointmentsPage() {
                                 </TableBody>
                             </Table>
                         </div>
+                        <TablePagination
+                            currentPage={currentPage}
+                            totalItems={filteredAppointments.length}
+                            pageSize={pageSize}
+                            loading={loading}
+                            onPageChange={setCurrentPage}
+                        />
                     </div>
                 </AppointmentPanel>
             </div>

--- a/src/app/scholar/dispense/page.tsx
+++ b/src/app/scholar/dispense/page.tsx
@@ -27,6 +27,7 @@ import {
     TableRow,
 } from "@/components/ui/table";
 import { formatManilaDateTime } from "@/lib/time";
+import { TablePagination } from "@/components/table-pagination";
 
 import ScholarDispenseLoading from "./loading";
 
@@ -91,6 +92,8 @@ export default function ScholarDispensePage() {
     const [initializing, setInitializing] = useState(true);
     const [loading, setLoading] = useState(false);
     const [submitting, setSubmitting] = useState(false);
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 10;
     const [form, setForm] = useState({
         idNumber: "",
         contact: "",
@@ -124,6 +127,15 @@ export default function ScholarDispensePage() {
             clinics: clinicsServed.size,
             latestDispense: latest,
         };
+    }, [dispenses]);
+
+    const paginatedDispenses = useMemo(
+        () => dispenses.slice((currentPage - 1) * pageSize, currentPage * pageSize),
+        [currentPage, dispenses, pageSize]
+    );
+
+    useEffect(() => {
+        setCurrentPage(1);
     }, [dispenses]);
 
     async function loadData() {
@@ -395,74 +407,88 @@ export default function ScholarDispensePage() {
                     </CardHeader>
                     <CardContent className="pt-4">
                         {dispenses.length > 0 ? (
-                            <div className="overflow-x-auto">
-                                <Table className="min-w-full text-sm">
-                                    <TableHeader className="bg-primary/10 text-primary">
-                                        <TableRow>
-                                            <TableHead className="whitespace-nowrap">Clinic</TableHead>
-                                            <TableHead className="whitespace-nowrap">Walk-in ID</TableHead>
-                                            <TableHead className="whitespace-nowrap">Medicine</TableHead>
-                                            <TableHead className="whitespace-nowrap">Quantity</TableHead>
-                                            <TableHead className="whitespace-nowrap">Scholar</TableHead>
-                                            <TableHead className="whitespace-nowrap">Dispensed At</TableHead>
-                                        </TableRow>
-                                    </TableHeader>
-                                    <TableBody>
-                                        {dispenses.map((dispense) => (
-                                            <TableRow key={dispense.dispense_id} className="transition hover:bg-primary/10">
-                                                <TableCell>
-                                                    <Badge
-                                                        variant="outline"
-                                                        className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-[0.7rem] font-semibold text-primary"
-                                                    >
-                                                        {dispense.med.clinic.clinic_name}
-                                                    </Badge>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <div className="flex flex-col gap-1">
-                                                        <span className="font-semibold text-gray-900">
-                                                            {dispense.walk_in_id_number ?? "—"}
-                                                        </span>
-                                                        {dispense.walk_in_contact ? (
-                                                            <span className="text-xs text-muted-foreground">
-                                                                Contact: {dispense.walk_in_contact}
-                                                            </span>
-                                                        ) : null}
-                                                        {dispense.walk_in_notes ? (
-                                                            <span className="text-xs text-muted-foreground">
-                                                                Notes: {dispense.walk_in_notes}
-                                                            </span>
-                                                        ) : null}
-                                                    </div>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <div className="flex flex-col">
-                                                        <span className="font-medium text-gray-900">{dispense.med.item_name}</span>
-                                                        <span className="text-xs text-muted-foreground">
-                                                            {dispense.med.clinic.clinic_name}
-                                                        </span>
-                                                    </div>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <Badge className="rounded-full bg-primary/10 px-3 py-1 text-[0.75rem] font-semibold text-primary">
-                                                        ×{dispense.quantity}
-                                                    </Badge>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <span className="text-sm font-medium text-gray-800">
-                                                        {formatScholarName(dispense.scholar)}
-                                                    </span>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <span className="text-sm text-muted-foreground">
-                                                        {formatManilaDateTime(dispense.createdAt) || "—"}
-                                                    </span>
-                                                </TableCell>
+                            <>
+                                <div className="overflow-x-auto">
+                                    <Table className="min-w-full text-sm">
+                                        <TableHeader className="bg-primary/10 text-primary">
+                                            <TableRow>
+                                                <TableHead className="whitespace-nowrap">Clinic</TableHead>
+                                                <TableHead className="whitespace-nowrap">Walk-in ID</TableHead>
+                                                <TableHead className="whitespace-nowrap">Medicine</TableHead>
+                                                <TableHead className="whitespace-nowrap">Quantity</TableHead>
+                                                <TableHead className="whitespace-nowrap">Scholar</TableHead>
+                                                <TableHead className="whitespace-nowrap">Dispensed At</TableHead>
                                             </TableRow>
-                                        ))}
-                                    </TableBody>
-                                </Table>
-                            </div>
+                                        </TableHeader>
+                                        <TableBody>
+                                            {paginatedDispenses.map((dispense) => (
+                                                <TableRow
+                                                    key={dispense.dispense_id}
+                                                    className="transition hover:bg-primary/10"
+                                                >
+                                                    <TableCell>
+                                                        <Badge
+                                                            variant="outline"
+                                                            className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-[0.7rem] font-semibold text-primary"
+                                                        >
+                                                            {dispense.med.clinic.clinic_name}
+                                                        </Badge>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <div className="flex flex-col gap-1">
+                                                            <span className="font-semibold text-gray-900">
+                                                                {dispense.walk_in_id_number ?? "—"}
+                                                            </span>
+                                                            {dispense.walk_in_contact ? (
+                                                                <span className="text-xs text-muted-foreground">
+                                                                    Contact: {dispense.walk_in_contact}
+                                                                </span>
+                                                            ) : null}
+                                                            {dispense.walk_in_notes ? (
+                                                                <span className="text-xs text-muted-foreground">
+                                                                    Notes: {dispense.walk_in_notes}
+                                                                </span>
+                                                            ) : null}
+                                                        </div>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <div className="flex flex-col">
+                                                            <span className="font-medium text-gray-900">
+                                                                {dispense.med.item_name}
+                                                            </span>
+                                                            <span className="text-xs text-muted-foreground">
+                                                                {dispense.med.clinic.clinic_name}
+                                                            </span>
+                                                        </div>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Badge className="rounded-full bg-primary/10 px-3 py-1 text-[0.75rem] font-semibold text-primary">
+                                                            ×{dispense.quantity}
+                                                        </Badge>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <span className="text-sm font-medium text-gray-800">
+                                                            {formatScholarName(dispense.scholar)}
+                                                        </span>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <span className="text-sm text-muted-foreground">
+                                                            {formatManilaDateTime(dispense.createdAt) || "—"}
+                                                        </span>
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                </div>
+                                <TablePagination
+                                    currentPage={currentPage}
+                                    totalItems={dispenses.length}
+                                    pageSize={pageSize}
+                                    loading={loading}
+                                    onPageChange={setCurrentPage}
+                                />
+                            </>
                         ) : (
                             <div className="py-10 text-center text-sm text-muted-foreground">
                                 No walk-in dispenses recorded yet.


### PR DESCRIPTION
## Summary
- add pagination controls to nurse, doctor, and scholar dispense history tables
- paginate nurse inventory stock overview, archived batches, and appointment/scheduling views
- add pagination to doctor and scholar appointment boards for easier navigation

## Testing
- npm run lint *(fails: ESLint circular config error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694744e7abf483278de55b49f40e4e41)