### PR TITLE
Add alphabetical sorting for users and registries

### DIFF
--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -18,16 +18,13 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { parseMedicalHistory, serializeMedicalHistory } from "@/lib/medical-history";
+import { sortByFullName } from "@/lib/sorting";
 
 import DoctorPatientsLoading from "./loading";
 import { PatientDirectoryTable } from "@/app/nurse/records/patient-directory-table";
 import type { RecordDetailsDialogTab } from "@/app/nurse/records/patient-record-dialog";
 import type { PatientRecord } from "@/app/nurse/records/types";
 import { usePagination } from "@/hooks/use-pagination";
-
-function sortPatientsByName<T extends { fullName: string }>(records: T[]): T[] {
-    return [...records].sort((a, b) => a.fullName.localeCompare(b.fullName, undefined, { sensitivity: "base" }));
-}
 
 const RecordDetailsDialog = dynamic(
     () => import("@/app/nurse/records/patient-record-dialog").then((mod) => mod.RecordDetailsDialog),
@@ -63,7 +60,7 @@ export default function DoctorPatientsPage() {
             if (!res.ok) throw new Error("Failed to load records");
             const data: PatientRecord[] = await res.json();
             startTransition(() => {
-                setRecords(sortPatientsByName(data));
+                setRecords(sortByFullName(data));
             });
         } catch (error) {
             console.error(error);

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -70,6 +70,7 @@ import { handleRateLimitError } from "@/lib/rate-limit-toast";
 import { cn } from "@/lib/utils";
 import { usePagination } from "@/hooks/use-pagination";
 import { TablePagination } from "@/components/table-pagination";
+import { sortByFullName } from "@/lib/sorting";
 
 import NurseAccountsLoading from "./loading";
 import {
@@ -118,7 +119,7 @@ export function NurseAccountsPageClient({
     initialUsersLoaded,
     initialProfileLoaded,
 }: NurseAccountsPageClientProps) {
-    const [users, setUsers] = useState<NurseAccountUser[]>(() => [...initialUsers]);
+    const [users, setUsers] = useState<NurseAccountUser[]>(() => sortByFullName(initialUsers));
     const [pendingStatusIds, setPendingStatusIds] = useState<string[]>([]);
     const [pendingScholarIds, setPendingScholarIds] = useState<string[]>([]);
     const [search, setSearch] = useState("");
@@ -251,9 +252,9 @@ export function NurseAccountsPageClient({
         try {
             const normalized = await fetchUsers();
             if (options?.silent) {
-                setUsers(normalized);
+                setUsers(sortByFullName(normalized));
             } else {
-                startUsersTransition(() => setUsers(normalized));
+                startUsersTransition(() => setUsers(sortByFullName(normalized)));
             }
         } catch (err) {
             console.error("Failed to load users:", err);

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -19,6 +19,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { parseMedicalHistory, serializeMedicalHistory } from "@/lib/medical-history";
+import { sortByFullName } from "@/lib/sorting";
 
 import NurseRecordsLoading from "./loading";
 import { PatientDirectoryTable } from "./patient-directory-table";
@@ -26,9 +27,6 @@ import type { RecordDetailsDialogTab } from "./patient-record-dialog";
 import type { PatientRecord } from "./types";
 import { usePagination } from "@/hooks/use-pagination";
 
-function sortPatientsByName<T extends { fullName: string }>(records: T[]): T[] {
-    return [...records].sort((a, b) => a.fullName.localeCompare(b.fullName, undefined, { sensitivity: "base" }));
-}
 
 const RecordDetailsDialog = dynamic(
     () => import("./patient-record-dialog").then((mod) => mod.RecordDetailsDialog),
@@ -46,7 +44,7 @@ export type NurseRecordsPageClientProps = {
 
 export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClientProps) {
     const { data: session } = useSession();
-    const [records, setRecords] = useState<PatientRecord[]>(() => sortPatientsByName(initialRecords ?? []));
+    const [records, setRecords] = useState<PatientRecord[]>(() => sortByFullName(initialRecords ?? []));
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("All");
     const [typeFilter, setTypeFilter] = useState("All");
@@ -68,7 +66,7 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
             if (!res.ok) throw new Error("Failed to load records");
             const data: PatientRecord[] = await res.json();
             startTransition(() => {
-                setRecords(sortPatientsByName(data));
+                setRecords(sortByFullName(data));
             });
         } catch {
             toast.error("Error loading records.");

--- a/src/app/scholar/patients/types.ts
+++ b/src/app/scholar/patients/types.ts
@@ -1,3 +1,5 @@
+import { sortByFullName } from "@/lib/sorting";
+
 export type StaffSummary = {
     id: string;
     username: string;
@@ -98,7 +100,5 @@ export function preparePatientRecords(
         return [];
     }
 
-    return [...records]
-        .sort((a, b) => a.fullName.localeCompare(b.fullName, undefined, { sensitivity: "base" }))
-        .map((record) => preparePatientRecord(record));
+    return sortByFullName(records).map((record) => preparePatientRecord(record));
 }

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns a new array sorted alphabetically by the `fullName` field.
+ */
+export function sortByFullName<T extends { fullName: string }>(items: T[]): T[] {
+    return [...items].sort((a, b) => a.fullName.localeCompare(b.fullName, undefined, { sensitivity: "base" }));
+}


### PR DESCRIPTION
## Summary
- add a shared `sortByFullName` helper to alphabetize lists by name
- sort nurse account management lists alphabetically when loading users
- ensure nurse, doctor, and scholar patient registries rely on the shared alphabetical sorter

## Testing
- npm run lint *(fails: existing ESLint config circular reference)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69476d0cd57483278b09c7d0c9a3110a)