### PR TITLE
Add alphabet filter to patient registries

### DIFF
--- a/src/app/doctor/patients/page.tsx
+++ b/src/app/doctor/patients/page.tsx
@@ -25,6 +25,7 @@ import { PatientDirectoryTable } from "@/app/nurse/records/patient-directory-tab
 import type { RecordDetailsDialogTab } from "@/app/nurse/records/patient-record-dialog";
 import type { PatientRecord } from "@/app/nurse/records/types";
 import { usePagination } from "@/hooks/use-pagination";
+import { AlphabetFilter } from "@/components/patient/alphabet-filter";
 
 const RecordDetailsDialog = dynamic(
     () => import("@/app/nurse/records/patient-record-dialog").then((mod) => mod.RecordDetailsDialog),
@@ -42,6 +43,7 @@ export default function DoctorPatientsPage() {
     const [statusFilter, setStatusFilter] = useState("All");
     const [typeFilter, setTypeFilter] = useState("All");
     const [appointmentFilter, setAppointmentFilter] = useState("All");
+    const [letterFilter, setLetterFilter] = useState("All");
     const [loadingRecords, setLoadingRecords] = useState(false);
     const [initializing, setInitializing] = useState(true);
     const [detailOpen, setDetailOpen] = useState(false);
@@ -84,7 +86,13 @@ export default function DoctorPatientsPage() {
     }, [records, selectedRecord]);
 
     const filteredRecords = useMemo(() => {
-        if (!deferredSearch && statusFilter === "All" && typeFilter === "All" && appointmentFilter === "All") {
+        if (
+            !deferredSearch &&
+            statusFilter === "All" &&
+            typeFilter === "All" &&
+            appointmentFilter === "All" &&
+            letterFilter === "All"
+        ) {
             return records;
         }
 
@@ -104,12 +112,15 @@ export default function DoctorPatientsPage() {
                 (appointmentFilter === "With" && record.latestAppointment) ||
                 (appointmentFilter === "Without" && !record.latestAppointment);
 
-            return matchesSearch && matchesStatus && matchesType && matchesAppointment;
+            const matchesLetter =
+                letterFilter === "All" || record.fullName.trim().toUpperCase().startsWith(letterFilter);
+
+            return matchesSearch && matchesStatus && matchesType && matchesAppointment && matchesLetter;
         });
-    }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
+    }, [appointmentFilter, deferredSearch, letterFilter, records, statusFilter, typeFilter]);
 
     const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
-        resetDeps: [appointmentFilter, deferredSearch, statusFilter, typeFilter],
+        resetDeps: [appointmentFilter, deferredSearch, letterFilter, statusFilter, typeFilter],
     });
 
     const totalPatients = records.length;
