### PR TITLE
Fix repeated auth gate flash during panel navigation

### DIFF
--- a/src/components/panel/panel-layout.tsx
+++ b/src/components/panel/panel-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useMemo, useRef, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -65,14 +65,7 @@ export function PanelLayout({
     const pathname = usePathname();
     const router = useRouter();
     const hasRedirectedRef = useRef(false);
-    const { data: session, status } = useSession({
-        required: true,
-        onUnauthenticated() {
-            if (hasRedirectedRef.current) return;
-            hasRedirectedRef.current = true;
-            router.replace("/login");
-        },
-    });
+    const { data: session, status } = useSession();
     const [isLoggingOut, setIsLoggingOut] = useState(false);
     const [mobileOpen, setMobileOpen] = useState(false);
     const fullName = session?.user?.name ?? defaultName;
@@ -83,12 +76,24 @@ export function PanelLayout({
         return initials || fallbackInitials;
     }, [fullName, fallbackInitials]);
 
-    if (status === "loading") {
+    useEffect(() => {
+        if (status !== "unauthenticated") return;
+        if (hasRedirectedRef.current) return;
+
+        hasRedirectedRef.current = true;
+        router.replace("/login");
+    }, [router, status]);
+
+    if (status === "loading" && !session) {
         return (
             <div className="flex min-h-screen items-center justify-center bg-white p-6" aria-busy>
                 <p className="text-sm font-medium text-muted-foreground">Verifying your session…</p>
             </div>
         );
+    }
+
+    if (status === "unauthenticated") {
+        return null;
     }
 
     async function handleLogout() {


### PR DESCRIPTION
### Motivation
- Navigating between panel pages caused the full-screen "Verifying your session…" gate to reappear unnecessarily, producing a visible flash for authenticated users.
- The intent is to keep the redirect behavior for unauthenticated users while avoiding the mandatory required-session gate on every client mount during intra-panel navigation.

### Description
- Replaced `useSession({ required: true })` with `useSession()` in `PanelLayout` to avoid forcing the auth gate on every mount.
- Added a guarded `useEffect` that performs an unauthenticated redirect with `router.replace("/login")` only when `status === "unauthenticated"` and the redirect hasn't already run, tracked via `hasRedirectedRef`.
- Limited the loading gate to render only when the session is unresolved (`status === "loading" && !session`) and return `null` while an unauthenticated redirect is in-flight to prevent UI flashing.
- Modified file: `src/components/panel/panel-layout.tsx` (session handling and render gating logic).

### Testing
- Ran `npm run lint`, which failed due to an existing ESLint circular config error unrelated to this change (error: `TypeError: Converting circular structure to JSON`).
- Ran `npx tsc --noEmit`, which failed in this environment due to missing `next` type definitions (error: `Cannot find type definition file for 'next'`).
- Manual verification: local behavior adjusted to avoid repeated full-screen gate flashes during panel navigation (no automated UI tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ba27555c83278b311d35d0c34729)