### PR TITLE
Standardize suffix handling across accounts

### DIFF
--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -111,7 +111,15 @@ export async function GET() {
             role: user.role,
             status: user.status,
             specialization: user.employee?.specialization ?? null,
-            profile: user.employee ?? null,
+            profile: user.employee
+                ? {
+                    ...user.employee,
+                    suffix:
+                        typeof user.employee.suffix === "string" && user.employee.suffix.trim()
+                            ? user.employee.suffix.trim()
+                            : null,
+                }
+                : null,
         });
     } catch (err) {
         console.error("[GET /api/doctor/account/me]", err);

--- a/src/app/api/doctor/account/me/route.ts
+++ b/src/app/api/doctor/account/me/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { Role, Gender, BloodType, Prisma, Employee } from "@prisma/client";
+import { isAllowedNameSuffix } from "@/lib/validation";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
 
@@ -63,7 +64,9 @@ function buildEmployeeUpdateInput(
     data.fname = stringField("fname");
     data.mname = stringField("mname");
     data.lname = stringField("lname");
-    data.suffix = stringField("suffix");
+    const suffix = stringField("suffix");
+    if (suffix !== undefined) data.suffix = suffix;
+    else if (raw.suffix === null) data.suffix = null;
     data.email = stringField("email");
     data.contactno = stringField("contactno");
     data.address = stringField("address");
@@ -143,6 +146,19 @@ export async function PUT(req: Request) {
         const incomingDOB = toDate(profile.date_of_birth);
         const existingDOB = existing.date_of_birth ?? null;
         const incomingGender = isGender(profile.gender) ? profile.gender : null;
+
+        if (profile.suffix !== undefined) {
+            const suffix = typeof profile.suffix === "string" ? profile.suffix.trim() : "";
+
+            if (!isAllowedNameSuffix(suffix)) {
+                return NextResponse.json(
+                    { error: "Suffix must be Jr., Sr., II, III, IV, or left blank." },
+                    { status: 400 }
+                );
+            }
+
+            profile.suffix = suffix || null;
+        }
 
         if (existing.gender && incomingGender && existing.gender !== incomingGender) {
             return NextResponse.json(

--- a/src/app/api/nurse/accounts/me/route.ts
+++ b/src/app/api/nurse/accounts/me/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { Role, Gender, Prisma, BloodType } from "@prisma/client";
+import { isAllowedNameSuffix } from "@/lib/validation";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
 
@@ -59,6 +60,9 @@ function buildEmployeeUpdateInput(raw: Record<string, unknown>): Prisma.Employee
     if (typeof raw.mname === "string") data.mname = raw.mname;
     if (typeof raw.lname === "string") data.lname = raw.lname;
 
+    const suffix = normalizeStringOrNull(raw.suffix);
+    if (suffix !== undefined) data.suffix = suffix;
+
     const dob = toDate(raw.date_of_birth);
     if (dob) data.date_of_birth = dob;
 
@@ -110,6 +114,10 @@ export async function GET() {
         const profile = user.employee
             ? {
                 ...user.employee,
+                suffix:
+                    typeof user.employee.suffix === "string" && user.employee.suffix.trim()
+                        ? user.employee.suffix.trim()
+                        : null,
                 email: user.employee.email || "",
                 bloodtype:
                     user.employee.bloodtype && typeof user.employee.bloodtype === "string"
@@ -144,6 +152,20 @@ export async function PUT(req: Request) {
 
         const payload = await req.json();
         const profile = (payload?.profile ?? {}) as Record<string, unknown>;
+
+        if (profile.suffix !== undefined) {
+            const normalizedSuffix =
+                typeof profile.suffix === "string" ? profile.suffix.trim() : profile.suffix;
+
+            if (!isAllowedNameSuffix(normalizedSuffix as string | null | undefined)) {
+                return NextResponse.json(
+                    { error: "Suffix must be Jr., Sr., II, III, IV, or left blank." },
+                    { status: 400 }
+                );
+            }
+
+            profile.suffix = typeof normalizedSuffix === "string" ? normalizedSuffix || null : normalizedSuffix;
+        }
 
         const user = await prisma.users.findUnique({
             where: { user_id: session.user.id },

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -11,6 +11,7 @@ import {
     AppointmentStatus,
 } from "@prisma/client";
 import { handleAuthError, requireRole } from "@/lib/authorization";
+import { isAllowedNameSuffix } from "@/lib/validation";
 
 // Generate random password (8 chars)
 const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -81,9 +82,9 @@ export async function POST(req: Request) {
             );
         }
 
-        if (suffix && isInvalidName(suffix)) {
+        if (!isAllowedNameSuffix(suffix)) {
             return NextResponse.json(
-                { error: "Suffix must only include letters, spaces, apostrophes, periods, or hyphens." },
+                { error: "Suffix must be Jr., Sr., II, III, IV, or left blank." },
                 { status: 400 }
             );
         }

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@prisma/client";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
+import { isAllowedNameSuffix } from "@/lib/validation";
 
 // ---------------- ENUM HELPERS ----------------
 function mapDepartment(val?: string | null): Department | undefined {
@@ -135,6 +136,7 @@ function buildStudentUpdateInput(raw: Record<string, unknown>): Prisma.StudentUp
     if (typeof raw.mname === "string") data.mname = raw.mname;
     if (typeof raw.lname === "string") data.lname = raw.lname;
     if (typeof raw.suffix === "string") data.suffix = raw.suffix;
+    else if (raw.suffix === null) data.suffix = null;
     if (typeof raw.email === "string") data.email = raw.email;
     if (isGender(raw.gender)) data.gender = raw.gender;
     const dob = toDate(raw.date_of_birth);
@@ -188,6 +190,7 @@ function buildEmployeeUpdateInput(
 
     const suffix = stringField("suffix");
     if (suffix !== undefined) data.suffix = suffix;
+    else if (raw.suffix === null) data.suffix = null;
 
     const email = stringField("email");
     if (email !== undefined) data.email = email;
@@ -271,6 +274,19 @@ export async function PUT(req: Request) {
 
         const payload = await req.json();
         const profile = (payload?.profile ?? {}) as Record<string, unknown>;
+
+        if (profile.suffix !== undefined) {
+            const normalizedSuffix = typeof profile.suffix === "string" ? profile.suffix.trim() : profile.suffix;
+
+            if (!isAllowedNameSuffix(normalizedSuffix as string | null | undefined)) {
+                return NextResponse.json(
+                    { error: "Suffix must be Jr., Sr., II, III, IV, or left blank." },
+                    { status: 400 }
+                );
+            }
+
+            profile.suffix = typeof normalizedSuffix === "string" ? normalizedSuffix || null : normalizedSuffix;
+        }
 
         const user = await prisma.users.findUnique({
             where: { user_id: session.user.id },

--- a/src/app/api/patient/account/me/route.ts
+++ b/src/app/api/patient/account/me/route.ts
@@ -254,7 +254,12 @@ export async function GET() {
             role: user.role,
             status: user.status,
             type: user.student ? "student" : user.employee ? "employee" : null,
-            profile: user.student ?? user.employee ?? null,
+            profile:
+                user.student
+                    ? { ...user.student, suffix: user.student.suffix?.trim() || null }
+                    : user.employee
+                        ? { ...user.employee, suffix: user.employee.suffix?.trim() || null }
+                        : null,
         });
     } catch (err) {
         console.error("[GET /api/patient/account/me]", err);

--- a/src/app/api/scholar/account/me/route.ts
+++ b/src/app/api/scholar/account/me/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@prisma/client";
 import { issueEmailVerification, clearEmailVerifications } from "@/lib/email-verification";
 import { consumeRateLimit } from "@/lib/rate-limit";
+import { isAllowedNameSuffix } from "@/lib/validation";
 
 /** ---------- MAPPERS (College-only) ---------- */
 function mapDepartment(val?: string | null): Department | undefined {
@@ -107,6 +108,7 @@ function buildStudentUpdateInput(
     if (typeof raw.mname === "string") data.mname = raw.mname;
     if (typeof raw.lname === "string") data.lname = raw.lname;
     if (typeof raw.suffix === "string") data.suffix = raw.suffix;
+    else if (raw.suffix === null) data.suffix = null;
     if (typeof raw.email === "string") data.email = raw.email;
     if (isGender(raw.gender)) data.gender = raw.gender;
 
@@ -184,6 +186,19 @@ export async function PUT(req: Request) {
 
         const payload = await req.json();
         const profile = (payload?.profile ?? {}) as Record<string, unknown>;
+
+        if (profile.suffix !== undefined) {
+            const normalizedSuffix = typeof profile.suffix === "string" ? profile.suffix.trim() : profile.suffix;
+
+            if (!isAllowedNameSuffix(normalizedSuffix as string | null | undefined)) {
+                return NextResponse.json(
+                    { error: "Suffix must be Jr., Sr., II, III, IV, or left blank." },
+                    { status: 400 }
+                );
+            }
+
+            profile.suffix = typeof normalizedSuffix === "string" ? normalizedSuffix || null : normalizedSuffix;
+        }
 
         const user = await prisma.users.findUnique({
             where: { user_id: session.user.id },

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -126,6 +126,11 @@ export default function DoctorAccountPage() {
                 return;
             }
 
+            const normalizedSuffix =
+                typeof data.profile?.suffix === "string" && data.profile.suffix.trim()
+                    ? data.profile.suffix.trim()
+                    : null;
+
             setProfile({
                 user_id: data.accountId,
                 username: data.username,
@@ -134,7 +139,7 @@ export default function DoctorAccountPage() {
                 fname: data.profile?.fname || "",
                 mname: data.profile?.mname || "",
                 lname: data.profile?.lname || "",
-                suffix: data.profile?.suffix ?? null,
+                suffix: normalizedSuffix,
                 date_of_birth: data.profile?.date_of_birth || "",
                 gender: data.profile?.gender || "",
                 contactno: data.profile?.contactno || "",

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -91,6 +91,7 @@ function buildPhoneNumberFromSubscriber(subscriber: string) {
 export default function DoctorAccountPage() {
     const namePattern = /^[A-Za-z][A-Za-z\s'\-.]*$/;
     const suffixOptions = NAME_SUFFIX_OPTIONS.filter(Boolean);
+    const NO_SUFFIX_VALUE = "__none__";
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(false);
     const [initializing, setInitializing] = useState(true);
@@ -690,14 +691,17 @@ export default function DoctorAccountPage() {
                                             <Select
                                                 value={profile.suffix ?? ""}
                                                 onValueChange={(value) =>
-                                                    setProfile({ ...profile, suffix: value || null })
+                                                    setProfile({
+                                                        ...profile,
+                                                        suffix: value === NO_SUFFIX_VALUE ? null : value,
+                                                    })
                                                 }
                                             >
                                                 <SelectTrigger>
                                                     <SelectValue placeholder="No suffix" />
                                                 </SelectTrigger>
                                                 <SelectContent>
-                                                    <SelectItem value="">No suffix</SelectItem>
+                                                    <SelectItem value={NO_SUFFIX_VALUE}>No suffix</SelectItem>
                                                     {suffixOptions.map((suffix) => (
                                                         <SelectItem key={suffix} value={suffix}>
                                                             {suffix}

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -24,7 +24,12 @@ import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
-import { formatPhoneInputDisplay, validateAndNormalizeContacts } from "@/lib/validation";
+import {
+    formatPhoneInputDisplay,
+    isAllowedNameSuffix,
+    NAME_SUFFIX_OPTIONS,
+    validateAndNormalizeContacts,
+} from "@/lib/validation";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 
 import DoctorAccountLoading from "./loading";
@@ -85,6 +90,7 @@ function buildPhoneNumberFromSubscriber(subscriber: string) {
 
 export default function DoctorAccountPage() {
     const namePattern = /^[A-Za-z][A-Za-z\s'\-.]*$/;
+    const suffixOptions = NAME_SUFFIX_OPTIONS.filter(Boolean);
     const [profile, setProfile] = useState<Profile | null>(null);
     const [profileLoading, setProfileLoading] = useState(false);
     const [initializing, setInitializing] = useState(true);
@@ -183,10 +189,8 @@ export default function DoctorAccountPage() {
             return;
         }
 
-        if (profile.suffix && isInvalidName(profile.suffix)) {
-            toast.error(
-                "Suffix must be at least 2 characters and can only include letters, spaces, apostrophes, periods, or hyphens."
-            );
+        if (!isAllowedNameSuffix(profile.suffix)) {
+            toast.error("Please select a valid suffix option or leave it blank.");
             return;
         }
 
@@ -683,11 +687,24 @@ export default function DoctorAccountPage() {
                                         </div>
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Suffix</Label>
-                                            <Input
-                                                value={profile.suffix || ""}
-                                                onChange={(e) => setProfile({ ...profile, suffix: e.target.value })}
-                                                placeholder="Jr., Sr., III"
-                                            />
+                                            <Select
+                                                value={profile.suffix ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile({ ...profile, suffix: value || null })
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="No suffix" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="">No suffix</SelectItem>
+                                                    {suffixOptions.map((suffix) => (
+                                                        <SelectItem key={suffix} value={suffix}>
+                                                            {suffix}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
                                         </div>
                                     </div>
                                 </AccountSection>

--- a/src/app/doctor/account/page.tsx
+++ b/src/app/doctor/account/page.tsx
@@ -134,7 +134,7 @@ export default function DoctorAccountPage() {
                 fname: data.profile?.fname || "",
                 mname: data.profile?.mname || "",
                 lname: data.profile?.lname || "",
-                suffix: data.profile?.suffix || "",
+                suffix: data.profile?.suffix ?? null,
                 date_of_birth: data.profile?.date_of_birth || "",
                 gender: data.profile?.gender || "",
                 contactno: data.profile?.contactno || "",
@@ -689,7 +689,7 @@ export default function DoctorAccountPage() {
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Suffix</Label>
                                             <Select
-                                                value={profile.suffix ?? ""}
+                                                value={profile.suffix ?? NO_SUFFIX_VALUE}
                                                 onValueChange={(value) =>
                                                     setProfile({
                                                         ...profile,

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -1155,7 +1155,7 @@ export function NurseAccountsPageClient({
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Suffix</Label>
                                             <Select
-                                                value={profile.suffix ?? ""}
+                                                value={profile.suffix ?? NO_SUFFIX_VALUE}
                                                 onValueChange={(value) =>
                                                     setProfile({
                                                         ...profile,
@@ -1375,7 +1375,7 @@ export function NurseAccountsPageClient({
                                 <div>
                                     <Label className="block mb-1 font-medium">Suffix</Label>
                                     <Select
-                                        value={newSuffix}
+                                        value={newSuffix || NO_SUFFIX_VALUE}
                                         onValueChange={(value) =>
                                             setNewSuffix(value === NO_SUFFIX_VALUE ? "" : value)
                                         }

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -65,7 +65,12 @@ import { AccountSection } from "@/components/account/account-section";
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
-import { formatPhoneInputDisplay, validateAndNormalizeContacts } from "@/lib/validation";
+import {
+    formatPhoneInputDisplay,
+    isAllowedNameSuffix,
+    NAME_SUFFIX_OPTIONS,
+    validateAndNormalizeContacts,
+} from "@/lib/validation";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 import { cn } from "@/lib/utils";
 import { usePagination } from "@/hooks/use-pagination";
@@ -128,6 +133,7 @@ export function NurseAccountsPageClient({
     const [role, setRole] = useState("");
     const [patientType, setPatientType] = useState<"student" | "employee" | "">("");
     const [workingScholar, setWorkingScholar] = useState(false);
+    const [newSuffix, setNewSuffix] = useState("");
     const [roleFilter, setRoleFilter] = useState<RoleFilterValue>("ALL");
     const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("ALL");
     const [scholarFilter, setScholarFilter] = useState<ScholarFilterValue>("ALL");
@@ -410,7 +416,7 @@ export function NurseAccountsPageClient({
         const fname = getTrimmedValue("fname");
         const mnameRaw = getTrimmedValue("mname");
         const lname = getTrimmedValue("lname");
-        const suffix = getTrimmedValue("suffix");
+        const suffix = newSuffix.trim();
         const employeeId = getTrimmedValue("employee_id");
         const studentId = getTrimmedValue("student_id");
 
@@ -451,8 +457,8 @@ export function NurseAccountsPageClient({
             return;
         }
 
-        if (suffix && isInvalidName(suffix)) {
-            toast.error("Suffix must be at least 2 characters and can only include letters, spaces, apostrophes, periods, or hyphens.", {
+        if (!isAllowedNameSuffix(suffix)) {
+            toast.error("Please select a valid suffix option or leave it blank.", {
                 position: "top-center",
             });
             return;
@@ -530,6 +536,7 @@ export function NurseAccountsPageClient({
             setRole("");
             setPatientType("");
             setWorkingScholar(false);
+            setNewSuffix("");
             setSpecialization(null);
             setPendingPayload(null);
             setShowCreateConfirm(false);
@@ -580,12 +587,12 @@ export function NurseAccountsPageClient({
             return;
         }
 
-        if (suffix && isInvalidName(suffix)) {
-            toast.error(
-                "Suffix must be at least 2 characters and can only include letters, spaces, apostrophes, periods, or hyphens."
-            );
+        if (!isAllowedNameSuffix(suffix)) {
+            toast.error("Please select a valid suffix option or leave it blank.");
             return;
         }
+
+        const normalizedSuffix = suffix || null;
 
         const contactValidation = validateAndNormalizeContacts({
             email: profile.email,
@@ -602,7 +609,7 @@ export function NurseAccountsPageClient({
             fname,
             mname,
             lname,
-            suffix,
+            suffix: normalizedSuffix,
             email: contactValidation.email,
             contactno: contactValidation.contactNumber,
         };
@@ -775,6 +782,7 @@ export function NurseAccountsPageClient({
     };
 
     const namePattern = /^[A-Za-z][A-Za-z\s'\-.]*$/;
+    const suffixOptions = NAME_SUFFIX_OPTIONS.filter(Boolean);
     const PHONE_PREFIX = "09";
 
     const extractSubscriberDigits = (value?: string | null) => {
@@ -1145,11 +1153,24 @@ export function NurseAccountsPageClient({
                                         </div>
                                         <div className="space-y-2">
                                             <Label className="text-sm font-medium text-emerald-900">Suffix</Label>
-                                            <Input
-                                                value={profile.suffix || ""}
-                                                onChange={(event) => setProfile({ ...profile, suffix: event.target.value })}
-                                                placeholder="Jr., Sr., III"
-                                            />
+                                            <Select
+                                                value={profile.suffix ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile({ ...profile, suffix: value || null })
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder="No suffix" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="">No suffix</SelectItem>
+                                                    {suffixOptions.map((suffix) => (
+                                                        <SelectItem key={suffix} value={suffix}>
+                                                            {suffix}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
                                         </div>
                                     </div>
                                 </AccountSection>
@@ -1349,7 +1370,19 @@ export function NurseAccountsPageClient({
                                 </div>
                                 <div>
                                     <Label className="block mb-1 font-medium">Suffix</Label>
-                                    <Input name="suffix" placeholder="Jr., Sr., III" />
+                                    <Select value={newSuffix} onValueChange={setNewSuffix}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="No suffix" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="">No suffix</SelectItem>
+                                            {suffixOptions.map((suffix) => (
+                                                <SelectItem key={suffix} value={suffix}>
+                                                    {suffix}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
                                 </div>
                             </div>
 

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -783,6 +783,7 @@ export function NurseAccountsPageClient({
 
     const namePattern = /^[A-Za-z][A-Za-z\s'\-.]*$/;
     const suffixOptions = NAME_SUFFIX_OPTIONS.filter(Boolean);
+    const NO_SUFFIX_VALUE = "__none__";
     const PHONE_PREFIX = "09";
 
     const extractSubscriberDigits = (value?: string | null) => {
@@ -1156,14 +1157,17 @@ export function NurseAccountsPageClient({
                                             <Select
                                                 value={profile.suffix ?? ""}
                                                 onValueChange={(value) =>
-                                                    setProfile({ ...profile, suffix: value || null })
+                                                    setProfile({
+                                                        ...profile,
+                                                        suffix: value === NO_SUFFIX_VALUE ? null : value,
+                                                    })
                                                 }
                                             >
                                                 <SelectTrigger>
                                                     <SelectValue placeholder="No suffix" />
                                                 </SelectTrigger>
                                                 <SelectContent>
-                                                    <SelectItem value="">No suffix</SelectItem>
+                                                    <SelectItem value={NO_SUFFIX_VALUE}>No suffix</SelectItem>
                                                     {suffixOptions.map((suffix) => (
                                                         <SelectItem key={suffix} value={suffix}>
                                                             {suffix}
@@ -1370,12 +1374,17 @@ export function NurseAccountsPageClient({
                                 </div>
                                 <div>
                                     <Label className="block mb-1 font-medium">Suffix</Label>
-                                    <Select value={newSuffix} onValueChange={setNewSuffix}>
+                                    <Select
+                                        value={newSuffix}
+                                        onValueChange={(value) =>
+                                            setNewSuffix(value === NO_SUFFIX_VALUE ? "" : value)
+                                        }
+                                    >
                                         <SelectTrigger>
                                             <SelectValue placeholder="No suffix" />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            <SelectItem value="">No suffix</SelectItem>
+                                            <SelectItem value={NO_SUFFIX_VALUE}>No suffix</SelectItem>
                                             {suffixOptions.map((suffix) => (
                                                 <SelectItem key={suffix} value={suffix}>
                                                     {suffix}

--- a/src/app/nurse/accounts/types.ts
+++ b/src/app/nurse/accounts/types.ts
@@ -151,7 +151,7 @@ export function normalizeNurseAccountProfile(
         fname: response.profile?.fname || "",
         mname: response.profile?.mname || "",
         lname: response.profile?.lname || "",
-        suffix: response.profile?.suffix || "",
+        suffix: response.profile?.suffix ?? null,
         date_of_birth: response.profile?.date_of_birth || "",
         gender: response.profile?.gender || "",
         contactno: response.profile?.contactno || "",

--- a/src/app/nurse/accounts/types.ts
+++ b/src/app/nurse/accounts/types.ts
@@ -143,6 +143,11 @@ export function normalizeNurseAccountProfile(
         ? nurseBloodTypeEnumMap[response.profile.bloodtype] || response.profile.bloodtype
         : "";
 
+    const normalizedSuffix =
+        typeof response.profile?.suffix === "string" && response.profile.suffix.trim()
+            ? response.profile.suffix.trim()
+            : null;
+
     return {
         user_id: response.accountId || "",
         username: response.username || "",
@@ -151,7 +156,7 @@ export function normalizeNurseAccountProfile(
         fname: response.profile?.fname || "",
         mname: response.profile?.mname || "",
         lname: response.profile?.lname || "",
-        suffix: response.profile?.suffix ?? null,
+        suffix: normalizedSuffix,
         date_of_birth: response.profile?.date_of_birth || "",
         gender: response.profile?.gender || "",
         contactno: response.profile?.contactno || "",

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -46,7 +46,12 @@ import { MedicalHistoryField } from "@/components/account/medical-history-field"
 import { AccountSummaryGrid } from "@/components/account/account-summary";
 import type { AccountSummaryItem } from "@/components/account/account-summary";
 import type { AccountPasswordResult } from "@/components/account/account-password-dialog";
-import { formatPhoneInputDisplay, validateAndNormalizeContacts } from "@/lib/validation";
+import {
+    formatPhoneInputDisplay,
+    isAllowedNameSuffix,
+    NAME_SUFFIX_OPTIONS,
+    validateAndNormalizeContacts,
+} from "@/lib/validation";
 import { handleRateLimitError } from "@/lib/rate-limit-toast";
 
 import PatientAccountLoading from "./loading";
@@ -191,6 +196,7 @@ export function PatientAccountPageClient({
     initialProfileLoaded,
 }: PatientAccountPageClientProps) {
     const namePattern = /^[A-Za-z][A-Za-z\s'\-.]*$/;
+    const suffixOptions = NAME_SUFFIX_OPTIONS.filter(Boolean);
     const normalizedTypeValue =
         initialPatientType === "student" || initialPatientType === "employee"
             ? initialPatientType
@@ -391,6 +397,7 @@ export function PatientAccountPageClient({
             const trimmed = value.trim();
             return trimmed.length < 2 || !namePattern.test(trimmed);
         };
+        const suffix = (profile.suffix ?? "").trim();
 
         if (isInvalidName(profile.fname)) {
             toast.error(
@@ -413,10 +420,8 @@ export function PatientAccountPageClient({
             return;
         }
 
-        if (profile.suffix && isInvalidName(profile.suffix)) {
-            toast.error(
-                "Suffix must be at least 2 characters and can only include letters, spaces, apostrophes, periods, or hyphens."
-            );
+        if (!isAllowedNameSuffix(suffix)) {
+            toast.error("Please select a valid suffix option or leave it blank.");
             return;
         }
         const contactValidation = validateAndNormalizeContacts({
@@ -432,6 +437,7 @@ export function PatientAccountPageClient({
 
         const updatedProfile = {
             ...profile,
+            suffix: suffix || null,
             email: contactValidation.email,
             contactno: contactValidation.contactNumber,
             emergencyco_num: contactValidation.emergencyNumber,
@@ -967,13 +973,24 @@ export function PatientAccountPageClient({
                                             <Label htmlFor="suffix" className="text-sm font-medium text-emerald-900">
                                                 Suffix
                                             </Label>
-                                            <Input
-                                                id="suffix"
-                                                name="suffix"
-                                                placeholder="Jr., Sr., III"
-                                                value={profile.suffix || ""}
-                                                onChange={(e) => setProfile({ ...profile, suffix: e.target.value })}
-                                            />
+                                            <Select
+                                                value={profile.suffix ?? ""}
+                                                onValueChange={(value) =>
+                                                    setProfile({ ...profile, suffix: value || null })
+                                                }
+                                            >
+                                                <SelectTrigger id="suffix">
+                                                    <SelectValue placeholder="No suffix" />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="">No suffix</SelectItem>
+                                                    {suffixOptions.map((suffix) => (
+                                                        <SelectItem key={suffix} value={suffix}>
+                                                            {suffix}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
                                         </div>
                                     </div>
                                 </AccountSection>

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -975,7 +975,7 @@ export function PatientAccountPageClient({
                                                 Suffix
                                             </Label>
                                             <Select
-                                                value={profile.suffix ?? ""}
+                                                value={profile.suffix ?? NO_SUFFIX_VALUE}
                                                 onValueChange={(value) =>
                                                     setProfile({
                                                         ...profile,

--- a/src/app/patient/account/page.client.tsx
+++ b/src/app/patient/account/page.client.tsx
@@ -197,6 +197,7 @@ export function PatientAccountPageClient({
 }: PatientAccountPageClientProps) {
     const namePattern = /^[A-Za-z][A-Za-z\s'\-.]*$/;
     const suffixOptions = NAME_SUFFIX_OPTIONS.filter(Boolean);
+    const NO_SUFFIX_VALUE = "__none__";
     const normalizedTypeValue =
         initialPatientType === "student" || initialPatientType === "employee"
             ? initialPatientType
@@ -976,14 +977,17 @@ export function PatientAccountPageClient({
                                             <Select
                                                 value={profile.suffix ?? ""}
                                                 onValueChange={(value) =>
-                                                    setProfile({ ...profile, suffix: value || null })
+                                                    setProfile({
+                                                        ...profile,
+                                                        suffix: value === NO_SUFFIX_VALUE ? null : value,
+                                                    })
                                                 }
                                             >
                                                 <SelectTrigger id="suffix">
                                                     <SelectValue placeholder="No suffix" />
                                                 </SelectTrigger>
                                                 <SelectContent>
-                                                    <SelectItem value="">No suffix</SelectItem>
+                                                    <SelectItem value={NO_SUFFIX_VALUE}>No suffix</SelectItem>
                                                     {suffixOptions.map((suffix) => (
                                                         <SelectItem key={suffix} value={suffix}>
                                                             {suffix}

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -145,7 +145,7 @@ export function normalizePatientAccountProfile(
         fname: raw.fname || "",
         mname: raw.mname || "",
         lname: raw.lname || "",
-        suffix: raw.suffix || "",
+        suffix: raw.suffix ?? null,
         date_of_birth: raw.date_of_birth || "",
         email: raw.email || "",
         contactno: raw.contactno || "",

--- a/src/app/patient/account/types.ts
+++ b/src/app/patient/account/types.ts
@@ -137,6 +137,9 @@ export function normalizePatientAccountProfile(
         ? patientDepartmentEnumMap[raw.department] || ""
         : "";
 
+    const normalizedSuffix =
+        typeof raw.suffix === "string" && raw.suffix.trim() ? raw.suffix.trim() : null;
+
     const profile: PatientAccountProfile = {
         user_id: response.accountId || "",
         username: response.username || "",
@@ -145,7 +148,7 @@ export function normalizePatientAccountProfile(
         fname: raw.fname || "",
         mname: raw.mname || "",
         lname: raw.lname || "",
-        suffix: raw.suffix ?? null,
+        suffix: normalizedSuffix,
         date_of_birth: raw.date_of_birth || "",
         email: raw.email || "",
         contactno: raw.contactno || "",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,11 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const PHONE_NUMBER_REGEX = /^09\d{9}$/;
+export const NAME_SUFFIX_OPTIONS = ["", "Jr.", "Sr.", "II", "III", "IV"] as const;
+
+export function isAllowedNameSuffix(value?: string | null): boolean {
+    if (value === undefined || value === null || value === "") return true;
+    return NAME_SUFFIX_OPTIONS.includes(value as (typeof NAME_SUFFIX_OPTIONS)[number]);
+}
 
 /**
  * Normalizes user-entered phone numbers to the 11-digit 09XXXXXXXXX format.


### PR DESCRIPTION
## Summary
- add shared suffix options and validation helper covering common suffixes
- update nurse, doctor, and patient account forms to use consistent suffix dropdowns
- enforce server-side suffix validation for nurse user creation and doctor/patient/scholar profile updates

## Testing
- npm run lint *(fails: ESLint config circular reference error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694907848984832796fa8d8a740c6c23)