### PR TITLE
Fix Prisma generated runtime imports for Turbopack

### DIFF
--- a/prisma/generated/client.ts
+++ b/prisma/generated/client.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 globalThis['__dirname'] = path.dirname(fileURLToPath(import.meta.url))
 
-import * as runtime from "@prisma/client/runtime/library"
+import * as runtime from "@prisma/client/runtime/client"
 import * as $Enums from "./enums"
 import * as $Class from "./internal/class"
 import * as Prisma from "./internal/prismaNamespace"

--- a/prisma/generated/commonInputTypes.ts
+++ b/prisma/generated/commonInputTypes.ts
@@ -9,7 +9,7 @@
  * 🟢 You can import this file directly.
  */
 
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import * as $Enums from "./enums"
 import type * as Prisma from "./internal/prismaNamespace"
 

--- a/prisma/generated/internal/class.ts
+++ b/prisma/generated/internal/class.ts
@@ -11,7 +11,7 @@
  * Please import the `PrismaClient` class from the `client.ts` file instead.
  */
 
-import * as runtime from "@prisma/client/runtime/library"
+import * as runtime from "@prisma/client/runtime/client"
 import type * as Prisma from "./prismaNamespace"
 
 
@@ -49,10 +49,10 @@ async function decodeBase64AsWasm(wasmBase64: string): Promise<WebAssembly.Modul
 }
 
 config.compilerWasm = {
-  getRuntime: async () => await import("@prisma/client/runtime/query_compiler_bg.postgresql.mjs"),
+  getRuntime: async () => await import("@prisma/client/runtime/query_compiler_small_bg.postgresql.mjs"),
 
   getQueryCompilerWasmModule: async () => {
-    const { wasm } = await import("@prisma/client/runtime/query_compiler_bg.postgresql.wasm-base64.mjs")
+    const { wasm } = await import("@prisma/client/runtime/query_compiler_small_bg.postgresql.wasm-base64.mjs")
     return await decodeBase64AsWasm(wasm)
   }
 }

--- a/prisma/generated/internal/prismaNamespace.ts
+++ b/prisma/generated/internal/prismaNamespace.ts
@@ -15,7 +15,7 @@
  * model files in the `model` directory!
  */
 
-import * as runtime from "@prisma/client/runtime/library"
+import * as runtime from "@prisma/client/runtime/client"
 import type * as Prisma from "../models"
 import { type PrismaClient } from "./class"
 

--- a/prisma/generated/models/Appointment.ts
+++ b/prisma/generated/models/Appointment.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/Clinic.ts
+++ b/prisma/generated/models/Clinic.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/Consultation.ts
+++ b/prisma/generated/models/Consultation.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/DispenseBatch.ts
+++ b/prisma/generated/models/DispenseBatch.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/DoctorAvailability.ts
+++ b/prisma/generated/models/DoctorAvailability.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/Employee.ts
+++ b/prisma/generated/models/Employee.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/MedCert.ts
+++ b/prisma/generated/models/MedCert.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/MedDispense.ts
+++ b/prisma/generated/models/MedDispense.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/MedInventory.ts
+++ b/prisma/generated/models/MedInventory.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/PasswordResetToken.ts
+++ b/prisma/generated/models/PasswordResetToken.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/RateLimitBucket.ts
+++ b/prisma/generated/models/RateLimitBucket.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/Replenishment.ts
+++ b/prisma/generated/models/Replenishment.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/Student.ts
+++ b/prisma/generated/models/Student.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 

--- a/prisma/generated/models/Users.ts
+++ b/prisma/generated/models/Users.ts
@@ -8,7 +8,7 @@
  *
  * 🟢 You can import this file directly.
  */
-import type * as runtime from "@prisma/client/runtime/library"
+import type * as runtime from "@prisma/client/runtime/client"
 import type * as $Enums from "../enums"
 import type * as Prisma from "../internal/prismaNamespace"
 


### PR DESCRIPTION
### Motivation
- Turbopack/Next.js was failing to resolve Prisma runtime modules because generated files import from the removed `@prisma/client/runtime/library` path and reference query-compiler artifacts that are not present in the installed `@prisma/client` package.
- The project needs the generated client to import the runtime where the installed client actually exposes it so server and app routes can bundle correctly.

### Description
- Replaced imports of `@prisma/client/runtime/library` with the actual runtime entry `@prisma/client/runtime/client` in Prisma-generated files under `prisma/generated`.
- Updated dynamic query-compiler imports to use the available artifacts `query_compiler_small_bg.postgresql.mjs` and `query_compiler_small_bg.postgresql.wasm-base64.mjs` in `prisma/generated/internal/class.ts`.
- Applied the import-path fixes consistently across the generated client entrypoint, internal namespace/class files, and all generated model type files under `prisma/generated` so Turbopack can resolve Prisma runtime modules at build time.

### Testing
- Ran `DATABASE_URL='postgresql://u:p@localhost:5432/db' npx prisma generate` and confirmed Prisma Client was generated successfully (generated client written to `./prisma/generated`).
- Ran `DATABASE_URL='postgresql://u:p@localhost:5432/db' npm run build` and verified the previous Prisma module-not-found errors are resolved; the build now fails only due to inability to fetch Google Fonts (`Inter` and `Poppins`) in this environment (Turbopack fetch errors), not Prisma resolution issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2741847608327b4380c68a571a331)