### PR TITLE
Add password support to nurse account import CSV

### DIFF
--- a/public/sample/nurse-account-import.csv
+++ b/public/sample/nurse-account-import.csv
@@ -1,0 +1,5 @@
+role,fname,mname,lname,suffix,password,patienttype,student_id,employee_id,working_scholar,department,program,year_level,specialization,email,phone,address,allergies,bloodtype,medical_cond,emergencyco_name,emergencyco_num,emergencyco_relation
+NURSE,Jamie,,Villanueva,,NrsPass!101,,,NRS-101,,,,,,jamie.villanueva@hnu.edu.ph,09171234567,"Clinics Building, Room 2",Latex,O+,Asthma,Pat Villanueva,09179876543,Sibling
+DOCTOR,Alex,M.,Lim,Jr.,DocPass!234,,,DOC-202,,,,,Physician,alex.lim@hnu.edu.ph,09172345678,"Main Campus, Faculty Lane",,A-,Hypertension,Ivy Lim,09177654321,Spouse
+PATIENT,Ana,Reyes,Santos,,AnaPwd2024,student,2024-00123,,yes,SHAS,BSN,3,,ana.santos@hnu.edu.ph,09173456789,"Dormitory 3, Room 12",Peanuts,B+,None,Liza Santos,09174567890,Mother
+PATIENT,Carlos,,Diaz,,EmpSecure445,employee,,EMP-445,false,,,,,carlos.diaz@hnu.edu.ph,09175678901,City Heights Subdivision,,O-,Migraine,Maria Diaz,09171239876,Spouse

--- a/public/samples/nurse-account-import.csv
+++ b/public/samples/nurse-account-import.csv
@@ -1,5 +1,0 @@
-role,fname,mname,lname,suffix,patienttype,student_id,employee_id,working_scholar,department,program,year_level,specialization,email,phone,address,allergies,bloodtype,medical_cond,emergencyco_name,emergencyco_num,emergencyco_relation
-NURSE,Jamie,,Villanueva,, , ,NRS-101,, , , , ,jamie.villanueva@hnu.edu.ph,09171234567,"Clinics Building, Room 2",Latex,O+,Asthma,Pat Villanueva,09179876543,Sibling
-DOCTOR,Alex,M.,Lim,M.D.,, ,DOC-202,, , , ,Physician,alex.lim@hnu.edu.ph,09172345678,"Main Campus, Faculty Lane",,A-,Hypertension,Ivy Lim,09177654321,Spouse
-PATIENT,Ana,Reyes,Santos,,student,2024-00123,,yes,SHAS,BSN,3,,ana.santos@hnu.edu.ph,09173456789,"Dormitory 3, Room 12",Peanuts,B+,None,Liza Santos,09174567890,Mother
-PATIENT,Carlos,,Diaz,,employee,,EMP-445,false,HR,, , ,carlos.diaz@hnu.edu.ph,09175678901,"City Heights Subdivision",,O-,Migraine,Maria Diaz,09171239876,Spouse

