### PR TITLE
Add blank medical certificate download option

### DIFF
--- a/src/app/api/patient/medical-certificate/empty/route.ts
+++ b/src/app/api/patient/medical-certificate/empty/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { Role } from "@prisma/client";
+import { formatManilaDateTime, manilaNow } from "@/lib/time";
+import { formatDateLong, renderCertificateHtml } from "@/lib/medical-certificate";
+import { launchServerlessChromium } from "@/lib/serverless-chromium";
+import { type MedicalHistoryValue } from "@/lib/medical-history";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function buildEmptyMedicalHistory(): MedicalHistoryValue {
+    return { conditions: [], other: "" };
+}
+
+export async function GET() {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const user = await prisma.users.findUnique({
+            where: { user_id: session.user.id },
+            select: { role: true },
+        });
+
+        if (!user || user.role !== Role.PATIENT) {
+            return NextResponse.json({ error: "Access denied" }, { status: 403 });
+        }
+
+        const now = manilaNow();
+        const issueDateDisplay = formatDateLong(now);
+        const consultationDate = formatManilaDateTime(now) ?? issueDateDisplay;
+
+        const html = renderCertificateHtml({
+            certificateId: "TBD",
+            issueDate: now,
+            validUntil: now,
+            issueDateDisplay,
+            patientName: "Patient name",
+            patientType: "Student/Employee",
+            age: "",
+            sex: "",
+            address: "",
+            program: "",
+            department: "",
+            yearLevel: "",
+            clinicName: "Clinic name",
+            consultationDate,
+            diagnosis: "",
+            findings: "",
+            reason: "",
+            allergies: [],
+            medicalHistory: buildEmptyMedicalHistory(),
+            doctorName: "Attending physician",
+            doctorTitle: "Attending Physician",
+            licenseNumber: "",
+            ptrNumber: "",
+        });
+
+        const browser = await launchServerlessChromium();
+
+        try {
+            const page = await browser.newPage();
+            await page.setContent(html, { waitUntil: "networkidle" });
+            await page.emulateMedia({ media: "print" });
+            const pdfBuffer = await page.pdf({
+                format: "A4",
+                printBackground: true,
+                margin: {
+                    top: "0.4in",
+                    bottom: "0.5in",
+                    left: "0.5in",
+                    right: "0.5in",
+                },
+            });
+
+            const pdfArrayBuffer =
+                pdfBuffer instanceof ArrayBuffer
+                    ? pdfBuffer
+                    : pdfBuffer.buffer.slice(pdfBuffer.byteOffset, pdfBuffer.byteOffset + pdfBuffer.byteLength);
+
+            return new Response(pdfArrayBuffer as ArrayBuffer, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/pdf",
+                    "Content-Disposition": "attachment; filename=medical-certificate-template.pdf",
+                    "Cache-Control": "no-store",
+                },
+            });
+        } finally {
+            await browser.close();
+        }
+    } catch (error) {
+        console.error("[GET /api/patient/medical-certificate/empty]", error);
+        return NextResponse.json({ error: "Failed to prepare blank certificate" }, { status: 500 });
+    }
+}