@@ -319,7 +330,8 @@ export default function DoctorPatientsPage() {
                                 </Select>
                             </div>
                         </CardHeader>
-                        <CardContent className="pt-4">
+                        <CardContent className="pt-4 space-y-6">
+                            <AlphabetFilter value={letterFilter} onChange={setLetterFilter} />
                             <PatientDirectoryTable
                                 records={paginatedRecords}
                                 loading={loadingRecords}

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -76,6 +76,7 @@ import { cn } from "@/lib/utils";
 import { usePagination } from "@/hooks/use-pagination";
 import { TablePagination } from "@/components/table-pagination";
 import { sortByFullName } from "@/lib/sorting";
+import { AlphabetFilter } from "@/components/patient/alphabet-filter";
 
 import NurseAccountsLoading from "./loading";
 import {
@@ -137,6 +138,7 @@ export function NurseAccountsPageClient({
     const [roleFilter, setRoleFilter] = useState<RoleFilterValue>("ALL");
     const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("ALL");
     const [scholarFilter, setScholarFilter] = useState<ScholarFilterValue>("ALL");
+    const [letterFilter, setLetterFilter] = useState("All");
 
     const [profile, setProfile] = useState<NurseAccountProfile | null>(initialProfile);
     const [profileLoading, setProfileLoading] = useState(false);
@@ -352,7 +354,13 @@ export function NurseAccountsPageClient({
     }, [profile?.gender]);
 
     const filteredUsers = useMemo(() => {
-        if (roleFilter === "ALL" && statusFilter === "ALL" && scholarFilter === "ALL" && !deferredSearch) {
+        if (
+            roleFilter === "ALL" &&
+            statusFilter === "ALL" &&
+            scholarFilter === "ALL" &&
+            letterFilter === "All" &&
+            !deferredSearch
+        ) {
             return users;
         }
 
@@ -374,13 +382,15 @@ export function NurseAccountsPageClient({
                 scholarFilter === "ALL" ||
                 (scholarFilter === "SCHOLAR" && u.isWorkingScholar) ||
                 (scholarFilter === "NON_SCHOLAR" && !u.isWorkingScholar);
+            const matchesLetter =
+                letterFilter === "All" || u.fullName.trim().toUpperCase().startsWith(letterFilter);
 
-            return matchesQuery && matchesRole && matchesStatus && matchesScholar;
+            return matchesQuery && matchesRole && matchesStatus && matchesScholar && matchesLetter;
         });
-    }, [deferredSearch, roleFilter, scholarFilter, statusFilter, users]);
+    }, [deferredSearch, letterFilter, roleFilter, scholarFilter, statusFilter, users]);
 
     const { pageItems: paginatedUsers, currentPage, pageSize, setPage } = usePagination(filteredUsers, {
-        resetDeps: [deferredSearch, roleFilter, scholarFilter, statusFilter],
+        resetDeps: [deferredSearch, letterFilter, roleFilter, scholarFilter, statusFilter],
     });
 
     // Create user
@@ -1613,6 +1623,15 @@ export function NurseAccountsPageClient({
                                     </SelectContent>
                                 </Select>
                             </div>
+                            <AlphabetFilter
+                                label="Filter by name initial"
+                                value={letterFilter}
+                                onChange={(val) => {
+                                    setLetterFilter(val);
+                                    setPage(1);
+                                }}
+                                disabled={loading || isRefreshingUsers}
+                            />
                         </div>
                     </CardHeader>
 

--- a/src/app/nurse/records/page.client.tsx
+++ b/src/app/nurse/records/page.client.tsx
@@ -26,6 +26,7 @@ import { PatientDirectoryTable } from "./patient-directory-table";
 import type { RecordDetailsDialogTab } from "./patient-record-dialog";
 import type { PatientRecord } from "./types";
 import { usePagination } from "@/hooks/use-pagination";
+import { AlphabetFilter } from "@/components/patient/alphabet-filter";
 
 
 const RecordDetailsDialog = dynamic(
@@ -48,6 +49,7 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("All");
     const [typeFilter, setTypeFilter] = useState("All");
+    const [letterFilter, setLetterFilter] = useState("All");
     const [loadingRecords, setLoadingRecords] = useState(false);
     const [initializing, setInitializing] = useState(!initialRecords);
     const [detailOpen, setDetailOpen] = useState(false);
@@ -91,7 +93,7 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
     }, [records, selectedRecord]);
 
     const filteredRecords = useMemo(() => {
-        if (!deferredSearch && statusFilter === "All" && typeFilter === "All") {
+        if (!deferredSearch && statusFilter === "All" && typeFilter === "All" && letterFilter === "All") {
             return records;
         }
 
@@ -107,12 +109,14 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
 
             const matchesStatus = statusFilter === "All" || record.status === statusFilter;
             const matchesType = typeFilter === "All" || record.patientType === typeFilter;
-            return matchesSearch && matchesStatus && matchesType;
+            const matchesLetter =
+                letterFilter === "All" || record.fullName.trim().toUpperCase().startsWith(letterFilter);
+            return matchesSearch && matchesStatus && matchesType && matchesLetter;
         });
-    }, [deferredSearch, records, statusFilter, typeFilter]);
+    }, [deferredSearch, letterFilter, records, statusFilter, typeFilter]);
 
     const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
-        resetDeps: [deferredSearch, statusFilter, typeFilter],
+        resetDeps: [deferredSearch, letterFilter, statusFilter, typeFilter],
     });
 
     const totalPatients = records.length;
