### PR TITLE
Add CSV import capability to nurse accounts dashboard

### DIFF
--- a/public/samples/nurse-account-import.csv
+++ b/public/samples/nurse-account-import.csv
@@ -1,0 +1,5 @@
+role,fname,mname,lname,suffix,patienttype,student_id,employee_id,working_scholar,department,program,year_level,specialization,email,phone,address,allergies,bloodtype,medical_cond,emergencyco_name,emergencyco_num,emergencyco_relation
+NURSE,Jamie,,Villanueva,, , ,NRS-101,, , , , ,jamie.villanueva@hnu.edu.ph,09171234567,"Clinics Building, Room 2",Latex,O+,Asthma,Pat Villanueva,09179876543,Sibling
+DOCTOR,Alex,M.,Lim,M.D.,, ,DOC-202,, , , ,Physician,alex.lim@hnu.edu.ph,09172345678,"Main Campus, Faculty Lane",,A-,Hypertension,Ivy Lim,09177654321,Spouse
+PATIENT,Ana,Reyes,Santos,,student,2024-00123,,yes,SHAS,BSN,3,,ana.santos@hnu.edu.ph,09173456789,"Dormitory 3, Room 12",Peanuts,B+,None,Liza Santos,09174567890,Mother
+PATIENT,Carlos,,Diaz,,employee,,EMP-445,false,HR,, , ,carlos.diaz@hnu.edu.ph,09175678901,"City Heights Subdivision",,O-,Migraine,Maria Diaz,09171239876,Spouse

--- a/src/app/api/nurse/accounts/import/route.ts
+++ b/src/app/api/nurse/accounts/import/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from "next/server";
+import { Role } from "@prisma/client";
+
+import { handleAuthError, requireRole } from "@/lib/authorization";
+
+const booleanTrueValues = new Set(["true", "yes", "1", "y"]);
+
+function splitCsvLine(line: string): string[] {
+    const values: string[] = [];
+    let current = "";
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        const nextChar = line[i + 1];
+
+        if (char === "\"") {
+            if (inQuotes && nextChar === "\"") {
+                current += "\"";
+                i += 1; // Skip escaped quote
+                continue;
+            }
+            inQuotes = !inQuotes;
+            continue;
+        }
+
+        if (char === "," && !inQuotes) {
+            values.push(current.trim());
+            current = "";
+            continue;
+        }
+
+        current += char;
+    }
+
+    values.push(current.trim());
+    return values;
+}
+
+function parseCsv(text: string) {
+    const lines = text
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+    if (!lines.length) return { headers: [] as string[], rows: [] as Record<string, string>[] };
+
+    const headers = splitCsvLine(lines[0]).map((header) => header.trim().toLowerCase());
+    const rows = lines.slice(1).map((line) => {
+        const values = splitCsvLine(line);
+        const record: Record<string, string> = {};
+        headers.forEach((header, index) => {
+            record[header] = values[index]?.trim() ?? "";
+        });
+        return record;
+    });
+
+    return { headers, rows };
+}
+
+function normalizeBoolean(value?: string) {
+    if (!value) return false;
+    return booleanTrueValues.has(value.trim().toLowerCase());
+}
+
+function normalizePayload(row: Record<string, string>) {
+    const patientType = row.patienttype?.toLowerCase() as "student" | "employee" | undefined;
+
+    return {
+        role: row.role?.toUpperCase(),
+        fname: row.fname,
+        mname: row.mname || undefined,
+        lname: row.lname,
+        suffix: row.suffix || undefined,
+        patientType,
+        student_id: row.student_id || undefined,
+        employee_id: row.employee_id || undefined,
+        workingScholar: patientType === "student" ? normalizeBoolean(row.working_scholar || row.workingscholar) : false,
+        department: row.department?.toUpperCase() || undefined,
+        program: row.program || undefined,
+        year_level: row.year_level || undefined,
+        specialization: row.specialization || undefined,
+        email: row.email || undefined,
+        phone: row.phone || undefined,
+        address: row.address || undefined,
+        allergies: row.allergies || undefined,
+        bloodtype: row.bloodtype || undefined,
+        medical_cond: row.medical_cond || undefined,
+        emergencyco_name: row.emergencyco_name || undefined,
+        emergencyco_num: row.emergencyco_num || undefined,
+        emergencyco_relation: row.emergencyco_relation || undefined,
+    } as Record<string, unknown>;
+}
+
+export async function POST(req: Request) {
+    try {
+        await requireRole([Role.NURSE]);
+
+        const formData = await req.formData();
+        const file = formData.get("file");
+
+        if (!(file instanceof File)) {
+            return NextResponse.json({ error: "Please attach a CSV file to import." }, { status: 400 });
+        }
+
+        const text = await file.text();
+        const { rows } = parseCsv(text);
+
+        if (!rows.length) {
+            return NextResponse.json({ error: "The uploaded CSV is empty." }, { status: 400 });
+        }
+
+        const targetUrl = new URL("/api/nurse/accounts", req.url);
+        const cookieHeader = req.headers.get("cookie") ?? "";
+
+        let created = 0;
+        const errors: { row: number; message: string }[] = [];
+
+        for (let index = 0; index < rows.length; index++) {
+            const lineNumber = index + 2; // account for header
+            const payload = normalizePayload(rows[index]);
+
+            if (!payload.role || !payload.fname || !payload.lname) {
+                errors.push({ row: lineNumber, message: "Missing required fields: role, fname, or lname." });
+                continue;
+            }
+
+            try {
+                const res = await fetch(targetUrl, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        cookie: cookieHeader,
+                    },
+                    body: JSON.stringify(payload),
+                    cache: "no-store",
+                });
+
+                const data = await res.json();
+
+                if (!res.ok || data?.error) {
+                    errors.push({
+                        row: lineNumber,
+                        message: data?.error || "Failed to create user from CSV row.",
+                    });
+                    continue;
+                }
+
+                created += 1;
+            } catch (err) {
+                console.error("[IMPORT CSV]", err);
+                errors.push({ row: lineNumber, message: "Unexpected error while processing this row." });
+            }
+        }
+
+        return NextResponse.json({ created, failed: errors.length, errors });
+    } catch (err) {
+        const authResponse = handleAuthError(err);
+        if (authResponse) return authResponse;
+
+        console.error("[POST /api/nurse/accounts/import]", err);
+        return NextResponse.json({ error: "Failed to import accounts from CSV." }, { status: 500 });
+    }
+}