--- a/src/app/api/nurse/accounts/import/route.ts
+++ b/src/app/api/nurse/accounts/import/route.ts
@@ -72,6 +72,7 @@ function normalizePayload(row: Record<string, string>) {
         mname: row.mname || undefined,
         lname: row.lname,
         suffix: row.suffix || undefined,
+        password: row.password || undefined,
         patientType,
         student_id: row.student_id || undefined,
         employee_id: row.employee_id || undefined,

--- a/src/app/api/nurse/accounts/import/route.ts
+++ b/src/app/api/nurse/accounts/import/route.ts
@@ -66,6 +66,9 @@ function normalizeBoolean(value?: string) {
 function normalizePayload(row: Record<string, string>) {
     const patientType = row.patienttype?.toLowerCase() as "student" | "employee" | undefined;
 
+    const studentId = row.student_id !== undefined ? String(row.student_id).trim() : undefined;
+    const employeeId = row.employee_id !== undefined ? String(row.employee_id).trim() : undefined;
+
     return {
         role: row.role?.toUpperCase(),
         fname: row.fname,
@@ -74,8 +77,8 @@ function normalizePayload(row: Record<string, string>) {
         suffix: row.suffix || undefined,
         password: row.password || undefined,
         patientType,
-        student_id: row.student_id || undefined,
-        employee_id: row.employee_id || undefined,
+        student_id: studentId || undefined,
+        employee_id: employeeId || undefined,
         workingScholar: patientType === "student" ? normalizeBoolean(row.working_scholar || row.workingscholar) : false,
         department: row.department?.toUpperCase() || undefined,
         program: row.program || undefined,

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -61,6 +61,23 @@ export async function POST(req: Request) {
         const roleEnum = payload.role as Role;
         const workingScholar = Boolean(payload.workingScholar);
 
+        const employeeIdRaw = payload.employee_id;
+        const studentIdRaw = payload.student_id;
+
+        const employeeId =
+            typeof employeeIdRaw === "string"
+                ? employeeIdRaw.trim()
+                : employeeIdRaw != null
+                    ? String(employeeIdRaw).trim()
+                    : "";
+
+        const studentId =
+            typeof studentIdRaw === "string"
+                ? studentIdRaw.trim()
+                : studentIdRaw != null
+                    ? String(studentIdRaw).trim()
+                    : "";
+
         const fname = typeof payload.fname === "string" ? payload.fname.trim() : "";
         const mname = typeof payload.mname === "string" ? payload.mname.trim() : "";
         const lname = typeof payload.lname === "string" ? payload.lname.trim() : "";
@@ -92,11 +109,11 @@ export async function POST(req: Request) {
         // Determine username
         let username: string;
         if (roleEnum === Role.NURSE || roleEnum === Role.DOCTOR) {
-            username = payload.employee_id;
+            username = employeeId;
         } else if (roleEnum === Role.PATIENT && payload.patientType === "student") {
-            username = payload.student_id;
+            username = studentId;
         } else if (roleEnum === Role.PATIENT && payload.patientType === "employee") {
-            username = payload.employee_id;
+            username = employeeId;
         } else {
             const suffixSlug = suffix.replace(/[^a-zA-Z]/g, "").toLowerCase();
             const baseUsername = `${fname.toLowerCase()}.${lname.toLowerCase()}`;
@@ -109,7 +126,7 @@ export async function POST(req: Request) {
 
         if (isStudentPatient) {
             const [existingStudent, existingUser] = await Promise.all([
-                prisma.student.findUnique({ where: { student_id: payload.student_id } }),
+                prisma.student.findUnique({ where: { student_id: studentId } }),
                 prisma.users.findUnique({ where: { username } }),
             ]);
 
@@ -123,7 +140,7 @@ export async function POST(req: Request) {
 
         if (isEmployeePatient || isEmployeeRole) {
             const [existingEmployee, existingUser] = await Promise.all([
-                prisma.employee.findUnique({ where: { employee_id: payload.employee_id } }),
+                prisma.employee.findUnique({ where: { employee_id: employeeId } }),
                 prisma.users.findUnique({ where: { username } }),
             ]);
 
@@ -186,7 +203,7 @@ export async function POST(req: Request) {
                 await tx.student.create({
                     data: {
                         user_id: newUser.user_id,
-                        student_id: payload.student_id,
+                        student_id: studentId,
                         is_working_scholar: workingScholar,
                         department,
                         program: payload.program ?? null,
@@ -200,7 +217,7 @@ export async function POST(req: Request) {
                 await tx.employee.create({
                     data: {
                         user_id: newUser.user_id,
-                        employee_id: payload.employee_id,
+                        employee_id: employeeId,
                         ...sharedProfileData,
                     },
                 });
@@ -210,7 +227,7 @@ export async function POST(req: Request) {
                 await tx.employee.create({
                     data: {
                         user_id: newUser.user_id,
-                        employee_id: payload.employee_id,
+                        employee_id: employeeId,
                         specialization:
                             roleEnum === Role.DOCTOR
                                 ? payload.specialization === "Physician"

--- a/src/app/api/nurse/accounts/route.ts
+++ b/src/app/api/nurse/accounts/route.ts
@@ -135,8 +135,13 @@ export async function POST(req: Request) {
             }
         }
 
-        // Generate password
-        const plainPassword = generatePassword();
+        // Generate password (use provided if available)
+        const providedPassword =
+            typeof payload.password === "string" && payload.password.trim().length > 0
+                ? payload.password.trim()
+                : null;
+
+        const plainPassword = providedPassword ?? generatePassword();
         const hashedPassword = await bcrypt.hash(plainPassword, 10);
 
         // Shared fields


### PR DESCRIPTION
## Summary
- pass CSV-provided passwords through the nurse account import pipeline and use them when creating users
- refresh the nurse import sample CSV with cleaned headers and required fields in /public/sample
- remove the outdated sample CSV location

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7df425148327aacf83ba11e96b60)