@@ -324,7 +328,8 @@ export function NurseRecordsPageClient({ initialRecords }: NurseRecordsPageClien
                                 </Select>
                             </div>
                         </CardHeader>
-                        <CardContent className="pt-4">
+                        <CardContent className="pt-4 space-y-6">
+                            <AlphabetFilter value={letterFilter} onChange={setLetterFilter} />
                             <PatientDirectoryTable
                                 records={paginatedRecords}
                                 loading={loadingRecords}

--- a/src/app/scholar/patients/page.client.tsx
+++ b/src/app/scholar/patients/page.client.tsx
@@ -23,6 +23,7 @@ import ScholarPatientsLoading from "./loading";
 import { PatientsTable } from "./patients-table";
 import { preparePatientRecords, type PreparedPatientRecord } from "./types";
 import { usePagination } from "@/hooks/use-pagination";
+import { AlphabetFilter } from "@/components/patient/alphabet-filter";
 
 const PatientDetailDialog = dynamic(
     () => import("./patient-detail-dialog").then((mod) => mod.PatientDetailDialog),
@@ -47,6 +48,7 @@ export function ScholarPatientsPageClient({ initialRecords, initialLoaded }: Sch
     const [typeFilter, setTypeFilter] = useState("all");
     const [statusFilter, setStatusFilter] = useState("active");
     const [appointmentFilter, setAppointmentFilter] = useState("all");
+    const [letterFilter, setLetterFilter] = useState("All");
     const [selected, setSelected] = useState<PreparedPatientRecord | null>(null);
     const [detailOpen, setDetailOpen] = useState(false);
     const [isRefreshing, startTransition] = useTransition();
@@ -104,14 +106,21 @@ export function ScholarPatientsPageClient({ initialRecords, initialLoaded }: Sch
             if (appointmentFilter === "with" && !record.latestAppointment) return false;
             if (appointmentFilter === "without" && record.latestAppointment) return false;
 
+            if (
+                letterFilter !== "All" &&
+                !record.fullName.trim().toUpperCase().startsWith(letterFilter)
+            ) {
+                return false;
+            }
+
             if (!deferredSearch) return true;
 
             return record.searchText.includes(deferredSearch);
         });
-    }, [appointmentFilter, deferredSearch, records, statusFilter, typeFilter]);
+    }, [appointmentFilter, deferredSearch, letterFilter, records, statusFilter, typeFilter]);
 
     const { pageItems: paginatedRecords, currentPage, pageSize, setPage } = usePagination(filteredRecords, {
-        resetDeps: [appointmentFilter, deferredSearch, statusFilter, typeFilter],
+        resetDeps: [appointmentFilter, deferredSearch, letterFilter, statusFilter, typeFilter],
     });
 
     const totalPatients = records.length;
@@ -244,7 +253,8 @@ export function ScholarPatientsPageClient({ initialRecords, initialLoaded }: Sch
                             </Select>
                         </div>
                     </CardHeader>
-                    <CardContent className="pt-4">
+                    <CardContent className="pt-4 space-y-6">
+                        <AlphabetFilter value={letterFilter} onChange={setLetterFilter} />
                         <PatientsTable
                             records={paginatedRecords}
                             loading={loading}

--- a/src/components/patient/alphabet-filter.tsx
+++ b/src/components/patient/alphabet-filter.tsx
@@ -18,7 +18,7 @@ export function AlphabetFilter({ label = "Filter by initial", value, onChange, d
     return (
         <div className="space-y-2">
             <p className="text-sm font-semibold text-primary">{label}</p>
-            <div className="flex flex-wrap gap-2">
+            <div className="grid grid-cols-[1.5fr_repeat(26,minmax(0,1fr))] gap-2">
                 {options.map((option) => {
                     const isActive = value === option;
                     return (

--- a/src/components/patient/alphabet-filter.tsx
+++ b/src/components/patient/alphabet-filter.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+
+const ALPHABET = Array.from({ length: 26 }, (_, index) => String.fromCharCode(65 + index));
+
+export interface AlphabetFilterProps {
+    label?: string;
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+}
+
+export function AlphabetFilter({ label = "Filter by initial", value, onChange, disabled }: AlphabetFilterProps) {
+    const options = useMemo(() => ["All", ...ALPHABET], []);
+
+    return (
+        <div className="space-y-2">
+            <p className="text-sm font-semibold text-primary">{label}</p>
+            <div className="flex flex-wrap gap-2">
+                {options.map((option) => {
+                    const isActive = value === option;
+                    return (
+                        <Button
+                            key={option}
+                            type="button"
+                            size="sm"
+                            variant={isActive ? "default" : "outline"}
+                            className={`h-8 px-3 ${isActive ? "bg-primary text-white hover:bg-primary" : ""}`}
+                            onClick={() => onChange(option)}
+                            disabled={disabled}
+                        >
+                            {option}
+                        </Button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared alphabet filter component for patient listings
- integrate alphabetical initial filtering into nurse, doctor, and scholar patient registries with pagination resets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949daab9ae8832790decb5a47ee99de)