--- a/src/app/nurse/accounts/page.client.tsx
+++ b/src/app/nurse/accounts/page.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import Link from "next/link";
 import { toast } from "sonner";
 import {
     Ban,
@@ -15,6 +16,8 @@ import {
     Phone,
     KeyRound,
     HeartPulse,
+    Upload,
+    FileDown,
 } from "lucide-react";
 
 import { NurseLayout } from "@/components/nurse/nurse-layout";
@@ -159,8 +162,14 @@ export function NurseAccountsPageClient({
     const [showCreateConfirm, setShowCreateConfirm] = useState(false);
     const [createdCredentials, setCreatedCredentials] = useState<{ id: string; password: string } | null>(null);
     const [showCreateSuccess, setShowCreateSuccess] = useState(false);
+    const [importing, setImporting] = useState(false);
+    const [importResult, setImportResult] = useState<
+        | { created: number; failed: number; errors: { row: number; message: string }[] }
+        | null
+    >(null);
 
     const formRef = useRef<HTMLFormElement | null>(null);
+    const importInputRef = useRef<HTMLInputElement | null>(null);
 
     const [isRefreshingUsers, startUsersTransition] = useTransition();
     const deferredSearch = useDeferredValue(search.trim().toLowerCase());
@@ -320,6 +329,50 @@ export function NurseAccountsPageClient({
             setRefreshingProfile(false);
         }
     }, [loadProfile]);
+
+    const handleImportAccounts = useCallback(
+        async (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+
+            const file = importInputRef.current?.files?.[0];
+            if (!file) {
+                toast.error("Please choose a CSV file to import.", { position: "top-center" });
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append("file", file);
+
+            try {
+                setImporting(true);
+                setImportResult(null);
+                const res = await fetch("/api/nurse/accounts/import", {
+                    method: "POST",
+                    body: formData,
+                });
+
+                const data = await res.json();
+
+                if (!res.ok) {
+                    toast.error(data?.error ?? "Failed to import accounts from CSV.");
+                    return;
+                }
+
+                setImportResult(data);
+                toast.success(`Imported ${data.created} account(s) from CSV.`);
+                await loadUsers({ silent: true });
+            } catch (err) {
+                console.error("Failed to import accounts:", err);
+                toast.error("Unexpected error while importing accounts.");
+            } finally {
+                setImporting(false);
+                if (importInputRef.current) {
+                    importInputRef.current.value = "";
+                }
+            }
+        },
+        [importInputRef, loadUsers]
+    );
 
     useEffect(() => {
         if (!profileLoaded) {
@@ -1542,6 +1595,72 @@ export function NurseAccountsPageClient({
                                 </DialogFooter>
                             </DialogContent>
                         </Dialog>
+                    </CardContent>
+                </Card>
+
+
+                {/* Import Users via CSV */}
+                <Card className="rounded-3xl border border-primary/20 bg-white/85 shadow-sm transition hover:-translate-y-px hover:shadow-md">
+                    <CardHeader className="flex flex-col gap-2 border-b sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-1">
+                            <CardTitle className="text-xl sm:text-2xl font-bold text-primary">Import accounts from CSV</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                Upload a CSV exported from your roster to quickly seed nurse, doctor, or patient accounts.
+                            </p>
+                        </div>
+                        <Link
+                            href="/samples/nurse-account-import.csv"
+                            className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:text-primary/80"
+                        >
+                            <FileDown className="h-4 w-4" />
+                            Download sample CSV
+                        </Link>
+                    </CardHeader>
+                    <CardContent className="space-y-4 pt-6">
+                        <form onSubmit={handleImportAccounts} className="space-y-3">
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                                <Input ref={importInputRef} type="file" accept=".csv" disabled={importing} />
+                                <Button
+                                    type="submit"
+                                    className="flex items-center gap-2 rounded-xl bg-primary px-4 text-sm font-semibold text-white hover:bg-primary/90 disabled:opacity-70"
+                                    disabled={importing}
+                                >
+                                    {importing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                                    {importing ? "Importing..." : "Import accounts"}
+                                </Button>
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                                Required columns: <strong>role</strong>, <strong>fname</strong>, and <strong>lname</strong>. Include
+                                <strong> patienttype</strong> plus an ID column for patients, or an <strong>employee_id</strong> for staff.
+                            </p>
+                        </form>
+
+                        {importResult ? (
+                            <div className="space-y-3 rounded-2xl border border-primary/20 bg-primary/5 p-4 text-sm text-slate-800">
+                                <div className="flex flex-wrap items-center gap-3">
+                                    <span className="rounded-full bg-emerald-100 px-3 py-1 text-emerald-800">
+                                        {importResult.created} created
+                                    </span>
+                                    <span className="rounded-full bg-amber-100 px-3 py-1 text-amber-800">
+                                        {importResult.failed} with issues
+                                    </span>
+                                </div>
+                                {importResult.errors.length > 0 ? (
+                                    <div className="space-y-2">
+                                        <p className="text-xs font-semibold text-amber-800">Rows needing attention</p>
+                                        <ul className="space-y-1 text-xs text-slate-700">
+                                            {importResult.errors.map((error) => (
+                                                <li key={`row-${error.row}`} className="rounded-lg bg-white/60 p-2 shadow-xs">
+                                                    <span className="font-semibold">Row {error.row}:</span> {error.message}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
+                                ) : (
+                                    <p className="text-xs text-emerald-800">All rows imported successfully.</p>
+                                )}
+                            </div>
+                        ) : null}
                     </CardContent>
                 </Card>
 


### PR DESCRIPTION
## Summary
- add a nurse API endpoint to ingest CSV uploads and create accounts via the existing creation flow
- add a dashboard import card so nurses can upload CSVs, monitor results, and refresh user lists
- provide a sample CSV to seed nurse, doctor, and patient records

## Testing
- npm run lint *(fails: TypeError: Converting circular structure to JSON in ESLint config)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a719bcea08327968cbaaebf9c62de)