--- a/src/app/api/patient/medical-certificate/empty/route.ts
+++ b/src/app/api/patient/medical-certificate/empty/route.ts
@@ -37,29 +37,31 @@ export async function GET() {
         const consultationDate = formatManilaDateTime(now) ?? issueDateDisplay;
 
         const html = renderCertificateHtml({
-            certificateId: "TBD",
+            certificateId: "",
             issueDate: now,
             validUntil: now,
             issueDateDisplay,
-            patientName: "Patient name",
-            patientType: "Student/Employee",
+            patientName: "",
+            patientType: "",
             age: "",
             sex: "",
             address: "",
             program: "",
             department: "",
             yearLevel: "",
-            clinicName: "Clinic name",
+            clinicName: "",
             consultationDate,
             diagnosis: "",
             findings: "",
             reason: "",
             allergies: [],
             medicalHistory: buildEmptyMedicalHistory(),
-            doctorName: "Attending physician",
-            doctorTitle: "Attending Physician",
+            doctorName: "",
+            doctorTitle: "",
             licenseNumber: "",
             ptrNumber: "",
+            includeCertificateId: false,
+            blankTemplate: true,
         });
 
         const browser = await launchServerlessChromium();

--- a/src/app/patient/medical-certificate/page.tsx
+++ b/src/app/patient/medical-certificate/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Download, Loader2 } from "lucide-react";
 
 import PatientLayout from "@/components/patient/patient-layout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
 import { formatManilaDateTime } from "@/lib/time";
 
 type CertificatePayload = {
@@ -35,6 +36,8 @@ export default function PatientMedicalCertificatePage() {
     const [loading, setLoading] = useState(true);
     const [certificate, setCertificate] = useState<CertificatePayload | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [downloading, setDownloading] = useState(false);
+    const [downloadError, setDownloadError] = useState<string | null>(null);
 
     const statusBadge = useMemo(() => {
         if (!certificate) return null;
@@ -72,10 +75,41 @@ export default function PatientMedicalCertificatePage() {
 
     const hasCertificate = Boolean(certificate);
 
+    async function handleDownloadTemplate() {
+        try {
+            setDownloadError(null);
+            setDownloading(true);
+
+            const response = await fetch("/api/patient/medical-certificate/empty");
+            if (!response.ok) {
+                throw new Error("Failed to download template");
+            }
+
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = "medical-certificate-template.pdf";
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            window.URL.revokeObjectURL(url);
+        } catch (err) {
+            console.error(err);
+            setDownloadError("We couldn't prepare a blank medical certificate right now. Please try again.");
+        } finally {
+            setDownloading(false);
+        }
+    }
+
     return (
         <PatientLayout
             title="Medical certificate"
-            description="View the status of your latest medical certificate issued by the clinic."
+            description={
+                hasCertificate
+                    ? "Review your active certificate and download a blank copy for printing."
+                    : "View the status of your latest medical certificate issued by the clinic."
+            }
         >
             <div className="mx-auto w-full max-w-5xl space-y-8">
                 <Card className="rounded-3xl border-primary/20 bg-white/80 shadow-sm">
@@ -149,6 +183,36 @@ export default function PatientMedicalCertificatePage() {
                                 </div>
                             </div>
                         )}
+
+                        <div className="flex flex-col gap-3 rounded-2xl border border-primary/10 bg-primary/5 p-4 text-sm text-primary">
+                            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <p className="font-semibold text-primary">Need a blank certificate?</p>
+                                    <p className="text-primary/80">
+                                        Download an empty template you can print and have signed during your next visit.
+                                    </p>
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    className="border-primary/20 text-primary hover:bg-primary/10"
+                                    onClick={handleDownloadTemplate}
+                                    disabled={downloading}
+                                >
+                                    {downloading ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Preparing PDF...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Download className="mr-2 h-4 w-4" /> Download blank copy
+                                        </>
+                                    )}
+                                </Button>
+                            </div>
+                            {downloadError ? (
+                                <p className="text-xs font-medium text-amber-800">{downloadError}</p>
+                            ) : null}
+                        </div>
                     </CardContent>
                 </Card>
 

--- a/src/lib/medical-certificate.ts
+++ b/src/lib/medical-certificate.ts
@@ -28,6 +28,8 @@ export type CertificateContext = {
   doctorTitle: string;
   licenseNumber: string;
   ptrNumber: string;
+  includeCertificateId?: boolean;
+  blankTemplate?: boolean;
 };
 
 export function escapeHtml(value: string) {
@@ -106,7 +108,13 @@ export function formatDateLong(date: Date) {
 }
 
 export function renderCertificateHtml(context: CertificateContext) {
+  const { blankTemplate = false, includeCertificateId = true } = context;
+
   const placeholder = (value?: string, fallback = "Not recorded") => {
+    if (blankTemplate) {
+      return "&nbsp;";
+    }
+
     if (value && value.trim()) {
       return escapeHtml(value);
     }
@@ -119,6 +127,10 @@ export function renderCertificateHtml(context: CertificateContext) {
   };
 
   const credentialValue = (value?: string) => {
+    if (blankTemplate) {
+      return "&nbsp;";
+    }
+
     if (value && value.trim()) {
       return escapeHtml(value);
     }
@@ -155,13 +167,15 @@ export function renderCertificateHtml(context: CertificateContext) {
   );
 
   const noteParts: string[] = [];
-  if (context.reason) {
+  if (!blankTemplate && context.reason) {
     noteParts.push(`Reason for visit: ${context.reason}.`);
   }
-  noteParts.push(`Consultation recorded on ${context.consultationDate}.`);
+  if (!blankTemplate) {
+    noteParts.push(`Consultation recorded on ${context.consultationDate}.`);
+  }
   const notes = placeholder(
     noteParts.map((entry) => entry.trim()).join(" "),
-    "No additional notes were recorded."
+    blankTemplate ? "" : "No additional notes were recorded."
   );
 
   return `<!DOCTYPE html>
@@ -571,9 +585,11 @@ export function renderCertificateHtml(context: CertificateContext) {
 
       <footer>
         <div>Valid until: ${escapeHtml(formatDateLong(context.validUntil))}</div>
-        <div class="certificate-id">Certificate ID: ${escapeHtml(
-    context.certificateId
-  )}</div>
+        ${includeCertificateId
+          ? `<div class="certificate-id">Certificate ID: ${escapeHtml(
+              context.certificateId
+            )}</div>`
+          : ""}
         <div>
           This certificate is issued for any school-related activity and is valid for one (1) year from the date of issuance.
         </div>


### PR DESCRIPTION
## Summary
- add an authenticated API route that generates a blank medical certificate PDF for patients
- update the patient medical certificate page with a download action and descriptive copy when a certificate is active
- preserve existing certificate status display while surfacing template access and any download errors

## Testing
- `npm run lint` *(fails: ESLint config circular structure error in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947516f5740832797bac268ae06ea98)